### PR TITLE
Fix crash when using %z for tz_time

### DIFF
--- a/py3status/__init__.py
+++ b/py3status/__init__.py
@@ -13,7 +13,7 @@ import sys
 from collections import OrderedDict
 from contextlib import contextmanager
 from copy import deepcopy
-from datetime import datetime
+from datetime import datetime, timezone
 from json import dumps, loads
 from py3status import modules as sitepkg_modules
 from signal import signal
@@ -548,7 +548,7 @@ class I3status(Thread):
                                 print_line(line)
                                 with jsonify(line) as (prefix, json_list):
                                     self.last_output = json_list
-                                    self.last_output_ts = datetime.utcnow()
+                                    self.last_output_ts = datetime.now(timezone.utc)
                                     self.last_prefix = ','
                                     self.update_json_list()
                                     self.set_responses(json_list)


### PR DESCRIPTION
tl;dr python's support for datetime leaves a bit to be desired.

The system can store 2 different objects under the same banner (datetime). These can either have tz info (including UTC) or be "naive" datetimes (no tzinfo). Stupidly, utcnow creates a naive datetime that cannot be used with other proper datetimes.

This was causing a crash when %z was included. The patch fixes this. I don't yet know why the timezone (%z) won't show up in i3bar yet though.