### PR TITLE
Add dual battery support to battery_level

### DIFF
--- a/py3status/modules/README.md
+++ b/py3status/modules/README.md
@@ -29,9 +29,9 @@ Available modules:
   battery_level          Display the battery level.
                          
                          Configuration parameters:
-                             - battery_id : id of the battery to be displayed which
-                               can be found from acpi (e.g. "Battery 0: ..." where 0 is the id).
-                               Default is 0.
+                             - battery_id : id of the battery to be displayed
+                               set to 'all' for combined display of all batteries
+                               default is 0
                              - blocks : a string, where each character represents battery level
                                especially useful when using icon fonts (e.g. FontAwesome)
                                default is "_▁▂▃▄▅▆▇█"

--- a/py3status/modules/README.md
+++ b/py3status/modules/README.md
@@ -29,6 +29,9 @@ Available modules:
   battery_level          Display the battery level.
                          
                          Configuration parameters:
+                             - battery_id : id of the battery to be displayed which
+                               can be found from acpi (e.g. "Battery 0: ..." where 0 is the id).
+                               Default is 0.
                              - blocks : a string, where each character represents battery level
                                especially useful when using icon fonts (e.g. FontAwesome)
                                default is "_▁▂▃▄▅▆▇█"

--- a/py3status/modules/battery_level.py
+++ b/py3status/modules/battery_level.py
@@ -3,6 +3,9 @@
 Display the battery level.
 
 Configuration parameters:
+    - battery_id : id of the battery to be displayed
+      set to 'all' for combined display of all batteries
+      default is 0
     - blocks : a string, where each character represents battery level
       especially useful when using icon fonts (e.g. FontAwesome)
       default is "_▁▂▃▄▅▆▇█"

--- a/py3status/modules/battery_level.py
+++ b/py3status/modules/battery_level.py
@@ -195,7 +195,7 @@ class Py3status:
         elif self.battery_id == "all":
             total_capacity = sum([battery['capacity'] for battery in battery_list])
 
-            # Average and weigh % charged by the capacities of the batteries so that the value
+            # Average and weigh % charged by the capacities of the batteries so that self.percent_charged
             # properly represents batteries that have different capacities.
             self.percent_charged = int(sum([battery["capacity"]/total_capacity * battery["percent_charged"]
                                             for battery in battery_list]))
@@ -214,13 +214,12 @@ class Py3status:
             # Therefore, ACPI does not provide a time remaining value for the other battery.
             # So the time remaining for the other battery is calculated using the time
             # remaining of the first battery and the capacity values for both batteries.
-            if active_battery and inactive_battery:  # handles systems with one battery
+            if active_battery and inactive_battery:
                 inactive_battery = inactive_battery[0]
-                time_remaining_seconds = self._hms_to_seconds(active_battery["time_remaining"])
 
+                time_remaining_seconds = self._hms_to_seconds(active_battery["time_remaining"])
                 rate_second_per_mah = time_remaining_seconds / (active_battery["capacity"] *
                                                                (active_battery["percent_charged"]/100))
-
                 time_remaining_seconds += inactive_battery["capacity"] * (inactive_battery["percent_charged"]/100) * \
                                           rate_second_per_mah
 

--- a/py3status/modules/battery_level.py
+++ b/py3status/modules/battery_level.py
@@ -131,6 +131,35 @@ class Py3status:
         # Backwards compatibility for '{}' option in format string
         self.format = self.format.replace('{}', '{percent}')
 
+    def _extract_battery_information_from_acpi(self, acpi_battery_lines):
+        """
+        Extract the percent charged, charging state, time remaining,
+        and capacity for a battery, given a list of two strings from acpi
+        """
+        battery = dict()
+        battery["percent_charged"] = int(findall("(?<= )(\d+)(?=%)", acpi_battery_lines[0])[0])
+        battery["charging"] = "Charging" in acpi_battery_lines[0]
+        battery["capacity"] = int(findall("(?<= )(\d+)(?= mAh)", acpi_battery_lines[1])[1])
+
+        # ACPI only shows time remaining if battery is discharging or charging
+        try:
+            battery["time_remaining"] = ''.join(findall("(?<=, )(\d+:\d+:\d+)(?= remaining)|"
+                                                        "(?<=, )(\d+:\d+:\d+)(?= until)",
+                                                        acpi_battery_lines[0])[0])
+        except IndexError:
+            battery["time_remaining"] = None
+
+        return battery
+
+    def _hms_to_seconds(self, t):
+        h, m, s = [int(i) for i in t.split(':')]
+        return 3600*h + 60*m + s
+
+    def _seconds_to_hms(self, secs):
+        m, s = divmod(secs, 60)
+        h, m = divmod(m, 60)
+        return "%d:%02d:%02d" % (h, m, s)
+
     def _refresh_battery_info(self):
         # Example acpi -bi raw output:
         #      "Battery 0: Discharging, 94%, 09:23:28 remaining
