### PR TITLE
[bugfix] incorrect parsing of "setxkbmap -query"

### DIFF
--- a/py3status/modules/keyboard_layout.py
+++ b/py3status/modules/keyboard_layout.py
@@ -13,6 +13,8 @@ Requires:
 
 from subprocess import check_output
 from time import time
+import shlex
+import re
 
 # colors of layouts, check your command's output to match keys
 LANG_COLORS = {
@@ -22,6 +24,7 @@ LANG_COLORS = {
     'us': '#729FCF',  # light blue
 }
 
+LAYOUT_RE = re.compile(r".*layout:\s*(\w+).*", flags=re.DOTALL)
 
 def xbklayout():
     """
@@ -39,9 +42,9 @@ def setxkbmap():
     Please read issue 33 for more information :
         https://github.com/ultrabug/py3status/pull/33
     """
-    q = check_output(['setxkbmap', '-query']).decode('utf-8')
-    return q.replace(' ', '').split(':')[-1]
+    out = check_output(shlex.split("setxkbmap -query")).decode("utf-8")
 
+    return re.match(LAYOUT_RE, out).group(1)
 
 class Py3status:
 


### PR DESCRIPTION
The setxkbmap method assumes that the layout appears at the end of the "setxkbmap -query" command, which is not always true (e.g. options defined with "setxkbmap -option" may appear after the layout).

The module has been modified so it uses a regular expression for parsing.