### PR TITLE
Add profiling support and setproctitle

### DIFF
--- a/py3status/__init__.py
+++ b/py3status/__init__.py
@@ -23,6 +23,11 @@ from threading import Event, Thread
 from time import sleep, time
 from syslog import syslog, LOG_ERR, LOG_INFO, LOG_WARNING
 
+try:
+    from setproctitle import setproctitle
+    setproctitle('py3status')
+except ImportError:
+    pass
 
 @contextmanager
 def jsonify(string):

--- a/py3status/__init__.py
+++ b/py3status/__init__.py
@@ -31,7 +31,7 @@ except ImportError:
     pass
 
 # Used in development
-enable_profiling = True
+enable_profiling = False
 
 
 def profile(thread_run_fn):


### PR DESCRIPTION
setproctitle is an optional dependency to set the process name.
The profiler can generate metrics for different threads and can be enabled using the enable_profiling  variable.