### PR TITLE
VLC support for player_control

### DIFF
--- a/py3status/modules/player_control.py
+++ b/py3status/modules/player_control.py
@@ -28,7 +28,7 @@ class Py3status:
     """
     Configuration parameters:
         - debug: enable verbose logging (bool) (default: False)
-        - supported_players: supported players (str) (whitespace separated list)
+        - supported_players: supported players (str) (comma separated list)
         - volume_tick: percentage volume change on mouse wheel (int) (positive number or None to disable it)
 
     """
@@ -37,7 +37,7 @@ class Py3status:
     pause_icon = u'❚❚'
     play_icon = u'▶'
     stop_icon = u'◼'
-    supported_players = 'audacious vlc'
+    supported_players = 'audacious,vlc'
     volume_tick = 1
 
     def __init__(self):
@@ -124,7 +124,7 @@ class Py3status:
     def _detect_running_player(self):
         """Detect running player process, if any
         """
-        supported_players = self.supported_players.split(' ')
+        supported_players = self.supported_players.split(',')
         running_players = []
         for pid in os.listdir('/proc'):
             if not pid.isdigit():

--- a/py3status/modules/player_control.py
+++ b/py3status/modules/player_control.py
@@ -114,10 +114,10 @@ class Py3status:
             if not pid.isdigit():
                 continue
 
-            fn = os.path.join('/proc', pid, 'cmdline')
+            fn = os.path.join('/proc', pid, 'comm')
             try:
                 with open(fn, 'rb') as f:
-                    player_name = f.read().decode().rstrip('\0')
+                    player_name = f.read().decode().rstrip()
 
             except:
                 continue

--- a/py3status/modules/player_control.py
+++ b/py3status/modules/player_control.py
@@ -15,6 +15,7 @@ Provides an icon to control simple functions of audio/video players:
 
 from syslog import syslog, LOG_INFO
 from time import time, sleep
+import dbus
 import os
 import subprocess
 
@@ -33,7 +34,7 @@ class Py3status:
     """
 
     debug = False
-    supported_players = 'audacious'
+    supported_players = 'audacious vlc'
     volume_tick = 1
 
     def __init__(self):
@@ -83,6 +84,10 @@ class Py3status:
         player_name = self._detect_running_player()
         if player_name == 'audacious':
             self._run(['/usr/bin/audacious', '-p'])
+        elif player_name == 'vlc':
+            player = self._get_vlc()
+            if player:
+                player.Play()
 
     def _stop(self):
         self.status = 'stop'
@@ -90,6 +95,10 @@ class Py3status:
         player_name = self._detect_running_player()
         if player_name == 'audacious':
             self._run(['/usr/bin/audacious', '-s'])
+        elif player_name == 'vlc':
+            player = self._get_vlc()
+            if player:
+                player.Stop()
 
     def _pause(self):
         self.status = 'pause'
@@ -97,6 +106,10 @@ class Py3status:
         player_name = self._detect_running_player()
         if player_name == 'audacious':
             self._run(['/usr/bin/audacious', '-u'])
+        elif player_name == 'vlc':
+            player = self._get_vlc()
+            if player:
+                player.Pause()
 
     def _change_volume(self, increase):
         """Change volume using amixer
@@ -134,6 +147,13 @@ class Py3status:
                 return player_name
 
         return None
+
+    def _get_vlc(self):
+        mpris = 'org.mpris.MediaPlayer2'
+        mpris_slash = '/' + mpris.replace('.', '/')
+        bus = dbus.SessionBus()
+        proxy = bus.get_object(mpris+'.vlc', mpris_slash)
+        return dbus.Interface(proxy, dbus_interface=mpris+'.Player')
 
     def player_control(self, i3s_output_list, i3s_config):
         return dict(

--- a/py3status/modules/player_control.py
+++ b/py3status/modules/player_control.py
@@ -117,7 +117,7 @@ class Py3status:
             fn = os.path.join('/proc', pid, 'cmdline')
             try:
                 with open(fn, 'rb') as f:
-                    player_name = f.read().rstrip('\0')
+                    player_name = f.read().decode().rstrip('\0')
 
             except:
                 continue

--- a/py3status/modules/player_control.py
+++ b/py3status/modules/player_control.py
@@ -7,7 +7,7 @@ Provides an icon to control simple functions of audio/video players:
  - stop  (left click)
  - pause (middle click)
 
-@author Federico Ceratto <federico.ceratto@gmail.com>
+@author Federico Ceratto <federico.ceratto@gmail.com>, rixx
 @license BSD
 """
 # Any contributor to this module should add his/her name to the @author
@@ -34,12 +34,15 @@ class Py3status:
     """
 
     debug = False
+    pause_icon = u'❚❚'
+    play_icon = u'▶'
+    stop_icon = u'◼'
     supported_players = 'audacious vlc'
     volume_tick = 1
 
     def __init__(self):
         self.status = 'stop'
-        self.icon = u'▶'
+        self.icon = self.play_icon
 
     def on_click(self, i3s_output_list, i3s_config, event):
         """
@@ -80,7 +83,7 @@ class Py3status:
 
     def _play(self):
         self.status = 'play'
-        self.icon = u'◼'
+        self.icon = self.stop_icon
         player_name = self._detect_running_player()
         if player_name == 'audacious':
             self._run(['/usr/bin/audacious', '-p'])
@@ -91,7 +94,7 @@ class Py3status:
 
     def _stop(self):
         self.status = 'stop'
-        self.icon = u'▶'
+        self.icon = self.play_icon
         player_name = self._detect_running_player()
         if player_name == 'audacious':
             self._run(['/usr/bin/audacious', '-s'])
@@ -102,7 +105,7 @@ class Py3status:
 
     def _pause(self):
         self.status = 'pause'
-        self.icon = u'❚❚'
+        self.icon = self.pause_icon
         player_name = self._detect_running_player()
         if player_name == 'audacious':
             self._run(['/usr/bin/audacious', '-u'])


### PR DESCRIPTION
uses only dbus and communicates via the MPRIS MusicPlayer2 interface