### PR TITLE
wwan_status: A network connectivity status indicator for newer Huawei modems

### DIFF
--- a/py3status/modules/README.md
+++ b/py3status/modules/README.md
@@ -712,7 +712,8 @@ Available modules:
                          		netifaces (for IP address display)
 
                          Configuration parameters:
-                         		- cache_timeout : how often we refresh this module in seconds
+                         		- cache_timeout : How often we refresh this module in seconds.
+                         		                    Default is 5.
                          		- prefix        : Default is "WWAN: ".
                          		- modem         : The device to send commands to. Default is
                                                 /dev/ttyUSB1, which should be fine for most

--- a/py3status/modules/README.md
+++ b/py3status/modules/README.md
@@ -712,27 +712,27 @@ Available modules:
                          		- pyserial
 
                          Configuration parameters:
+                         		- baudrate      : Default is 115200. There should be no need
+                                                to configure this, but feel free to experiment
                          		- cache_timeout : How often we refresh this module in seconds.
                          		                    Default is 5.
-                         		- prefix        : Default is "WWAN: ".
-                         		- modem         : The device to send commands to. Default is
-                                                /dev/ttyUSB1, which should be fine for most
-                                                USB modems
-                         		- show_ip       : Enable or disable IP address display for the
-                                                configured interface (see below). Default is
-                                                true
                          		- interface     : The default interface to obtain the IP address
                                                 from. For wvdial this is most likely ppp0
                                                 (default), for netctl it can be different. If
                                                 show_ip is false, then this settings has no
                                                 effect
+                         		- modem         : The device to send commands to. Default is
+                                                /dev/ttyUSB1, which should be fine for most
+                                                USB modems
                          		- modem_timeout : The timespan betwenn querying the modem and
                                                 collecting the response. 0.2 seconds has turned
                                                 out to work for my E3276. If you do not get any
                                                 output, consider increasing the value in 0.1
                                                 second steps
-                         		- baudrate      : Default is 115200. There should be no need
-                                                to configure this, but feel free to experiment
+                         		- prefix        : Default is "WWAN: ".
+                         		- show_ip       : Enable or disable IP address display for the
+                                                configured interface (see below). Default is
+                                                true
 
 
                          i3status.conf example configs:
@@ -740,14 +740,13 @@ Available modules:
                          Default:
 
                          		wwan_status {
-                         				cache_timeout = 5
-                         				prefix = "WWAN: "
-                         				modem1 = "/dev/ttyUSB1"
                          				baudrate = 115200
-                         				modem_timeout = 0.2
-                         				show_ip = True
-                         				noipstring = "no ip"
+                         				cache_timeout = 5
                          				interface = "ppp0"
+                         				modem1 = "/dev/ttyUSB1"
+                         				modem_timeout = 0.2
+                         				prefix = "WWAN: "
+                         				show_ip = True
                          		}
 
                          which is equvivalent to

--- a/py3status/modules/README.md
+++ b/py3status/modules/README.md
@@ -754,10 +754,6 @@ Available modules:
                          		wwan_status {
                          		}
 
-                         or simply
-
-                         		wwan_status
-
                          An alternative configuration with longer modem respond time but
                          without IP address display:
 

--- a/py3status/modules/README.md
+++ b/py3status/modules/README.md
@@ -679,7 +679,7 @@ Available modules:
                          @author Anon1234 https://github.com/Anon1234
                          @license BSD
                          ---
-	wwan_status
+  wwan_status
                          Display current network and ip address for newer Huwei modems.
                          
                          It is tested for Huawei E3276 (usb-id 12d1:1506) aka Telekom Speed
@@ -697,15 +697,17 @@ Available modules:
                          to see them in this module, feel free to edit the code or contact me.
 
                          IMPORTANT/PREREQUISITES:
-                         		1. Many USB modems (including the one tested) do not register as a
-                         		modem but as a storage device. If this applies to your modem, too,
-                         		consider using the usb_modeswitch tool which is part of many Linux
-                         		distributions
+                            1. Many USB modems (including the one tested) do not register as a
+                            modem but as a storage device. If this applies to your modem, too,
+                            consider using the usb_modeswitch tool which is part of many Linux
+                            distributions
 
-                         		2. This module needs read/write access to your modem communication
-                         		device file. If your modem is /dev/ttyUSB{n}, then it is
-                         		usually /dev/ttyUSB{n+1}. So in the vast majority of cases it is
-                         		/dev/ttyUSB1, which is the default setting.
+                            2. This module needs read/write access to your modem communication
+                            device file. If your modem is /dev/ttyUSB{n}, then it is
+                            usually /dev/ttyUSB{n+1}. So in the vast majority of cases it is
+                            /dev/ttyUSB1, which is the default setting. If you keep getting a
+                            "no access to /dev/..." message, checking permissions is the way to
+                            go
 
 
                          DEPENDENCIES:

