### PR TITLE
Call the method disconnect whatever the outcome of block try/except, …

### DIFF
--- a/py3status/modules/mpd_status.py
+++ b/py3status/modules/mpd_status.py
@@ -213,8 +213,7 @@ class Py3status:
             text = "Failed to connect to mpd!"
         except CommandError:
             text = "Failed to authenticate to mpd!"
-            c.disconnect()
-        else:
+        finally:
             c.disconnect()
 
 


### PR DESCRIPTION
…or being ensure to avoid the connection leak. :)

In seeing this #127 , I thought it would be better to make the call to the disconnect method in a finally block. :)

But not possible to call this method in this condition, which is why I have proposed an enhancement on python-mpd2 (https://github.com/Mic92/python-mpd2/pull/59).