### PR TITLE
Fix parsing of taskWarrior's output

### DIFF
--- a/py3status/modules/taskwarrior.py
+++ b/py3status/modules/taskwarrior.py
@@ -28,7 +28,7 @@ class Py3status:
     def taskWarrior(self, i3s_output_list, i3s_config):
         command = 'task start.before:tomorrow status:pending export'
         taskwarrior_output = check_output(shlex.split(command))
-        tasks_json = json.loads('[' + taskwarrior_output.decode('utf-8') + ']')
+        tasks_json = json.loads(taskwarrior_output.decode('utf-8'))
 
         def describeTask(taskObj):
             return str(taskObj['id']) + ' ' + taskObj['description']


### PR DESCRIPTION
I don't know for older versions, but the latest stable release (2.5.1) already
have '[' and ']' when doing an export. This lead to raising an exception
because it makes a nested list and you try to access it using a string
rather than an integer