### PR TITLE
add format string support for dpms module, and add some options

### DIFF
--- a/py3status/modules/dpms.py
+++ b/py3status/modules/dpms.py
@@ -7,12 +7,8 @@ of DPMS (Display Power Management Signaling)
 by clicking on 'DPMS' in the status bar.
 
 Configuration parameters:
-    - format: output format string
-    - status_off: string to display when DPMS is enabled
-    - status_on: string to display when DPMS is disabled
-
-Format of status string placeholders:
-    {status} - DPMS status (defined by status_on/off parameters)
+    - format_off: string to display when DPMS is enabled
+    - format_on: string to display when DPMS is disabled
 
 @author Andre Doser <dosera AT tf.uni-freiburg.de>
 """
@@ -24,9 +20,8 @@ class Py3status:
     """
     """
     # available configuration parameters
-    format = "DPMS"
-    status_off = "Off"
-    status_on = "On"
+    format_off = "DPMS"
+    format_on = "DPMS"
 
     def dpms(self, i3s_output_list, i3s_config):
         """
@@ -36,15 +31,9 @@ class Py3status:
         self.run = system('xset -q | grep -iq "DPMS is enabled"') == 0
 
         response = {
-            'full_text': self.format.format(
-                status = self.status_on if self.run else self.status_off
-            )
+            'full_text': self.format_on if self.run else self.format_off,
+            'color': i3s_config['color_good'] if self.run else i3s_config['color_bad']
         }
-
-        if self.run:
-            response['color'] = i3s_config['color_good']
-        else:
-            response['color'] = i3s_config['color_bad']
 
         return response
 

--- a/py3status/modules/dpms.py
+++ b/py3status/modules/dpms.py
@@ -6,6 +6,14 @@ This module allows activation and deactivation
 of DPMS (Display Power Management Signaling)
 by clicking on 'DPMS' in the status bar.
 
+Configuration parameters:
+    - format: output format string
+    - status_off: string to display when DPMS is enabled
+    - status_on: string to display when DPMS is disabled
+
+Format of status string placeholders:
+    {status} - DPMS status (defined by status_on/off parameters)
+
 @author Andre Doser <dosera AT tf.uni-freiburg.de>
 """
 
@@ -15,6 +23,11 @@ from os import system
 class Py3status:
     """
     """
+    # available configuration parameters
+    format = "DPMS"
+    status_off = "Off"
+    status_on = "On"
+
     def dpms(self, i3s_output_list, i3s_config):
         """
         Display a colorful state of DPMS.
@@ -23,13 +36,16 @@ class Py3status:
         self.run = system('xset -q | grep -iq "DPMS is enabled"') == 0
 
         response = {
-            'full_text': 'DPMS'
+            'full_text': self.format.format(
+                status = self.status_on if self.run else self.status_off
+            )
         }
 
         if self.run:
             response['color'] = i3s_config['color_good']
         else:
             response['color'] = i3s_config['color_bad']
+
         return response
 
     def on_click(self, i3s_output_list, i3s_config, event):
@@ -43,3 +59,18 @@ class Py3status:
             else:
                 self.run = True
                 system("xset +dpms;xset s on")
+
+if __name__ == "__main__":
+    """
+    Test this module by calling it directly.
+    """
+    from time import sleep
+    x = Py3status()
+    config = {
+        'color_bad': '#FF0000',
+        'color_good': '#00FF00',
+    }
+
+    while True:
+        print(x.dpms([], config))
+        sleep(1)

--- a/py3status/modules/dpms.py
+++ b/py3status/modules/dpms.py
@@ -7,8 +7,8 @@ of DPMS (Display Power Management Signaling)
 by clicking on 'DPMS' in the status bar.
 
 Configuration parameters:
-    - format_off: string to display when DPMS is enabled
-    - format_on: string to display when DPMS is disabled
+    - format_off: string to display when DPMS is disabled
+    - format_on: string to display when DPMS is enabled
 
 @author Andre Doser <dosera AT tf.uni-freiburg.de>
 """


### PR DESCRIPTION
In response to issue #98 - add format string support for the `dpms` module.

Since it's going to be a bit more configurable with a `format` string, I added the placeholder, `{status}`, which allows customising the textual output based on DPMS state. I have not added this new parameter to the default string, to not confuse or surprise existing users.

Also added a little test which this module was lacking.