### PR TITLE
[battery_level] Allow user-defined blocks with percentage

### DIFF
--- a/py3status/modules/battery_level.py
+++ b/py3status/modules/battery_level.py
@@ -3,12 +3,12 @@
 Display the battery level.
 
 Configuration parameters:
+    - blocks : a string, where each character represents a battery level
+    - charging_character : a character to represent charging battery
     - color_* : None means - get it from i3status config
     - format : text with "text" mode. percentage with % replaces {}
     - hide_when_full : hide any information when battery is fully charged
     - mode : for primitive-one-char bar, or "text" for text percentage ouput
-    - blocks : a string, where each character represents a battery level
-    - charging_character : a character to represent charging battery
     - show_percent_with_blocks : show battery level percentage in blocks mode
 
 Requires:
@@ -35,7 +35,9 @@ class Py3status:
     """
     """
     # available configuration parameters
+    blocks = BLOCKS
     cache_timeout = 30
+    charging_character = CHARGING_CHARACTER
     color_bad = None
     color_charging = "#FCE94F"
     color_degraded = None
@@ -44,8 +46,6 @@ class Py3status:
     hide_when_full = False
     mode = "bar"
     notification = False
-    blocks = BLOCKS
-    charging_character = CHARGING_CHARACTER
     show_percent_with_blocks = False
 
     def battery_level(self, i3s_output_list, i3s_config):

--- a/py3status/modules/battery_level.py
+++ b/py3status/modules/battery_level.py
@@ -7,6 +7,8 @@ Configuration parameters:
     - format : text with "text" mode. percentage with % replaces {}
     - hide_when_full : hide any information when battery is fully charged
     - mode : for primitive-one-char bar, or "text" for text percentage ouput
+    - blocks : a string, where each character represents a battery level
+    - charging_character : a character to represent charging battery
 
 Requires:
     - the 'acpi' command line
@@ -41,6 +43,8 @@ class Py3status:
     hide_when_full = False
     mode = "bar"
     notification = False
+    blocks = BLOCKS
+    charging_character = CHARGING_CHARACTER
 
     def battery_level(self, i3s_output_list, i3s_config):
         response = {}
@@ -60,9 +64,9 @@ class Py3status:
 
         if self.mode == "bar":
             if charging:
-                full_text = CHARGING_CHARACTER
+                full_text = self.charging_character
             else:
-                full_text = BLOCKS[int(math.ceil(percent_charged/100*(len(BLOCKS) - 1)))]
+                full_text = self.blocks[int(math.ceil(percent_charged/100*(len(self.blocks) - 1)))]
         elif self.mode == "ascii_bar":
             full_part = FULL_BLOCK * int(percent_charged/10)
             if charging:
@@ -94,7 +98,7 @@ class Py3status:
                 if self.color_good
                 else i3s_config['color_good']
             )
-            response['full_text'] = "" if self.hide_when_full else BLOCKS[-1]
+            response['full_text'] = "" if self.hide_when_full else self.blocks[-1]
         elif charging:
             response['color'] = self.color_charging
 

--- a/py3status/modules/battery_level.py
+++ b/py3status/modules/battery_level.py
@@ -9,6 +9,7 @@ Configuration parameters:
     - mode : for primitive-one-char bar, or "text" for text percentage ouput
     - blocks : a string, where each character represents a battery level
     - charging_character : a character to represent charging battery
+    - show_percent_with_blocks : show battery level percentage in blocks mode
 
 Requires:
     - the 'acpi' command line
@@ -45,6 +46,7 @@ class Py3status:
     notification = False
     blocks = BLOCKS
     charging_character = CHARGING_CHARACTER
+    show_percent_with_blocks = False
 
     def battery_level(self, i3s_output_list, i3s_config):
         response = {}
@@ -67,6 +69,8 @@ class Py3status:
                 full_text = self.charging_character
             else:
                 full_text = self.blocks[int(math.ceil(percent_charged/100*(len(self.blocks) - 1)))]
+            if self.show_percent_with_blocks:
+                full_text += "  {}%".format(percent_charged)
         elif self.mode == "ascii_bar":
             full_part = FULL_BLOCK * int(percent_charged/10)
             if charging:

--- a/py3status/modules/battery_level.py
+++ b/py3status/modules/battery_level.py
@@ -3,13 +3,17 @@
 Display the battery level.
 
 Configuration parameters:
-    - blocks : a string, where each character represents a battery level
-    - charging_character : a character to represent charging battery
+    - blocks : a string, where each character represents battery level in bar mode
+      especially useful when using icon fonts (e.g. FontAwesome)
+      default is "_▁▂▃▄▅▆▇█"
+    - charging_character : a character to represent charging battery in bar mode
+      especially useful when using icon fonts (e.g. FontAwesome)
+      default is "⚡"
     - color_* : None means - get it from i3status config
     - format : text with "text" mode. percentage with % replaces {}
     - hide_when_full : hide any information when battery is fully charged
     - mode : for primitive-one-char bar, or "text" for text percentage ouput
-    - show_percent_with_blocks : show battery level percentage in blocks mode
+    - show_percent_with_blocks : show battery level percentage in bar mode
 
 Requires:
     - the 'acpi' command line


### PR DESCRIPTION
Hello, I'd like to propose extending the `battery_level` module to allow using user-defined characters as blocks. This is especially beneficial when using icon font:

![selection_008](https://cloud.githubusercontent.com/assets/1177900/10715451/bc8495be-7b17-11e5-88f5-fe0f7051682c.png)
![selection_003](https://cloud.githubusercontent.com/assets/1177900/10715449/bc83a71c-7b17-11e5-8944-2e6ca5706262.png)
![selection_004](https://cloud.githubusercontent.com/assets/1177900/10715453/bc851e4e-7b17-11e5-8379-f2794597d77b.png)
![selection_005](https://cloud.githubusercontent.com/assets/1177900/10715452/bc84bca6-7b17-11e5-81f1-1ddfef201a40.png)
![selection_006](https://cloud.githubusercontent.com/assets/1177900/10715450/bc843d3a-7b17-11e5-9df3-c6c97937cbad.png)
![selection_007](https://cloud.githubusercontent.com/assets/1177900/10715454/bc87129e-7b17-11e5-96f4-ac9d7c5caf9c.png)

As you can see, I also made it possible to show percentage next to the icon.

Both settings are optional, and their default values are set to preserve the existing behavior -- so current users shouldn't notice any difference. 

This is the configuration that produces the screenshots above (it assumes the icon font to be installed and configured in `.i3/config`):

```
battery_level {
  blocks = ""
  charging_character = ""
  show_percent_with_blocks = true
}
```