### PR TITLE
imap module: fix empty color that made text invisible on i3bar when no unread email

### DIFF
--- a/py3status/modules/imap.py
+++ b/py3status/modules/imap.py
@@ -47,13 +47,11 @@ class Py3status:
             self.new_mail_color = i3s_config['color_good']
 
         if mail_count == 'N/A':
-            response['color'] = ''
             response['full_text'] = mail_count
         elif mail_count != 0:
             response['color'] = self.new_mail_color
             response['full_text'] = self.name.format(unseen=mail_count)
         else:
-            response['color'] = ''
             if self.hide_if_zero:
                 response['full_text'] = ''
             else:


### PR DESCRIPTION
When the **imap module** isn't able to connect to the mailbox through imap,
or when there is no unread email, the color is set like that :

    response['color'] = ''

That makes the color black on i3bar, and thus invisible on most
backgrounds.

Removing these 2 lines makes it use the default color, which is white
and visible in most of the case. That also allow the "hide_if_zero"
module option to be useful !