### PR TITLE
[DPMS] Activate/deactivate the screensaver as well.

### DIFF
--- a/py3status/modules/dpms.py
+++ b/py3status/modules/dpms.py
@@ -38,8 +38,8 @@ class Py3status:
         if event['button'] == 1:
             if self.run:
                 self.run = False
-                system("xset -dpms")
+                system("xset -dpms;xset s off")
             else:
                 self.run = True
-                system("xset +dpms")
+                system("xset +dpms;xset s on")
             system("killall -USR1 py3status")


### PR DESCRIPTION
The DPMS module allows activation/deactivation of DPMS and does it well.
However, the purpose of deactivating DPMS is, in most cases, to avoid
the screen going blank. If the screensaver is not deactivated then the
screen will go blank anyway. This commits allow simultaneous
activation/deactivation of both.