### PR TITLE
Improve documentation in the example module

### DIFF
--- a/py3status/modules/empty_class.py
+++ b/py3status/modules/empty_class.py
@@ -1,15 +1,35 @@
 # -*- coding: utf-8 -*-
-"""
-Empty and basic py3status class.
 
-NOTE: py3status will NOT execute:
-    - methods starting with '_'
-    - methods decorated by @property and @staticmethod
-
-NOTE: reserved method names:
-    - 'kill' method for py3status exit notification
-    - 'on_click' method for click events from i3bar (read below please)
+# This is an example module to be used as a template.
+# See https://github.com/ultrabug/py3status/wiki/Write-your-own-modules
+# for more details.
+#
+# NOTE: py3status will NOT execute:
+#     - methods starting with '_'
+#     - methods decorated by @property and @staticmethod
+# 
+# NOTE: reserved method names:
+#     - 'kill' method for py3status exit notification
+#     - 'on_click' method for click events from i3bar (read below please)
+#
+# Do NOT use print on your modules: py3status will catch any output and discard 
+# it silently because this would break your i3bar (see issue #20 for details). 
+# Make sure you catch any output from any external program you may call 
+# from your module. Any output from an external program cannot be caught and 
+# silenced by py3status and will break your i3bar so please, redirect any 
+# stdout/stderr to /dev/null for example (see issue #20 for details). 
+# 
+# Fill in the following docstring: it will beparsed py3status to document
+# your module:
 """
+One-line summary followed by an empty line.
+
+Multi-line description followed by an empty line.
+
+@author <your full name> <your email address>
+@license <ancronym>     (please favor BSD or GPLv3)
+"""
+# Any contributor to this module should add his/her name to the @author line, comma separated
 
 # import your useful libs here
 from time import time


### PR DESCRIPTION
Maybe the example module should be moved to doc/examples/ to move it out the real modules directory and also make it easier to find for people looking at the docs.