### PR TITLE
fix UserModules.clear()

### DIFF
--- a/py3status/__init__.py
+++ b/py3status/__init__.py
@@ -355,7 +355,8 @@ class UserModules(Thread):
         """
         clear user cache
         """
-        self.cache = {}
+        for k in self.cache.keys():
+            self.cache[k] = {}
 
     def run(self):
         """


### PR DESCRIPTION
UserModules.clear() was wiping the entire cache, causing [this line](https://github.com/edk141/py3status/blob/c9cbccb27b9fd3d1e8e56b7adcc22325dbdac76b/py3status/__init__.py#L338) to throw exceptions because `class_name` wasn't in the cache dict, and ultimately making a lot of messages like this after a SIGUSR1:

```
Apr 29 14:19:21 keel py3status: injection failed ('notify.py')
Apr 29 14:20:35  py3status: last message repeated 13 times
```

My fix for this clears the cache at one level deep instead, which leaves it in a state where execute_classes() can still work.
