### PR TITLE
Workaround, removed PlaybackStatus query

### DIFF
--- a/py3status/modules/spotify.py
+++ b/py3status/modules/spotify.py
@@ -59,13 +59,7 @@ class Py3status:
             microtime = metadata.get('mpris:length')
             rtime = str(timedelta(microseconds=microtime))
             title = metadata.get('xesam:title')
-
-            playback_status = self.player.Get('org.mpris.MediaPlayer2.Player',
-                                              'PlaybackStatus')
-            if playback_status.strip() == 'Playing':
-                color = self.color_playing or i3s_config['color_good']
-            else:
-                color = self.color_paused or i3s_config['color_degraded']
+            color = self.color_playing or i3s_config['color_good']
 
             return (
                 self.format.format(title=title,


### PR DESCRIPTION
A bug in the spotify linux client makes dbus run into a timout while
retrieving the PlaybackStatus. Song information are updated immediately.