@@ -149,18 +178,56 @@ class Py3status:
 
         # Separate the output because each pair of lines corresponds to a single battery.
         # Now the list index will correspond to the index of the battery we want to look at
-        acpi_list = [acpi_list[i:i+2] for i in range(0,len(acpi_list)-1,2)]
+        acpi_list = [acpi_list[i:i+2] for i in range(0, len(acpi_list)-1, 2)]
 
-        battery = acpi_list[self.battery_id]
-        self.percent_charged = int(findall("(?<= )(\d+)(?=%)", battery[0])[0])
-        self.charging = "Charging" in battery[0]
+        battery_list = [self._extract_battery_information_from_acpi(battery)
+                        for battery in acpi_list]
 
-        # ACPI only shows time remaining if battery is discharging or charging
-        try:
-            self.time_remaining = findall("(?<=, )(\d+:\d+:\d+)(?= remaining)", battery[0])[0]
-        except IndexError:
-            self.time_remaining = None
+        if type(self.battery_id) == int:
+            battery = battery_list[self.battery_id]
+            self.percent_charged = battery['percent_charged']
+            self.charging = battery['charging']
+            self.time_remaining = battery['time_remaining']
 
+        elif self.battery_id == "all":
+            total_capacity = sum([battery['capacity'] for battery in battery_list])
+
+            # Average and weigh % charged by the capacities of the batteries so that the value
+            # properly represents batteries that have different capacities.
+            self.percent_charged = int(sum([battery["capacity"]/total_capacity * battery["percent_charged"]
+                                            for battery in battery_list]))
+
+            self.charging = any([battery["charging"] for battery in battery_list])
+
+            # Assumes a system has at max two batteries
+            active_battery = None
+            inactive_battery = battery_list[:]
+            for battery_id in range(0, len(battery_list)):
+                if battery_list[battery_id]["time_remaining"]:
+                    active_battery = battery_list[battery_id]
+                    del inactive_battery[battery_id]
+
+            # Only one battery will be discharging or charging at a time.
+            # Therefore, ACPI does not provide a time remaining value for the other battery.
+            # So the time remaining for the other battery is calculated using the time
+            # remaining of the first battery and the capacity values for both batteries.
+            if active_battery and inactive_battery:  # handles systems with one battery
+                inactive_battery = inactive_battery[0]
+                time_remaining_seconds = self._hms_to_seconds(active_battery["time_remaining"])
+
+                rate_second_per_mah = time_remaining_seconds / (active_battery["capacity"] *
+                                                               (active_battery["percent_charged"]/100))
+
+                time_remaining_seconds += inactive_battery["capacity"] * (inactive_battery["percent_charged"]/100) * \
+                                          rate_second_per_mah
+
+                self.time_remaining = self._seconds_to_hms(time_remaining_seconds)
+
+            elif active_battery:
+                self.time_remaining = active_battery["time_remaining"]
+
+            else:
+                self.time_remaining = None
 
     def _update_ascii_bar(self):
         self.ascii_bar = FULL_BLOCK * int(self.percent_charged / 10)

--- a/py3status/modules/battery_level.py
+++ b/py3status/modules/battery_level.py
@@ -155,6 +155,13 @@ class Py3status:
         self.percent_charged = int(findall("(?<= )(\d+)(?=%)", battery[0])[0])
         self.charging = "Charging" in battery[0]
 
+        # ACPI only shows time remaining if battery is discharging or charging
+        try:
+            self.time_remaining = findall("(?<=, )(\d+:\d+:\d+)(?= remaining)", battery[0])[0]
+        except IndexError:
+            self.time_remaining = None
+
+
     def _update_ascii_bar(self):
         self.ascii_bar = FULL_BLOCK * int(self.percent_charged / 10)
         if self.charging:


### PR DESCRIPTION
I've added dual battery support to the battery_level module.
The batteries can now either be displayed individually and selected through the battery_id parameter or combined into a single display (so % charge represents all batteries).

The on_click function didn't seem to work because self.time_remaining wasn't provided anywhere, so I wrote some code to extract time remaining from the acpi output.

This is my first code pull request and any suggestions on how to improve or simplify the code are super welcome.

Cheers.
