### PR TITLE
__init__.py: Fix include_paths default.

### DIFF
--- a/py3status/__init__.py
+++ b/py3status/__init__.py
@@ -591,13 +591,13 @@ class Py3statusWrapper():
         Create the py3status based on command line options we received.
         """
         # get home path
-        home = '{}{}'.format(os.path.expanduser('~'), '/')
+        home_path = '{}{}'.format(os.path.expanduser('~'), '/')
 
         # defaults
         config = {
             'cache_timeout': 60,
             'i3status_config_path': '/etc/i3status.conf',
-            'include_paths': ['{}{}'.format(home, '.i3/py3status/')],
+            'include_paths': ['{}{}'.format(home_path, '.i3/py3status/')],
             'interval': 1
         }
 


### PR DESCRIPTION
There is a problem with py3status when starting X not from '$HOME' root dir. The default tries to load modules from $PWD'.i3/py3status.'

This patch fix it. I'm not sure if this the best way, I'm quite new to python.

Greetings, Frank
