### PR TITLE
Universal module options

### DIFF
--- a/py3status/module.py
+++ b/py3status/module.py
@@ -106,6 +106,20 @@ class Module(Thread):
         if 'min_width' in mod_config:
             self.module_options['min_width'] = mod_config['min_width']
 
+        if 'separator' in mod_config:
+            separator = mod_config['separator']
+            if not isinstance(separator, bool):
+                raise TypeError("invalid 'separator' attribute, should be a bool")
+
+            self.module_options['separator'] = separator
+
+        if 'separator_block_width' in mod_config:
+            separator_block_width = mod_config['separator_block_width']
+            if not isinstance(separator_block_width, int):
+                raise TypeError("invalid 'separator_block_width' attribute, should be an int")
+
+            self.module_options['separator_block_width'] = separator_block_width
+
         if 'align' in mod_config:
             align = mod_config['align']
             if not (isinstance(align, str) and align.lower() in ("left", "center", "right")):

--- a/py3status/module.py
+++ b/py3status/module.py
@@ -43,6 +43,7 @@ class Module(Thread):
         # if the module is part of a group then we want to store it's name
         self.group = self.i3status_thread.config.get(module, {}).get('.group')
         #
+        self.set_module_options(module)
         self.load_methods(module, user_modules)
 
     @staticmethod
@@ -93,6 +94,24 @@ class Module(Thread):
         for method in self.methods.values():
             output.append(method['last_output'])
         return output
+
+    def set_module_options(self, module):
+        """
+        Set universal module options to be interpreted by i3bar
+        https://i3wm.org/i3status/manpage.html#_universal_module_options
+        """
+        self.module_options = {}
+        mod_config = self.i3status_thread.config.get(module, {})
+
+        if 'min_width' in mod_config:
+            self.module_options['min_width'] = mod_config['min_width']
+
+        if 'align' in mod_config:
+            align = mod_config['align']
+            if not (isinstance(align, str) and align.lower() in ("left", "center", "right")):
+                raise ValueError("invalid 'align' attribute, valid values are: left, center, right")
+
+            self.module_options['align'] = align
 
     def load_methods(self, module, user_modules):
         """
@@ -233,6 +252,9 @@ class Module(Thread):
                     else:
                         result['instance'] = self.module_inst
                         result['name'] = self.module_name
+
+                    # set universal module options in result
+                    result.update(self.module_options)
 
                     # initialize method object
                     if my_method['name'] is None:

--- a/py3status/modules/bluetooth.py
+++ b/py3status/modules/bluetooth.py
@@ -7,6 +7,8 @@ Confiuration parameters:
     format_no_conn: format when there is no connected device
     format_no_conn_prefix: prefix when there is no connected device
     format_prefix: prefix when there is a connected device
+    device_separator: the separator char between devices (only if more than one
+    device)
 
 Format of status string placeholders
   - `{name}`  device name
@@ -39,7 +41,7 @@ class Py3status:
     format_no_conn = 'OFF'
     format_no_conn_prefix = 'BT: '
     format_prefix = 'BT: '
-    separator = '|'
+    device_separator = '|'
 
     def bluetooth(self, i3s_output_list, i3s_config):
         """
@@ -62,7 +64,7 @@ class Py3status:
 
             output = '{format_prefix}{data}'.format(
                 format_prefix=self.format_prefix,
-                data=self.separator.join(data)
+                data=self.device_separator.join(data)
             )
 
             color = self.color_good or i3s_config['color_good']

--- a/py3status/modules/nvidia_temp.py
+++ b/py3status/modules/nvidia_temp.py
@@ -8,7 +8,8 @@ Configuration parameters:
     color_good: the color used if everything is OK.
     format_prefix: a prefix for the output.
     format_units: the temperature units. Will appear at the end.
-    separator: the separator char between temperatures (only if more than one GPU)
+    temp_separator: the separator char between temperatures (only if more than
+    one GPU)
 
 Requires:
     nvidia-smi:
@@ -34,7 +35,7 @@ class Py3status:
     color_good = None
     format_prefix = "GPU: "
     format_units = "°C"
-    separator = '|'
+    temp_separator = '|'
 
     def nvidia_temp(self, i3s_output_list, i3s_config):
         # The whole command:
@@ -54,7 +55,7 @@ class Py3status:
 
             output = "{format_prefix}{data}".format(
                 format_prefix=self.format_prefix,
-                data=self.separator.join(data)
+                data=self.temp_separator.join(data)
             )
 
             color = self.color_good or i3s_config['color_good']

--- a/py3status/modules/static_string.py
+++ b/py3status/modules/static_string.py
@@ -5,7 +5,6 @@ Display static text.
 Configuration parameters:
     color: color of printed text
     format: text that should be printed
-    separator: whether the separator is shown or not (true or false)
 
 @author frimdo ztracenastopa@centrum.cz
 """
@@ -19,14 +18,12 @@ class Py3status:
     # available configuration parameters
     color = None
     format = ''
-    separator = True
 
     def static_string(self, i3s_output_list, i3s_config):
         response = {
             'cached_until': time() + 60,
             'color': self.color,
             'full_text': self.format,
-            'separator': self.separator
         }
         return response
 

--- a/py3status/modules/window_title_async.py
+++ b/py3status/modules/window_title_async.py
@@ -110,7 +110,7 @@ class Py3status:
             'full_text': self.title,
         }
 
-        for option in ('min_width', 'align', 'separator'):
+        for option in ('separator'):
             try:
                 resp[option] = getattr(self, option)
             except AttributeError:

--- a/py3status/modules/window_title_async.py
+++ b/py3status/modules/window_title_async.py
@@ -110,12 +110,6 @@ class Py3status:
             'full_text': self.title,
         }
 
-        for option in ('separator'):
-            try:
-                resp[option] = getattr(self, option)
-            except AttributeError:
-                continue
-
         return resp
 
 


### PR DESCRIPTION
Introduce universal module options like [i3status](https://i3wm.org/i3status/manpage.html#_universal_module_options), which can be used in each module block. Some user modules already implemented this functionality themselves, but i think it is preferable to handle this once for all modules.

The first commits adds the two options ```min_width``` and ```align```, like with i3status. The second commit additionally adds ```separator``` and ```separator_block_width```, which are defined in the [i3bar protocol](https://i3wm.org/docs/i3bar-protocol.html#_blocks_in_detail).

I have updated the user modules accordingly, but two modules (bluetooth and nvidia-temp) already made use of the ```separator``` property for another purpose. So I renamed these two properties, which might break backwards compatibility. What do you think?