### PR TITLE
[battery_level] Uniformize and standardize 'format' option

### DIFF
--- a/py3status/modules/battery_level.py
+++ b/py3status/modules/battery_level.py
@@ -92,6 +92,7 @@ class Py3status:
 
         self.refresh_battery_info()
 
+        self.provide_backwards_compatibility()
         self.update_icon()
         self.update_ascii_bar()
         self.update_full_text()
@@ -108,6 +109,18 @@ class Py3status:
                 stdout=open('/dev/null', 'w'),
                 stderr=open('/dev/null', 'w')
             )
+
+    def provide_backwards_compatibility(self):
+        # Backwards compatibility for 'mode' parameter
+        if self.format == FORMAT and self.mode == 'ascii_bar':
+            self.format = "{ascii_bar}"
+
+        # Backwards compatibility for 'show_percent_with_blocks' parameter
+        if self.format == FORMAT and self.show_percent_with_blocks:
+            self.format = "{icon} {percent}%"
+
+        # Backwards compatibility for '{}' option in format string
+        self.format = self.format.replace('{}', '{percent}')
 
     def refresh_battery_info(self):
         # Example acpi raw output: "Battery 0: Discharging, 43%, 00:59:20 remaining"

--- a/py3status/modules/battery_level.py
+++ b/py3status/modules/battery_level.py
@@ -3,17 +3,32 @@
 Display the battery level.
 
 Configuration parameters:
-    - blocks : a string, where each character represents battery level in bar mode
+    - blocks : a string, where each character represents battery level
       especially useful when using icon fonts (e.g. FontAwesome)
       default is "_▁▂▃▄▅▆▇█"
-    - charging_character : a character to represent charging battery in bar mode
+    - charging_character : a character to represent charging battery
       especially useful when using icon fonts (e.g. FontAwesome)
       default is "⚡"
     - color_* : None means - get it from i3status config
-    - format : text with "text" mode. percentage with % replaces {}
+    - format : string that formats the output. Supported options:
+      - '{percent}' : the remaining battery percentage (previously '{}')
+      - '{icon}' : a character representing the battery level,
+                   as defined by the 'blocks' and 'charging_character' parameters
+      - '{ascii_bar}' : a string of ascii characters representing the battery level,
+                        an alternative visualization to '{icon}' option
+      default is "Battery: {percent}"
     - hide_when_full : hide any information when battery is fully charged
-    - mode : for primitive-one-char bar, or "text" for text percentage ouput
-    - show_percent_with_blocks : show battery level percentage in bar mode
+
+Obsolete configuration parameters:
+    - mode : an old way to define 'format' parameter. The current behavior is:
+      - if 'format' is specified, this parameter is completely ignored
+      - if the value is 'ascii_bar', the 'format' is set to "{ascii_bar}"
+      - all other values are ignored
+      - there is no default value for this parameter
+    - show_percent_with_blocks : an old way to define 'format' parameter:
+      - if 'format' is specified, this parameter is completely ignored
+      - if the value is True, the 'format' is set to "{icon} {percent}%"
+      - there is no default value for this parameter
 
 Requires:
     - the 'acpi' command line

--- a/py3status/modules/battery_level.py
+++ b/py3status/modules/battery_level.py
@@ -29,7 +29,7 @@ Configuration parameters:
                    as defined by the 'blocks' and 'charging_character' parameters
       - '{ascii_bar}' : a string of ascii characters representing the battery level,
                         an alternative visualization to '{icon}' option
-      default is "Battery: {percent}"
+      default is "{icon}"
     - hide_when_full : hide any information when battery is fully charged
       default is False
     - notification : show current battery state as notification on click
@@ -39,6 +39,7 @@ Obsolete configuration parameters:
     - mode : an old way to define 'format' parameter. The current behavior is:
       - if 'format' is specified, this parameter is completely ignored
       - if the value is 'ascii_bar', the 'format' is set to "{ascii_bar}"
+      - if the value is 'text', the 'format' is set to "Battery: {percent}"
       - all other values are ignored
       - there is no default value for this parameter
     - show_percent_with_blocks : an old way to define 'format' parameter:
