### PR TITLE
pomodoro: fix display_bar in python3

### DIFF
--- a/py3status/modules/pomodoro.py
+++ b/py3status/modules/pomodoro.py
@@ -106,14 +106,14 @@ class Py3status:
                 bar += PROGRESS_BAR_ITEMS[selector]
                 bar_val -= 1
 
-            bar = bar.ljust(self.num_progress_bars).encode('utf_8')
+            bar = bar.ljust(self.num_progress_bars)
         else:
             bar = self.timer
 
         if self.run:
-            text = '{} [{}]'.format(self.prefix, bar)
+            text = u'{} [{}]'.format(self.prefix, bar)
         else:
-            text = '{} ({})'.format(self.prefix, bar)
+            text = u'{} ({})'.format(self.prefix, bar)
 
         return dict(full_text=text)
 


### PR DESCRIPTION
In python3 calling `encode` on a string will yield a `bytes` obj which
then leads to a status bar with escaped hex chars instead of the bars, i.e.
`Pomodoro [b'\xe2\x96\x89\xe2\x96\x89\xe2\x96\x8d ']` vs `Pomodoro [b'▉▉▍ ']`.

The fix in python2 is to call format on a `unicode` object vs a `str` (ansii)
object. This will work fine in python3 > 3.3 where the `u` prefix was brought
into python3.