### PR TITLE
Bar / ASCII bar also available for text mode format in battery_level.py

### DIFF
--- a/py3status/__init__.py
+++ b/py3status/__init__.py
@@ -260,7 +260,7 @@ class I3status(Thread):
                         on_c[section_name][button] = value
 
                     # override time format
-                    if section_name in ['time', 'tztime'] and key == 'format':
+                    if section_name.split(' ')[0] in ['time', 'tztime'] and key == 'format':
                         self.time_format = value
 
             if line.endswith('}'):

--- a/py3status/modules/battery_level.py
+++ b/py3status/modules/battery_level.py
@@ -58,20 +58,26 @@ class Py3status:
         self.time_remaining = ' '.join(acpi_list[4:])
         battery_full = False
 
-        if self.mode == "bar":
-            if charging:
-                full_text = CHARGING_CHARACTER
-            else:
-                full_text = BLOCKS[int(math.ceil(percent_charged/100*(len(BLOCKS) - 1)))]
-        elif self.mode == "ascii_bar":
-            full_part = FULL_BLOCK * int(percent_charged/10)
-            if charging:
-                empty_part = EMPTY_BLOCK_CHARGING * (10 - int(percent_charged/10))
-            else:
-                empty_part = EMPTY_BLOCK_DISCHARGING * (10 - int(percent_charged/10))
-            full_text = full_part + empty_part
+        # Format the bar character for both the bar mode and text format
+        full_part = FULL_BLOCK * int(percent_charged/10)
+        if charging:
+            bar = CHARGING_CHARACTER
+            empty_part = EMPTY_BLOCK_CHARGING * (10 - int(percent_charged/10))
         else:
-            full_text = self.format.format(str(percent_charged) + "%")
+            bar = BLOCKS[int(math.ceil(percent_charged/100*(len(BLOCKS) - 1)))]
+            empty_part = EMPTY_BLOCK_DISCHARGING * (10 - int(percent_charged/10))
+        ascii_bar = full_part + empty_part
+
+        if self.mode == "bar":
+            full_text = bar
+        elif self.mode == "ascii_bar":
+            full_text = ascii_bar
+        else:
+            # Support both named variables and a single variable
+            full_text = self.format.format(str(percent_charged) + "%",
+              percentage=str(percent_charged) + "%",
+              bar=bar,
+              ascii_bar=ascii_bar)
 
         response['full_text'] = full_text
 


### PR DESCRIPTION
I wanted to show the bar icon in addition to the percentage in battery_level text mode. This adds the possibility of using both bar and ascii_bar contents in the text mode format option also.