--- a/py3status/modules/README.md
+++ b/py3status/modules/README.md
@@ -687,7 +687,7 @@ Available modules:
 
                          When using anything but NetworkManger (like wvdial, netctl), you
                          never get to know which kind of Network (LTE/4G, UMTS/3G, EDGE, ...)
-                         your modem is using at a given point in time. This module querys
+                         your modem is using at a given point in time. This module queries
                          the modem using AT commands and displays its response.
 
                          You can optionally give a network interface name to display the IP

--- a/py3status/modules/README.md
+++ b/py3status/modules/README.md
@@ -777,6 +777,7 @@ Available modules:
 
                          @author Timo Kohorst timo@kohorst-online.com
                          PGP: B383 6AE6 6B46 5C45 E594 96AB 89D2 209D DBF3 2BB5
+                         @license GPLv3
                          ---
   xrandr                 Control your screen(s) layout easily.
                          

--- a/py3status/modules/README.md
+++ b/py3status/modules/README.md
@@ -779,7 +779,6 @@ Available modules:
 
                          @author Timo Kohorst timo@kohorst-online.com
                          PGP: B383 6AE6 6B46 5C45 E594 96AB 89D2 209D DBF3 2BB5
-                         @license GPLv3
                          ---
   xrandr                 Control your screen(s) layout easily.
                          

--- a/py3status/modules/README.md
+++ b/py3status/modules/README.md
@@ -708,8 +708,8 @@ Available modules:
 
 
                          DEPENDENCIES:
-                         		pyserial (mandatory)
-                         		netifaces (for IP address display)
+                         		pyserial
+                         		netifaces
 
                          Configuration parameters:
                          		- cache_timeout : How often we refresh this module in seconds.

--- a/py3status/modules/README.md
+++ b/py3status/modules/README.md
@@ -679,6 +679,96 @@ Available modules:
                          @author Anon1234 https://github.com/Anon1234
                          @license BSD
                          ---
+	wwan_status
+                         Display current network and ip address for newer Huwei modems. It
+                         is tested for Huawei E3276 (usb-id 12d1:1506) aka Telekom Speed
+                         Stick LTE III
+
+                         When using anything but NetworkManger (like wvdial, netctl), you
+                         never get to know which kind of Network (LTE/4G, UMTS/3G, EDGE, ...)
+                         your modem is using at a given point in time. This module querys
+                         the modem using AT commands and displays its response.
+
+                         You can optionally give a network interface name to display the IP
+                         address your mobile service provider has assigned you.
+
+                         If you know AT command-/answer pairs for other modems and would like
+                         to see them in this module, feel free to edit the code or contact me.
+
+                         IMPORTANT/PREREQUISITES:
+                         		1. Many USB modems (including the one tested) do not register as a
+                         		modem but as a storage device. If this applies to your modem, too,
+                         		consider using the usb_modeswith tool which is part of many Linux
+                         		distributions
+
+                         		2. This module needs read/write access to your modem communication
+                         		device file. If your modem is /dev/ttyUSB{n}, then it is
+                         		usually /dev/ttyUSB{n+1}. So in the vast majority of cases it is
+                         		/dev/ttyUSB1, which is the default setting.
+
+
+                         DEPENDENCIES:
+                         		pyserial (mandatory)
+                         		netifaces (for IP address display)
+
+                         Configuration parameters:
+                         		- cache_timeout : how often we refresh this module in seconds
+                         		- prefix        : Default is "WWAN: ".
+                         		- modem         : The device to send commands to. Default is
+                                                /dev/ttyUSB1, which should be fine for most
+                                                USB modems
+                         		- show_ip       : Enable or disable IP address display for the
+                                                configured interface (see below). Default is
+                                                true
+                         		- interface     : The default interface to obtain the IP address
+                                                from. For wvdial this is most likely ppp0
+                                                (default), for netctl it can be different. If
+                                                show_ip is false, then this settings has no
+                                                effect
+                         		- modem_timeout : The timespan betwenn querying the modem and
+                                                collecting the response. 0.2 seconds has turned
+                                                out to work for my E3276. If you do not get any
+                                                output, consider increasing the value in 0.1
+                                                second steps
+                         		- baudrate      : Default is 115200. There should be no need
+                                                to configure this, but feel free to experiment
+
+
+                         i3status.conf example configs:
+
+                         Default:
+
+                         		wwan_status {
+                         				cache_timeout = 5
+                         				prefix = "WWAN: "
+                         				modem1 = "/dev/ttyUSB1"
+                         				baudrate = 115200
+                         				modem_timeout = 0.2
+                         				show_ip = True
+                         				noipstring = "no ip"
+                         				interface = "ppp0"
+                         		}
+
+                         which is equvivalent to
+
+                         		wwan_status {
+                         		}
+
+                         or simply
+
+                         		wwan_status
+
+                         An alternative configuration with longer modem respond time but
+                         without IP address display:
+
+                         		wwan_status {
+                         				modem_timeout = 0.3
+                         				show_ip = False
+                         		}
+
+                         @author Timo Kohorst timo@kohorst-online.com
+                         PGP: B383 6AE6 6B46 5C45 E594 96AB 89D2 209D DBF3 2BB5
+                         ---
   xrandr                 Control your screen(s) layout easily.
                          
                          This modules allows you to handle your screens outputs directly from your bar!

