### PR TITLE
Proper parsing for boolean values in config

### DIFF
--- a/py3status/__init__.py
+++ b/py3status/__init__.py
@@ -195,6 +195,8 @@ class I3status(Thread):
         it properly. This is used to parse i3status configuration parameters
         such as 'disk "/home" {}' or worse like '"cpu_temperature" 0 {}'.
         """
+        if value.lower() in ('true', 'false'):
+            return eval(value.title())
         try:
             e_value = eval(value)
             if isinstance(e_value, str) or isinstance(e_value, int):

--- a/py3status/__init__.py
+++ b/py3status/__init__.py
@@ -199,7 +199,12 @@ class I3status(Thread):
             return eval(value.title())
         try:
             e_value = eval(value)
-            if isinstance(e_value, str) or isinstance(e_value, int):
+            if isinstance(e_value, str):
+                if e_value.lower() in ('true', 'false'):
+                    value = eval(e_value.title())
+                else:
+                    value = e_value
+            elif isinstance(e_value, int):
                 value = e_value
             else:
                 raise ValueError()


### PR DESCRIPTION
Hi! 
At this moment such config parameters as ```separator = false``` converts to ```"separator": "false"``` when parsed, that is not a proper representation for a boolean variable in Python or in JSON.
This PR must fix it.