### PR TITLE
Fixed imports of user modules when using Python 3

### DIFF
--- a/py3status/__init__.py
+++ b/py3status/__init__.py
@@ -291,17 +291,11 @@ class UserModules(Thread):
                         if module and class_inst:
                             self.classes[f_name] = (class_inst, [])
                             self.cache[f_name] = {}
-                            for method in dir(class_inst):
-                                # ignore private methods
-                                if '_Py3status' in method:
-                                    continue
-                                try:
-                                    cl = eval("class_inst.%s.im_class" % method)
-                                    if 'Py3status' in str(cl):
+
+                            if 'Py3status' in str(class_inst):
+                                for method in dir(class_inst):
+                                    if not method.startswith('_'):
                                         self.classes[f_name][1].append(method)
-                                except:
-                                    # ignore non Py3status-wide methods
-                                    pass
                     except Exception:
                         err = sys.exc_info()[1]
                         syslog(LOG_ERR, "loading %s failed (%s)" \


### PR DESCRIPTION
Hi there again.

One of the last commits broke support for Python3, as discussed here: https://github.com/ultrabug/py3status/issues/11
I've tried to fix it. I hope it's working for you as well.
I'm not 100% sure how the code was supposed to work before, so maybe I'm missing something.