--- a/py3status/modules/README.md
+++ b/py3status/modules/README.md
@@ -708,8 +708,8 @@ Available modules:
 
 
                          DEPENDENCIES:
-                         		pyserial
-                         		netifaces
+                         		- netifaces
+                         		- pyserial
 
                          Configuration parameters:
                          		- cache_timeout : How often we refresh this module in seconds.

--- a/py3status/modules/README.md
+++ b/py3status/modules/README.md
@@ -680,8 +680,9 @@ Available modules:
                          @license BSD
                          ---
 	wwan_status
-                         Display current network and ip address for newer Huwei modems. It
-                         is tested for Huawei E3276 (usb-id 12d1:1506) aka Telekom Speed
+                         Display current network and ip address for newer Huwei modems.
+                         
+                         It is tested for Huawei E3276 (usb-id 12d1:1506) aka Telekom Speed
                          Stick LTE III
 
                          When using anything but NetworkManger (like wvdial, netctl), you

--- a/py3status/modules/README.md
+++ b/py3status/modules/README.md
@@ -735,10 +735,9 @@ Available modules:
                          		- format_up             : What to display upon regular connection
                                                       Default is 'WWAN: {status} ({netgen}) {ip}'
                          		- interface             : The default interface to obtain the IP address
-                                                      from. For wvdial this is most likely ppp0
-                                                      (default), for netctl it can be different. If
-                                                      show_ip is false, then this settings has no
-                                                      effect
+                                                      from. For wvdial this is most likely ppp0.
+                                                      For netctl it can be different.
+                                                      Default is: ppp0
                          		- modem                 : The device to send commands to.
                                                       Default is /dev/ttyUSB1
                          		- modem_timeout         : The timespan betwenn querying the modem and

--- a/py3status/modules/README.md
+++ b/py3status/modules/README.md
@@ -698,7 +698,7 @@ Available modules:
                          IMPORTANT/PREREQUISITES:
                          		1. Many USB modems (including the one tested) do not register as a
                          		modem but as a storage device. If this applies to your modem, too,
-                         		consider using the usb_modeswith tool which is part of many Linux
+                         		consider using the usb_modeswitch tool which is part of many Linux
                          		distributions
 
                          		2. This module needs read/write access to your modem communication
@@ -712,55 +712,68 @@ Available modules:
                          		- pyserial
 
                          Configuration parameters:
-                         		- baudrate      : Default is 115200. There should be no need
-                                                to configure this, but feel free to experiment
-                         		- cache_timeout : How often we refresh this module in seconds.
-                         		                    Default is 5.
-                         		- interface     : The default interface to obtain the IP address
-                                                from. For wvdial this is most likely ppp0
-                                                (default), for netctl it can be different. If
-                                                show_ip is false, then this settings has no
-                                                effect
-                         		- modem         : The device to send commands to. Default is
-                                                /dev/ttyUSB1, which should be fine for most
-                                                USB modems
-                         		- modem_timeout : The timespan betwenn querying the modem and
-                                                collecting the response. 0.2 seconds has turned
-                                                out to work for my E3276. If you do not get any
-                                                output, consider increasing the value in 0.1
-                                                second steps
-                         		- prefix        : Default is "WWAN: ".
-                         		- show_ip       : Enable or disable IP address display for the
-                                                configured interface (see below). Default is
-                                                true
-
-
+                         		- baudrate              : There should be no need to configure this, but
+                                                      feel free to experiment.
+                                                      Default is 115200.
+                         		- cache_timeout         : How often we refresh this module in seconds.
+                                                      Default is 5.
+                         		- consider_3G_degraded  : If set to True, only 4G-networks will be
+                                                      considered 'good'; 3G connections are shown
+                                                      as 'degraded', which is yellow by default. Mostly
+                                                      useful if you want to keep track of where there
+                                                      is a 4G connection.
+                                                      Default is False.
+                         		- format_down           : What to display when the modem is not plugged in
+                                                      Default is: 'WWAN: down'
+                         		- format_error          : What to display when modem can't be accessed.
+                                                      Default is 'WWAN: {error}'
+                         		- format_no_service     : What to display when the modem does not have a
+                                                      network connection. This allows to omit the then
+                                                      meaningless network generation. Therefore the
+                                                      default is 'WWAN: {status} {ip}'
+                         		- format_up             : What to display upon regular connection
+                                                      Default is 'WWAN: {status} ({netgen}) {ip}'
+                         		- interface             : The default interface to obtain the IP address
+                                                      from. For wvdial this is most likely ppp0
+                                                      (default), for netctl it can be different. If
+                                                      show_ip is false, then this settings has no
+                                                      effect
+                         		- modem                 : The device to send commands to.
+                                                      Default is /dev/ttyUSB1
+                         		- modem_timeout         : The timespan betwenn querying the modem and
+                                                      collecting the response.
+                                                      Default is 0.4 (which should be sufficient)
+                        
                          i3status.conf example configs:
 
                          Default:
 