@@ -64,7 +65,7 @@ CHARGING_CHARACTER = "⚡"
 EMPTY_BLOCK_CHARGING = '|'
 EMPTY_BLOCK_DISCHARGING = '⍀'
 FULL_BLOCK = '█'
-FORMAT = "Battery: {percent}"
+FORMAT = "{icon}"
 
 
 class Py3status:
@@ -78,7 +79,7 @@ class Py3status:
     color_charging = "#FCE94F"
     color_degraded = None
     color_good = None
-    format = "Battery: {}"
+    format = FORMAT
     hide_when_full = False
     notification = False
     # obsolete configuration parameters
@@ -114,6 +115,8 @@ class Py3status:
         # Backwards compatibility for 'mode' parameter
         if self.format == FORMAT and self.mode == 'ascii_bar':
             self.format = "{ascii_bar}"
+        if self.format == FORMAT and self.mode == 'text':
+            self.format = "Battery: {percent}"
 
         # Backwards compatibility for 'show_percent_with_blocks' parameter
         if self.format == FORMAT and self.show_percent_with_blocks:

--- a/py3status/modules/battery_level.py
+++ b/py3status/modules/battery_level.py
@@ -150,10 +150,7 @@ class Py3status:
             self.icon = self.blocks[int(math.ceil(self.percent_charged/100*(len(self.blocks) - 1)))]
 
     def _update_full_text(self):
-        self.full_text = self.format                                          \
-                             .replace('{percent}', str(self.percent_charged)) \
-                             .replace('{icon}', self.icon)                    \
-                             .replace('{ascii_bar}', self.ascii_bar)
+        self.full_text = self.format.format(ascii_bar=self.ascii_bar, icon=self.icon, percent=self.percent_charged)
 
     def _build_response(self):
         self.response = {}

--- a/py3status/modules/battery_level.py
+++ b/py3status/modules/battery_level.py
@@ -90,14 +90,14 @@ class Py3status:
         self.i3s_config = i3s_config
         self.i3s_output_list = i3s_output_list
 
-        self.refresh_battery_info()
+        self._refresh_battery_info()
 
-        self.provide_backwards_compatibility()
-        self.update_icon()
-        self.update_ascii_bar()
-        self.update_full_text()
+        self._provide_backwards_compatibility()
+        self._update_icon()
+        self._update_ascii_bar()
+        self._update_full_text()
 
