### PR TITLE
Support time/tztime definitions with extra parts in the section name

### DIFF
--- a/py3status/__init__.py
+++ b/py3status/__init__.py
@@ -260,7 +260,7 @@ class I3status(Thread):
                         on_c[section_name][button] = value
 
                     # override time format
-                    if section_name in ['time', 'tztime'] and key == 'format':
+                    if section_name.split(' ')[0] in ['time', 'tztime'] and key == 'format':
                         self.time_format = value
 
             if line.endswith('}'):


### PR DESCRIPTION
The time/tztime handler currently only supports definitions with section names that match the exact string. I have two time definitions, ”tztime local” and ”tztime utc”; this fixes the section name detection to only use the first space-separated part to detect if the section defines a time segment.