### PR TITLE
battery_level: custom format for on_click notification

### DIFF
--- a/py3status/modules/battery_level.py
+++ b/py3status/modules/battery_level.py
@@ -28,10 +28,10 @@ Configuration parameters:
       default is None
     - format : string that formats the output. See placeholders below.
       default is "{icon}"
-    - format_notif_plugged : format of the notification received when you click
+    - format_notify_charging : format of the notification received when you click
       on the module while your computer is plugged
       default is "In charge ({percent}%)"
-    - format_notif_discharging : format of the notification received when you
+    - format_notify_discharging : format of the notification received when you
       click on the module while your comupter is not plugged
       default is "{time_remaining}"
     - hide_when_full : hide any information when battery is fully charged
@@ -98,8 +98,8 @@ class Py3status:
     color_degraded = None
     color_good = None
     format = FORMAT
-    format_notif_plugged = FORMAT_NOTIF_PLUGGED
-    format_notif_discharging = FORMAT_NOTIF_DISCHARGING
+    format_notify_charging = FORMAT_NOTIF_PLUGGED
+    format_notify_discharging = FORMAT_NOTIF_DISCHARGING
     hide_when_full = False
     notification = False
     notify_low_level = False
@@ -128,9 +128,9 @@ class Py3status:
             return
 
         if self.time_remaining:
-            format = self.format_notif_discharging
+            format = self.format_notify_discharging
         else:
-            format = self.format_notif_plugged
+            format = self.format_notify_charging
 
         message = format.format(ascii_bar=self.ascii_bar, icon=self.icon,
                                 time_remaining=self.time_remaining,
@@ -290,8 +290,8 @@ class Py3status:
     def _update_full_text(self):
         self.full_text = self.format.format(ascii_bar=self.ascii_bar,
                                             icon=self.icon,
-                                            time_remaining=self.time_remaining,
-                                            percent=self.percent_charged)
+                                            percent=self.percent_charged,
+                                            time_remaining=self.time_remaining)
 
     def _build_response(self):
         self.response = {}

--- a/py3status/modules/battery_level.py
+++ b/py3status/modules/battery_level.py
@@ -81,8 +81,8 @@ EMPTY_BLOCK_CHARGING = '|'
 EMPTY_BLOCK_DISCHARGING = '⍀'
 FULL_BLOCK = '█'
 FORMAT = "{icon}"
-FORMAT_NOTIFY_DISCHARGING = "{time_remaining}"
 FORMAT_NOTIFY_CHARGING = "Charging ({percent}%)"
+FORMAT_NOTIFY_DISCHARGING = "{time_remaining}"
 
 
 class Py3status:
@@ -133,8 +133,8 @@ class Py3status:
             format = self.format_notify_charging
 
         message = format.format(ascii_bar=self.ascii_bar, icon=self.icon,
-                                time_remaining=self.time_remaining,
-                                percent=self.percent_charged)
+                                percent=self.percent_charged,
+                                time_remaining=self.time_remaining)
 
         if message:
             self._desktop_notification(message)

--- a/py3status/modules/battery_level.py
+++ b/py3status/modules/battery_level.py
@@ -30,7 +30,7 @@ Configuration parameters:
       default is "{icon}"
     - format_notify_charging : format of the notification received when you click
       on the module while your computer is plugged
-      default is "In charge ({percent}%)"
+      default is "Charging ({percent}%)"
     - format_notify_discharging : format of the notification received when you
       click on the module while your comupter is not plugged
       default is "{time_remaining}"
@@ -81,8 +81,8 @@ EMPTY_BLOCK_CHARGING = '|'
 EMPTY_BLOCK_DISCHARGING = '⍀'
 FULL_BLOCK = '█'
 FORMAT = "{icon}"
-FORMAT_NOTIF_DISCHARGING = "{time_remaining}"
-FORMAT_NOTIF_PLUGGED = "In charge ({percent}%)"
+FORMAT_NOTIFY_DISCHARGING = "{time_remaining}"
+FORMAT_NOTIFY_CHARGING = "Charging ({percent}%)"
 
 
 class Py3status:
@@ -98,8 +98,8 @@ class Py3status:
     color_degraded = None
     color_good = None
     format = FORMAT
-    format_notify_charging = FORMAT_NOTIF_PLUGGED
-    format_notify_discharging = FORMAT_NOTIF_DISCHARGING
+    format_notify_charging = FORMAT_NOTIFY_CHARGING
+    format_notify_discharging = FORMAT_NOTIFY_DISCHARGING
     hide_when_full = False
     notification = False
     notify_low_level = False

--- a/py3status/modules/battery_level.py
+++ b/py3status/modules/battery_level.py
@@ -41,6 +41,7 @@ Format of status string placeholders:
     {icon} - a character representing the battery level,
              as defined by the 'blocks' and 'charging_character' parameters
     {percent} - the remaining battery percentage (previously '{}')
+    {time_remaining} - the remaining time until the battery is empty
 
 Obsolete configuration parameters:
     - mode : an old way to define 'format' parameter. The current behavior is:
@@ -261,6 +262,7 @@ class Py3status:
     def _update_full_text(self):
         self.full_text = self.format.format(ascii_bar=self.ascii_bar,
                                             icon=self.icon,
+                                            time_remaining=self.time_remaining,
                                             percent=self.percent_charged)
 
     def _build_response(self):


### PR DESCRIPTION
Hi,

I've implemented a custom format for the on_click notification of battery_level. You can also have different notifications when the computer is plugged or not.

I introduced a new placeholder, time_remaining, who was necessary to keep the same default notification as before.

I hope you like it !