-        return self.build_response()
+        return self._build_response()
 
     def on_click(self, i3s_output_list, i3s_config, event):
         """
@@ -110,7 +110,7 @@ class Py3status:
                 stderr=open('/dev/null', 'w')
             )
 
-    def provide_backwards_compatibility(self):
+    def _provide_backwards_compatibility(self):
         # Backwards compatibility for 'mode' parameter
         if self.format == FORMAT and self.mode == 'ascii_bar':
             self.format = "{ascii_bar}"
@@ -122,7 +122,7 @@ class Py3status:
         # Backwards compatibility for '{}' option in format string
         self.format = self.format.replace('{}', '{percent}')
 
-    def refresh_battery_info(self):
+    def _refresh_battery_info(self):
         # Example acpi raw output: "Battery 0: Discharging, 43%, 00:59:20 remaining"
         acpi_raw = subprocess.check_output(["acpi"], stderr=subprocess.STDOUT)
         acpi_unicode = acpi_raw.decode("UTF-8")
@@ -133,41 +133,41 @@ class Py3status:
         self.charging = self.acpi_list[2][:8] == "Charging"
         self.percent_charged = int(self.acpi_list[3][:-2])
 
-    def update_ascii_bar(self):
+    def _update_ascii_bar(self):
         self.ascii_bar = FULL_BLOCK * int(self.percent_charged/10)
         if self.charging:
             self.ascii_bar += EMPTY_BLOCK_CHARGING * (10 - int(self.percent_charged/10))
         else:
             self.ascii_bar += EMPTY_BLOCK_DISCHARGING * (10 - int(self.percent_charged/10))
 
-    def update_icon(self):
+    def _update_icon(self):
         if self.charging:
             self.icon = self.charging_character
         else:
             self.icon = self.blocks[int(math.ceil(self.percent_charged/100*(len(self.blocks) - 1)))]
 
-    def update_full_text(self):
+    def _update_full_text(self):
         self.full_text = self.format                                          \
                              .replace('{percent}', str(self.percent_charged)) \
                              .replace('{icon}', self.icon)                    \
                              .replace('{ascii_bar}', self.ascii_bar)
 
-    def build_response(self):
+    def _build_response(self):
         self.response = {}
 
-        self.set_bar_text()
-        self.set_bar_color()
-        self.set_cache_timeout()
+        self._set_bar_text()
+        self._set_bar_color()
+        self._set_cache_timeout()
 
         return self.response
 
-    def set_bar_text(self):
+    def _set_bar_text(self):
         if self.percent_charged == 100 and self.hide_when_full:
             self.response['full_text'] = ''
         else:
             self.response['full_text'] = self.full_text
 
-    def set_bar_color(self):
+    def _set_bar_color(self):
         if self.charging:
             self.response['color'] = self.color_charging
         elif self.percent_charged < 10:
@@ -177,7 +177,7 @@ class Py3status:
         elif self.percent_charged == 100:
             self.response['color'] = self.color_good or self.i3s_config['color_good']
 
-    def set_cache_timeout(self):
+    def _set_cache_timeout(self):
         self.response['cached_until'] = time() + self.cache_timeout
 
 

--- a/py3status/modules/battery_level.py
+++ b/py3status/modules/battery_level.py
@@ -6,10 +6,23 @@ Configuration parameters:
     - blocks : a string, where each character represents battery level
       especially useful when using icon fonts (e.g. FontAwesome)
       default is "_▁▂▃▄▅▆▇█"
+    - cache_timeout : a timeout to refresh the battery state
+      default is 30
     - charging_character : a character to represent charging battery
       especially useful when using icon fonts (e.g. FontAwesome)
       default is "⚡"
-    - color_* : None means - get it from i3status config
+    - color_bad : a color to use when the battery level is bad
+      None means get it from i3status config
+      default is None
+    - color_charging : a color to use when the battery is charging
+      None means get it from i3status config
+      default is "#FCE94F"
+    - color_degraded : a color to use when the battery level is degraded
+      None means get it from i3status config
+      default is None
+    - color_good : a color to use when the battery level is good
+      None means get it from i3status config
+      default is None
     - format : string that formats the output. Supported options:
       - '{percent}' : the remaining battery percentage (previously '{}')
       - '{icon}' : a character representing the battery level,
@@ -18,6 +31,9 @@ Configuration parameters:
                         an alternative visualization to '{icon}' option
       default is "Battery: {percent}"
     - hide_when_full : hide any information when battery is fully charged
+      default is False
+    - notification : show current battery state as notification on click
+      default is False
 
 Obsolete configuration parameters:
     - mode : an old way to define 'format' parameter. The current behavior is:

--- a/py3status/modules/battery_level.py
+++ b/py3status/modules/battery_level.py
@@ -185,8 +185,9 @@ if __name__ == "__main__":
     from time import sleep
     x = Py3status()
     config = {
-        'color_good': '#00FF00',
         'color_bad': '#FF0000',
+        'color_degraded': '#FFFF00',
+        'color_good': '#00FF00',
     }
     while True:
         print(x.battery_level([], config))


### PR DESCRIPTION
@ultrabug, as promised, here's an implementation for the uniform 'format' option in battery_level module. I've also refactored quite a bit and provided previously missing documentation for several options.

It should be fully backwards compatible, and all those compatibility rules are collected in one place for easier future reference.

Feedback is welcome :smiley: 

/link: #98


**UPDATE:** Forgot to mention, there's also one bug fixed while refactoring, so the behavior is *not exactly the same* as before. Previously `battery_full` variable was set to `False` and never updated, which means that `color_good` and `hide_when_full` parameters did nothing. Now this is fixed.