-                         		wwan_status {
-                         				baudrate = 115200
-                         				cache_timeout = 5
-                         				interface = "ppp0"
-                         				modem1 = "/dev/ttyUSB1"
-                         				modem_timeout = 0.2
-                         				prefix = "WWAN: "
-                         				show_ip = True
-                         		}
+                            wwan_status {
+                                baudrate = 115200
+                                cache_timeout = 5
+                                consider_3G_degraded = False
+                                format_down = 'WWAN: down'
+                                format_error = 'WWAN: {error}'
+                                format_no_service = 'WWAN: {status} {ip}'
+                                format_up = 'WWAN: {status} ({netgen}) {ip}'
+                                interface = "ppp0"
+                                modem1 = "/dev/ttyUSB1"
+                                modem_timeout = 0.4
+                            }
 
                          which is equvivalent to
 
-                         		wwan_status {
-                         		}
+                            wwan_status {
+                            }
 
-                         An alternative configuration with longer modem respond time but
-                         without IP address display:
+                         An alternative configuration with in which only 4G is show in 'good'
+                         color and IP address display is not desired:
 
-                         		wwan_status {
-                         				modem_timeout = 0.3
-                         				show_ip = False
-                         		}
+                            wwan_status {
+                                consider_3G_degraded = False
+                                format_no_service = 'WWAN: {status}'
+                                format_up = 'WWAN: {status} ({netgen})'
+                            }
 
                          @author Timo Kohorst timo@kohorst-online.com
                          PGP: B383 6AE6 6B46 5C45 E594 96AB 89D2 209D DBF3 2BB5

--- a/py3status/modules/README.md
+++ b/py3status/modules/README.md
@@ -768,7 +768,7 @@ Available modules:
                             wwan_status {
                             }
 
