### PR TITLE
Eliminate intrusive log messages from pomodoro's module

### DIFF
--- a/py3status/modules/pomodoro.py
+++ b/py3status/modules/pomodoro.py
@@ -107,7 +107,7 @@ class Py3status:
                 self.__setup('break')
             self.run = False
 
-    def setup_mmss_time(self, form=None):
+    def _setup_mmss_time(self, form=None):
         """
         Setup the formatted time string.
         """
@@ -124,7 +124,7 @@ class Py3status:
 
         return time
 
-    def setup_bar(self):
+    def _setup_bar(self):
         """
         Setup the process bar.
         """
@@ -148,10 +148,10 @@ class Py3status:
         Return the response full_text string
         """
         formatters = {
-            'bar': self.setup_bar(),
+            'bar': self._setup_bar(),
             'ss': self.timer,
-            'mm': self.setup_mmss_time(form='mm'),
-            'mmss': self.setup_mmss_time()
+            'mm': self._setup_mmss_time(form='mm'),
+            'mmss': self._setup_mmss_time()
         }
 
         if self.display_bar is True:


### PR DESCRIPTION
Hi,

Py3status imports all methods of a module except those starting with an
underscore and special methods. It then call these methods with self,
i3s_output_list and i3s_config.

Because of these rules, py3status call setup_mmss_time and setup_bar
with too many arguments, causing intrusive messages in logs. This PR 
fix this behaviour by adding an underscore before these methods' name.