### PR TITLE
Float update-time option

### DIFF
--- a/py3status/__init__.py
+++ b/py3status/__init__.py
@@ -513,7 +513,7 @@ class Py3statusWrapper():
                             directories (default .i3/py3status)""")
         parser.add_argument('-n', action="store",
                             dest="interval",
-                            type=int,
+                            type=float,
                             default=config['interval'],
                             help="update interval in seconds (default 1 sec)")
         parser.add_argument('-t', action="store",


### PR DESCRIPTION
This allows setting a fractional-second update time, which is helpful for instant response in UI. Code works; all the actual timing logic accepts floats already, so only argparse needed to be told to let the user pass one in. Use with "-n .1" or similar.
