### PR TITLE
Free output format for unread mails

### DIFF
--- a/py3status/modules/imap.py
+++ b/py3status/modules/imap.py
@@ -1,7 +1,8 @@
 # -*- coding: utf8 -*-
 """
 Module displaying the number of unread messages
-on an IMAP inbox (configurable).
+on an IMAP inbox (configurable, may also be a 
+comma-separated list of IMAP folders).
 
 @author obb
 """
@@ -42,13 +43,19 @@ class Py3status:
 
     def _get_mail_count(self):
         try:
-            connection = imaplib.IMAP4_SSL(self.imap_server, self.port)
-            connection.login(self.user, self.password)
-            connection.select(self.mailbox)
-            unseen_response = connection.search(None, self.criterion)
-            mails = unseen_response[1][0].split()
-            mail_count = len(mails)
+            mail_count = 0
+            directories = self.mailbox.split(',')
+            
+            for directory in directories:
+                connection = imaplib.IMAP4_SSL(self.imap_server, self.port)
+                connection.login(self.user, self.password)
+                connection.select(directory)
+                unseen_response = connection.search(None, self.criterion)
+                connection.close()
+                mails = unseen_response[1][0].split()
+                mail_count += len(mails)
             return mail_count
+
         except:
             return 'N/A'
 

--- a/py3status/modules/imap.py
+++ b/py3status/modules/imap.py
@@ -46,7 +46,7 @@ class Py3status:
             if self.hide_if_zero:
                 response['full_text'] = ''
             else:
-                response['full_text'] = self.name.replace('%unseen', '0')
+                response['full_text'] = self.name.format(unseen=mail_count)
 
         return response
 

--- a/py3status/modules/imap.py
+++ b/py3status/modules/imap.py
@@ -51,9 +51,10 @@ class Py3status:
             for directory in directories:
                 connection.select(directory)
                 unseen_response = connection.search(None, self.criterion)
-                connection.close()
                 mails = unseen_response[1][0].split()
                 mail_count += len(mails)
+
+            connection.close()
             return mail_count
 
         except:

--- a/py3status/modules/imap.py
+++ b/py3status/modules/imap.py
@@ -45,10 +45,10 @@ class Py3status:
         try:
             mail_count = 0
             directories = self.mailbox.split(',')
+            connection = imaplib.IMAP4_SSL(self.imap_server, self.port)
+            connection.login(self.user, self.password)
             
             for directory in directories:
-                connection = imaplib.IMAP4_SSL(self.imap_server, self.port)
-                connection.login(self.user, self.password)
                 connection.select(directory)
                 unseen_response = connection.search(None, self.criterion)
                 connection.close()

--- a/py3status/modules/imap.py
+++ b/py3status/modules/imap.py
@@ -19,7 +19,7 @@ class Py3status:
     hide_if_zero = False
     imap_server = '<IMAP_SERVER>'
     mailbox = 'INBOX'
-    name = 'Mail: %unseen'
+    name = 'Mail: {unseen}'
     new_mail_color = ''
     password = '<PASSWORD>'
     port = '993'
@@ -40,7 +40,7 @@ class Py3status:
             response['full_text'] = mail_count
         elif mail_count != 0:
             response['color'] = self.new_mail_color
-            response['full_text'] = self.name.replace('%unseen', str(mail_count))
+            response['full_text'] = self.name.format(unseen=mail_count)
         else:
             response['color'] = ''
             if self.hide_if_zero:

--- a/py3status/modules/spaceapi.py
+++ b/py3status/modules/spaceapi.py
@@ -28,9 +28,10 @@ class Py3status:
     # available configuration parameters
     cache_timeout = 60
     closed_color = None
-    closed_text = 'closed since %H:%M'
+    closed_text = 'closed'
     open_color = None
-    open_text = 'open since %H:%M'
+    open_text = 'open'
+    time_text = ' since %H:%M'
     url = 'http://status.chaospott.de/status.json'
 
     def check(self, i3s_output_list, i3s_config):
@@ -54,20 +55,30 @@ class Py3status:
             json_file.close()
 
             if(data['state']['open'] is True):
-                response['full_text'] = self.open_text
-                response['short_text'] = '%H:%M'
                 if self.open_color:
                     response['color'] = self.open_color
+                if 'lastchange' in data['state'].keys():
+                    response['full_text'] = self.open_text + self.time_text
+                    response['short_text'] = '%H:%M'
+                else:
+                    response['full_text'] = self.open_text
+                    response['short_text'] = self.open_text
+
             else:
-                response['full_text'] = self.closed_text
-                response['short_text'] = ''
                 if self.closed_color:
                     response['color'] = self.closed_color
+                if 'lastchange' in data['state'].keys():
+                    response['full_text'] = self.closed_text + self.time_text
+                    response['short_text'] = ''
+                else:
+                    response['full_text'] = self.closed_text
+                    response['short_text'] = self.closed_text
 
-            # apply strftime to full and short text
-            dt = datetime.datetime.fromtimestamp(data['state']['lastchange'])
-            response['full_text'] = dt.strftime(response['full_text'])
-            response['short_text'] = dt.strftime(response['short_text'])
+            if 'lastchange' in data['state'].keys():
+                # apply strftime to full and short text
+                dt = datetime.datetime.fromtimestamp(data['state']['lastchange'])
+                response['full_text'] = dt.strftime(response['full_text'])
+                response['short_text'] = dt.strftime(response['short_text'])
 
         except:
             response['full_text'] = ''


### PR DESCRIPTION
Gives the user the choice of formatting the mail notification (including where to put the number of unread mails). Additionally provides the option to just not show the mail notification if there are no unread mails.

Default behaviour doesn't change.