-                         An alternative configuration with in which only 4G is show in 'good'
+                         An alternative configuration in which only 4G networks are displayed in 'good'
                          color and IP address display is not desired:
 
                             wwan_status {

--- a/py3status/modules/wwan_status.py
+++ b/py3status/modules/wwan_status.py
@@ -49,24 +49,24 @@ class Py3status:
 
     def wwan_status(self, i3s_output_list, i3s_config):
 
-        query = "AT^SYSINFOEX" 
-        target_line = "^SYSINFOEX" 
+        query = "AT^SYSINFOEX"
+        target_line = "^SYSINFOEX"
         noipstring = "no ip"
 
         response = {}
         # Check if path exists and is a character device
-        if os.path.exists(self.modem) and stat.S_ISCHR(os.stat(self.modem).st_mode):
+        if os.path.exists(self.modem) and stat.S_ISCHR(os.stat(
+                self.modem).st_mode):
             print("Found modem " + self.modem)
             try:
-                ser = serial.Serial (
-                    port = self.modem,
-                    baudrate = self.baudrate,
+                ser = serial.Serial(
+                    port=self.modem,
+                    baudrate=self.baudrate,
                     # Values below work for my modem. Not sure if
                     # they neccessarily work for all modems
-                    parity = serial.PARITY_ODD,
-                    stopbits = serial.STOPBITS_ONE,
-                    bytesize = serial.EIGHTBITS
-                )
+                    parity=serial.PARITY_ODD,
+                    stopbits=serial.STOPBITS_ONE,
+                    bytesize=serial.EIGHTBITS)
                 if ser.isOpen():
                     ser.close()
                 ser.open()
@@ -85,7 +85,8 @@ class Py3status:
                 PermissionError
                 print("Permission error")
                 response['color'] = i3s_config['color_bad']
-                response['full_text'] = self.prefix + "no access to " + self.modem
+                response[
+                    'full_text'] = self.prefix + "no access to " + self.modem
                 return response
             # Dissect response
             for line in modem_response.decode("utf-8").split('\n'):
@@ -108,11 +109,13 @@ class Py3status:
                             response['color'] = i3s_config['color_degraded']
                     elif netmode == "LTE":
                         response['color'] = i3s_config['color_good']
-                    else: 
+                    else:
                         response['color'] = i3s_config['color_degraded']
-                    response['full_text'] = self.prefix + "(" + netmode + ") " + ip_addr
+                    response[
+                        'full_text'] = self.prefix + "(" + netmode + ") " + ip_addr
                     return response
-                elif line.startswith("COMMAND NOT SUPPORT") or line.startswith("ERROR") :
+                elif line.startswith("COMMAND NOT SUPPORT") or line.startswith(
+                        "ERROR"):
                     response['full_text'] = self.prefix + "unsupported modem"
                     response['color'] = i3s_config['color_bad']
 

--- a/py3status/modules/wwan_status.py
+++ b/py3status/modules/wwan_status.py
@@ -117,8 +117,7 @@ class Py3status:
                         response['color'] = i3s_config['color_good']
                     else:
                         response['color'] = i3s_config['color_degraded']
-                    response[
-                        'full_text'] = self.prefix + "(" + netmode + ")"
+                    response['full_text'] = self.prefix + "(" + netmode + ")"
                     if self.show_ip:
                         response['full_text'] += " " + ip_addr
                     return response

--- a/py3status/modules/wwan_status.py
+++ b/py3status/modules/wwan_status.py
@@ -112,6 +112,10 @@ class Py3status:
                         response['color'] = i3s_config['color_degraded']
                     response['full_text'] = self.prefix + "(" + netmode + ") " + ip_addr
                     return response
+                elif line.startswith("COMMAND NOT SUPPORT"):
+                    response['full_text'] = self.prefix + "unsupported modem"
+                    response['color'] = i3s_config['color_bad']
+
         else:
             print(self.modem + " not found")
             response['full_text'] = self.prefix + "down"

--- a/py3status/modules/wwan_status.py
+++ b/py3status/modules/wwan_status.py
@@ -32,10 +32,9 @@ Configuration parameters:
     - format_up             : What to display upon regular connection
                               Default is 'WWAN: ({status}/{netgen}) {ip}'
     - interface             : The default interface to obtain the IP address
-                              from. For wvdial this is most likely ppp0
-                              (default), for netctl it can be different. If
-                              show_ip is false, then this settings has no
-                              effect
+                              from. For wvdial this is most likely ppp0.
+                              For netctl it can be different.
+                              Default is: ppp0
     - modem                 : The device to send commands to. Default is
     - modem_timeout         : The timespan betwenn querying the modem and
                               collecting the response.

--- a/py3status/modules/wwan_status.py
+++ b/py3status/modules/wwan_status.py
@@ -59,8 +59,8 @@ class Py3status:
     consider_3G_degraded = False
     format_down = 'WWAN: down'
     format_error = 'WWAN: {error}'
-    format_no_service = 'WWAN: ({status}) {ip}'
-    format_up = 'WWAN: ({status}/{netgen}) {ip}'
+    format_no_service = 'WWAN: {status} {ip}'
+    format_up = 'WWAN: {status} ({netgen}) {ip}'
     interface = "ppp0"
     modem = "/dev/ttyUSB1"
     modem_timeout = 0.4

--- a/py3status/modules/wwan_status.py
+++ b/py3status/modules/wwan_status.py
@@ -5,7 +5,8 @@ is tested for Huawei E3276 (usb-id 12d1:1506) aka Telekom Speed
 Stick LTE III
 
 Configuration parameters:
-    - cache_timeout : how often we refresh this module in seconds
+    - cache_timeout : How often we refresh this module in seconds.
+                      Default is 5.
     - prefix        : Default is "WWAN: ".
     - modem         : The device to send commands to. Default is
                       /dev/ttyUSB1, which should be fine for most
@@ -54,6 +55,7 @@ class Py3status:
         noipstring = "no ip"
 
         response = {}
+        response['cached_until'] = time() + self.cache_timeout
         # Check if path exists and is a character device
         if os.path.exists(self.modem) and stat.S_ISCHR(os.stat(
                 self.modem).st_mode):

--- a/py3status/modules/wwan_status.py
+++ b/py3status/modules/wwan_status.py
@@ -42,7 +42,6 @@ Configuration parameters:
 
 @author Timo Kohorst timo@kohorst-online.com
 PGP: B383 6AE6 6B46 5C45 E594 96AB 89D2 209D DBF3 2BB5
-@license GPLv3
 """
 
 import subprocess

--- a/py3status/modules/wwan_status.py
+++ b/py3status/modules/wwan_status.py
@@ -43,6 +43,7 @@ Configuration parameters:
 
 @author Timo Kohorst timo@kohorst-online.com
 PGP: B383 6AE6 6B46 5C45 E594 96AB 89D2 209D DBF3 2BB5
+@license GPLv3
 """
 
 import subprocess

--- a/py3status/modules/wwan_status.py
+++ b/py3status/modules/wwan_status.py
@@ -112,7 +112,7 @@ class Py3status:
                         response['color'] = i3s_config['color_degraded']
                     response['full_text'] = self.prefix + "(" + netmode + ") " + ip_addr
                     return response
-                elif line.startswith("COMMAND NOT SUPPORT"):
+                elif line.startswith("COMMAND NOT SUPPORT") or line.startswith("ERROR") :
                     response['full_text'] = self.prefix + "unsupported modem"
                     response['color'] = i3s_config['color_bad']
 

--- a/py3status/modules/wwan_status.py
+++ b/py3status/modules/wwan_status.py
@@ -9,27 +9,27 @@ DEPENDENCIES:
     - pyserial
 
 Configuration parameters:
+    - baudrate      : Default is 115200. There should be no need
+                      to configure this, but feel free to experiment
     - cache_timeout : How often we refresh this module in seconds.
                       Default is 5.
-    - prefix        : Default is "WWAN: ".
-    - modem         : The device to send commands to. Default is
-                      /dev/ttyUSB1, which should be fine for most
-                      USB modems
-    - show_ip       : Enable or disable IP address display for the
-                      configured interface (see below). Default is
-                      true
     - interface     : The default interface to obtain the IP address
                       from. For wvdial this is most likely ppp0
                       (default), for netctl it can be different. If
                       show_ip is false, then this settings has no
                       effect
+    - modem         : The device to send commands to. Default is
     - modem_timeout : The timespan betwenn querying the modem and
                       collecting the response. 0.2 seconds has turned
                       out to work for my E3276. If you do not get any
                       output, consider increasing the value in 0.1
                       second steps
-    - baudrate      : Default is 115200. There should be no need
-                      to configure this, but feel free to experiment
+                      /dev/ttyUSB1, which should be fine for most
+                      USB modems
+    - prefix        : Default is "WWAN: ".
+    - show_ip       : Enable or disable IP address display for the
+                      configured interface (see below). Default is
+                      true
 
 @author Timo Kohorst timo@kohorst-online.com
 PGP: B383 6AE6 6B46 5C45 E594 96AB 89D2 209D DBF3 2BB5
@@ -44,12 +44,12 @@ from time import time, sleep
 
 
 class Py3status:
+    baudrate = 115200
     cache_timeout = 5
     interface = "ppp0"
-    prefix = "WWAN: "
     modem = "/dev/ttyUSB1"
-    baudrate = 115200
     modem_timeout = 0.2
+    prefix = "WWAN: "
     show_ip = True
 
     def wwan_status(self, i3s_output_list, i3s_config):

--- a/py3status/modules/wwan_status.py
+++ b/py3status/modules/wwan_status.py
@@ -1,0 +1,192 @@
+# -*- coding: utf-8 -*-
+"""
+Display current network and ip address for newer Huwei modems. It
+is tested for Huawei E3276 (usb-id 12d1:1506) aka Telekom Speed
+Stick LTE III
+
+When using anything but NetworkManger (like wvdial, netctl), you
+never get to know which kind of Network (LTE/4G, UMTS/3G, EDGE, ...)
+your modem is using at a given point in time. This module querys
+the modem using AT commands and displays its response.
+
+You can optionally give a network interface name to display the IP
+address your mobile service provider has assigned you.
+
+If you know AT command-/answer pairs for other modems and would like
+to see them in this module, feel free to edit the code or contact me.
+
+IMPORTANT/PREREQUISITES:
+    1. Many USB modems (including the one tested) do not register as a
+    modem but as a storage device. If this applies to your modem, too,
+    consider using the usb_modeswith tool which is part of many Linux
+    distributions
+
+    2. This module needs read/write access to your modem communication
+    device file. If your modem is /dev/ttyUSB{n}, then it is
+    usually /dev/ttyUSB{n+1}. So in the vast majority of cases it is
+    /dev/ttyUSB1, which is the default setting.
+
+
+DEPENDENCIES:
+    pyserial (mandatory)
+    netifaces (for IP address display)
+
+Configuration parameters:
+    - cache_timeout : how often we refresh this module in seconds
+    - prefix        : Default is "WWAN: ".
+    - modem         : The device to send commands to. Default is
+                      /dev/ttyUSB1, which should be fine for most
+                      USB modems
+    - show_ip       : Enable or disable IP address display for the
+                      configured interface (see below). Default is
+                      true
+    - interface     : The default interface to obtain the IP address
+                      from. For wvdial this is most likely ppp0
+                      (default), for netctl it can be different. If
+                      show_ip is false, then this settings has no
+                      effect
+    - modem_timeout : The timespan betwenn querying the modem and
+                      collecting the response. 0.2 seconds has turned
+                      out to work for my E3276. If you do not get any
+                      output, consider increasing the value in 0.1
+                      second steps
+    - baudrate      : Default is 115200. There should be no need
+                      to configure this, but feel free to experiment
+
+
+i3status.conf example configs:
+
+Default:
+
+    wwan_status {
+        cache_timeout = 5
+        prefix = "WWAN: "
+        modem1 = "/dev/ttyUSB1"
+        baudrate = 115200
+        modem_timeout = 0.2
+        show_ip = True
+        noipstring = "no ip"
+        interface = "ppp0"
+    }
+
+which is equvivalent to
+
+    wwan_status {
+    }
+
+or simply
+
+    wwan_status
+
+An alternative configuration with longer modem respond time but
+without IP address display:
+
+    wwan_status {
+        modem_timeout = 0.3
+        show_ip = False
+    }
+
+@author Timo Kohorst timo@kohorst-online.com
+PGP: B383 6AE6 6B46 5C45 E594 96AB 89D2 209D DBF3 2BB5
+"""
+
+import subprocess
+import netifaces as ni
+import os
+import stat
+import serial
+from time import time, sleep
+
+
+class Py3status:
+    cache_timeout = 5
+    interface = "ppp0"
+    prefix = "WWAN: "
+    modem = "/dev/ttyUSB1"
+    baudrate = 115200
+    modem_timeout = 0.2
+    show_ip = True
+
+    def wwan_status(self, i3s_output_list, i3s_config):
+
+        query = "AT^SYSINFOEX" 
+        target_line = "^SYSINFOEX" 
+        noipstring = "no ip"
+
+        response = {}
+        # Check if path exists and is a character device
+        if os.path.exists(self.modem) and stat.S_ISCHR(os.stat(self.modem).st_mode):
+            print("Found modem " + self.modem)
+            try:
+                ser = serial.Serial (
+                    port = self.modem,
+                    baudrate = self.baudrate,
+                    # Values below work for my modem. Not sure if
+                    # they neccessarily work for all modems
+                    parity = serial.PARITY_ODD,
+                    stopbits = serial.STOPBITS_ONE,
+                    bytesize = serial.EIGHTBITS
+                )
+                if ser.isOpen():
+                    ser.close()
+                ser.open()
+                ser.write((query + "\r").encode())
+                print("Issued query to " + self.modem)
+                sleep(self.modem_timeout)
+                n = ser.inWaiting()
+                modem_response = ser.read(n)
+                ser.close()
+            except:
+                # This will happen...
+                # 1) in the short timespan between the creation of the device node
+                # and udev changing the permissions. If this message persists,
+                # double check if you are using the proper device file
+                # 2) if/when you unplug the device
+                PermissionError
+                print("Permission error")
+                response['color'] = i3s_config['color_bad']
+                response['full_text'] = self.prefix + "no access to " + self.modem
+                return response
+            # Dissect response
+            for line in modem_response.decode("utf-8").split('\n'):
+                print(line)
+                if line.startswith(target_line):
+                    netmode = line.split(',')[-1].rstrip()[1:-1]
+                    # Query IP address if desired
+                    if self.show_ip:
+                        ip_addr = noipstring
+                        if self.interface in ni.interfaces():
+                            addresses = ni.ifaddresses(self.interface)
+                            if ni.AF_INET in addresses:
+                                ip_addr = addresses[ni.AF_INET][0]['addr']
+
+                    if netmode == "NO SERVICE":
+                        response['color'] = i3s_config['color_bad']
+                        if ip_addr != noipstring:
+                            # Merely downgrade color to degraded if we still have an IP
+                            # address, but there is no service
+                            response['color'] = i3s_config['color_degraded']
+                    elif netmode == "LTE":
+                        response['color'] = i3s_config['color_good']
+                    else: 
+                        response['color'] = i3s_config['color_degraded']
+                    response['full_text'] = self.prefix + "(" + netmode + ") " + ip_addr
+                    return response
+        else:
+            print(self.modem + " not found")
+            response['full_text'] = self.prefix + "down"
+            response['color'] = i3s_config['color_bad']
+        return response
+
+
+if __name__ == "__main__":
+    from time import sleep
+    x = Py3status()
+    config = {
+        'color_good': '#00FF00',
+        'color_bad': '#FF0000',
+        'color_degraded': '#FFFF00',
+    }
+    while True:
+        print(x.wwan_status([], config))
+        sleep(1)

--- a/py3status/modules/wwan_status.py
+++ b/py3status/modules/wwan_status.py
@@ -38,12 +38,8 @@ Configuration parameters:
                               effect
     - modem                 : The device to send commands to. Default is
     - modem_timeout         : The timespan betwenn querying the modem and
-                              collecting the response. 0.2 seconds has turned
-                              out to work for my E3276. If you do not get any
-                              output, consider increasing the value in 0.1
-                              second steps
-                              /dev/ttyUSB1, which should be fine for most
-                              USB modems
+                              collecting the response.
+                              Default is 0.4 (which should be sufficient)
 
 @author Timo Kohorst timo@kohorst-online.com
 PGP: B383 6AE6 6B46 5C45 E594 96AB 89D2 209D DBF3 2BB5
@@ -67,7 +63,7 @@ class Py3status:
     format_up = 'WWAN: ({status}/{netgen}) {ip}'
     interface = "ppp0"
     modem = "/dev/ttyUSB1"
-    modem_timeout = 0.2
+    modem_timeout = 0.4
 
     def wwan_status(self, i3s_output_list, i3s_config):
 

--- a/py3status/modules/wwan_status.py
+++ b/py3status/modules/wwan_status.py
@@ -4,33 +4,6 @@ Display current network and ip address for newer Huwei modems. It
 is tested for Huawei E3276 (usb-id 12d1:1506) aka Telekom Speed
 Stick LTE III
 
-When using anything but NetworkManger (like wvdial, netctl), you
-never get to know which kind of Network (LTE/4G, UMTS/3G, EDGE, ...)
-your modem is using at a given point in time. This module querys
-the modem using AT commands and displays its response.
-
-You can optionally give a network interface name to display the IP
-address your mobile service provider has assigned you.
-
-If you know AT command-/answer pairs for other modems and would like
-to see them in this module, feel free to edit the code or contact me.
-
-IMPORTANT/PREREQUISITES:
-    1. Many USB modems (including the one tested) do not register as a
-    modem but as a storage device. If this applies to your modem, too,
-    consider using the usb_modeswith tool which is part of many Linux
-    distributions
-
-    2. This module needs read/write access to your modem communication
-    device file. If your modem is /dev/ttyUSB{n}, then it is
-    usually /dev/ttyUSB{n+1}. So in the vast majority of cases it is
-    /dev/ttyUSB1, which is the default setting.
-
-
-DEPENDENCIES:
-    pyserial (mandatory)
-    netifaces (for IP address display)
-
 Configuration parameters:
     - cache_timeout : how often we refresh this module in seconds
     - prefix        : Default is "WWAN: ".
@@ -52,39 +25,6 @@ Configuration parameters:
                       second steps
     - baudrate      : Default is 115200. There should be no need
                       to configure this, but feel free to experiment
-
-
-i3status.conf example configs:
-
-Default:
-
-    wwan_status {
-        cache_timeout = 5
-        prefix = "WWAN: "
-        modem1 = "/dev/ttyUSB1"
-        baudrate = 115200
-        modem_timeout = 0.2
-        show_ip = True
-        noipstring = "no ip"
-        interface = "ppp0"
-    }
-
-which is equvivalent to
-
-    wwan_status {
-    }
-
-or simply
-
-    wwan_status
-
-An alternative configuration with longer modem respond time but
-without IP address display:
-
-    wwan_status {
-        modem_timeout = 0.3
-        show_ip = False
-    }
 
 @author Timo Kohorst timo@kohorst-online.com
 PGP: B383 6AE6 6B46 5C45 E594 96AB 89D2 209D DBF3 2BB5

--- a/py3status/modules/wwan_status.py
+++ b/py3status/modules/wwan_status.py
@@ -119,7 +119,7 @@ class Py3status:
                 print(line)
                 if line.startswith(target_line):
                     # Determine IP once the modem responds
-                    ip = self.get_ip(self.interface)
+                    ip = self._get_ip(self.interface)
                     if not ip:
                         ip = "no ip"
                     modem_answer = line.split(',')
@@ -153,7 +153,7 @@ class Py3status:
             response['full_text'] = self.format_down
         return response
 
-    def get_ip(self, interface):
+    def _get_ip(self, interface):
         """
         Returns the interface's IPv4 address if device exists and has a valid
         ip address. Otherwise, returns an empty string

--- a/py3status/modules/wwan_status.py
+++ b/py3status/modules/wwan_status.py
@@ -4,6 +4,10 @@ Display current network and ip address for newer Huwei modems. It
 is tested for Huawei E3276 (usb-id 12d1:1506) aka Telekom Speed
 Stick LTE III
 
+DEPENDENCIES:
+    - netifaces
+    - pyserial
+
 Configuration parameters:
     - cache_timeout : How often we refresh this module in seconds.
                       Default is 5.

--- a/py3status/modules/wwan_status.py
+++ b/py3status/modules/wwan_status.py
@@ -118,7 +118,9 @@ class Py3status:
                     else:
                         response['color'] = i3s_config['color_degraded']
                     response[
-                        'full_text'] = self.prefix + "(" + netmode + ") " + ip_addr
+                        'full_text'] = self.prefix + "(" + netmode + ")"
+                    if self.show_ip:
+                        response['full_text'] += " " + ip_addr
                     return response
                 elif line.startswith("COMMAND NOT SUPPORT") or line.startswith(
                         "ERROR"):


### PR DESCRIPTION
Hello,

here's my first pull request. I hope you consider it useful because as of now only Huawei modems which understand the AT command I am using are supported. I tried to extend it to the Ericsson F3507g modem, but I could not verify that the AT commands I found actually return what I expect.

When reviewing, please keep an eye on the following things:
 * I am new to Python. If I violated any conventions, just point it out and I'll fix it.
 * I moved the main part of the documentation to the README.md file. Is this what it should be like?