### PR TITLE
Added module to display WiFi status using iw.

### DIFF
--- a/py3status/modules/README.md
+++ b/py3status/modules/README.md
@@ -754,6 +754,30 @@ Available modules:
                          Inspired by i3 FAQ:
                              https://faq.i3wm.org/question/1618/add-user-name-to-status-bar/
                          ---
+  wifi                   Display WiFi quality or signal, and bitrate using iw.
+                         
+                         Configuration parameters:
+                             - cache_timeout : Update interval in seconds (default: 5)
+                             - device : Wireless device name (default: "wlan0")
+                             - label : Left-sided label (default: "W: ")
+                             - down_text : Output when disconnected (default: "down")
+                             - down_color : Output color when disconnected, possible values:
+                               "good", "degraded", "bad" (default: "bad")
+                             - signal_dbm : If true, displays signal in dBm instead of quality in
+                               percent (default: false)
+                             - signal_bad : Bad signal strength in dBm, or percent if signal_quality is
+                               true (default: -85)
+                             - signal_degraded : Degraded signal strength in dBm, or percent if
+                               signal_quality is true (default: -75)
+                             - rate_bad : Bad bitrate in Mbit/s (default: 26)
+                             - rate_degraded : Degraded bitrate in Mbit/s (default: 53)
+                         
+                         Requires:
+                             - iw
+                         
+                         @author Markus Weimar <mail@markusweimar.de>
+                         @license BSD
+                         ---
   window_title           Display the current window title.
                          
                          Requires:

--- a/py3status/modules/README.md
+++ b/py3status/modules/README.md
@@ -770,7 +770,9 @@ Available modules:
                                (default: true)
                              - signal_bad : Bad signal strength in percent (default: 29)
                              - signal_degraded : Degraded signal strength in percent (default: 49)
-                             - use_sudo : Use sudo to run iw, make sure it requires no password
+                             - use_sudo : Use sudo to run iw, make sure iw requires no password by
+                               adding a sudoers entry like
+                               "<username> ALL=(ALL) NOPASSWD: /usr/bin/iw dev wl* link"
                                (default: false)
                          
                          Format of status string placeholders:

--- a/py3status/modules/README.md
+++ b/py3status/modules/README.md
@@ -754,24 +754,31 @@ Available modules:
                          Inspired by i3 FAQ:
                              https://faq.i3wm.org/question/1618/add-user-name-to-status-bar/
                          ---
-  wifi                   Display WiFi quality or signal, and bitrate using iw.
+  wifi                   Display WiFi bit rate, quality, signal and SSID using iw.
                          
                          Configuration parameters:
                              - cache_timeout : Update interval in seconds (default: 5)
                              - device : Wireless device name (default: "wlan0")
-                             - label : Left-sided label (default: "W: ")
-                             - down_text : Output when disconnected (default: "down")
                              - down_color : Output color when disconnected, possible values:
                                "good", "degraded", "bad" (default: "bad")
-                             - signal_dbm : If true, displays signal in dBm instead of quality in
                                percent (default: false)
-                             - signal_bad : Bad signal strength in dBm, or percent if signal_quality is
-                               true (default: -85)
-                             - signal_degraded : Degraded signal strength in dBm, or percent if
-                               signal_quality is true (default: -75)
-                             - rate_bad : Bad bitrate in Mbit/s (default: 26)
-                             - rate_degraded : Degraded bitrate in Mbit/s (default: 53)
+                             - signal_bad : Bad signal strength in percent (default: 29)
+                             - signal_degraded : Degraded signal strength in percent
+                               (default: 49)
+                             - bitrate_bad : Bad bit rate in Mbit/s (default: 26)
+                             - bitrate_degraded : Degraded bit rate in Mbit/s (default: 53)
+                             - round_bitrate : If true, bitrate is rounded to the nearest whole number
+                               (default: true)
+                             - format_up : See placeholders below (default:
+                               "W: {bitrate} {signal_percent} {ssid}").
+                             - format_down : Output when disconnected (default: "down")
                          
+                         Format of status string placeholders:
+                             {bitrate} - Display bit rate
+                             {signal_percent} - Display signal in percent
+                             {signal_dbm} - Display signal in dBm
+                             {ssid} - Display SSID
+
                          Requires:
                              - iw
                          

--- a/py3status/modules/README.md
+++ b/py3status/modules/README.md
@@ -757,28 +757,26 @@ Available modules:
   wifi                   Display WiFi bit rate, quality, signal and SSID using iw.
                          
                          Configuration parameters:
+                             - bitrate_bad : Bad bit rate in Mbit/s (default: 26)
+                             - bitrate_degraded : Degraded bit rate in Mbit/s (default: 53)
                              - cache_timeout : Update interval in seconds (default: 5)
                              - device : Wireless device name (default: "wlan0")
                              - down_color : Output color when disconnected, possible values:
                                "good", "degraded", "bad" (default: "bad")
-                               percent (default: false)
-                             - signal_bad : Bad signal strength in percent (default: 29)
-                             - signal_degraded : Degraded signal strength in percent
-                               (default: 49)
-                             - bitrate_bad : Bad bit rate in Mbit/s (default: 26)
-                             - bitrate_degraded : Degraded bit rate in Mbit/s (default: 53)
+                             - format_down : Output when disconnected (default: "down")
+                             - format_up : See placeholders below
+                               (default: "W: {bitrate} {signal_percent} {ssid}")
                              - round_bitrate : If true, bitrate is rounded to the nearest whole number
                                (default: true)
-                             - format_up : See placeholders below (default:
-                               "W: {bitrate} {signal_percent} {ssid}").
-                             - format_down : Output when disconnected (default: "down")
+                             - signal_bad : Bad signal strength in percent (default: 29)
+                             - signal_degraded : Degraded signal strength in percent (default: 49)
                          
                          Format of status string placeholders:
                              {bitrate} - Display bit rate
-                             {signal_percent} - Display signal in percent
                              {signal_dbm} - Display signal in dBm
+                             {signal_percent} - Display signal in percent
                              {ssid} - Display SSID
-
+                         
                          Requires:
                              - iw
                          

--- a/py3status/modules/README.md
+++ b/py3status/modules/README.md
@@ -759,7 +759,7 @@ Available modules:
                          Configuration parameters:
                              - bitrate_bad : Bad bit rate in Mbit/s (default: 26)
                              - bitrate_degraded : Degraded bit rate in Mbit/s (default: 53)
-                             - cache_timeout : Update interval in seconds (default: 5)
+                             - cache_timeout : Update interval in seconds (default: 10)
                              - device : Wireless device name (default: "wlan0")
                              - down_color : Output color when disconnected, possible values:
                                "good", "degraded", "bad" (default: "bad")

--- a/py3status/modules/README.md
+++ b/py3status/modules/README.md
@@ -770,6 +770,8 @@ Available modules:
                                (default: true)
                              - signal_bad : Bad signal strength in percent (default: 29)
                              - signal_degraded : Degraded signal strength in percent (default: 49)
+                             - use_sudo : Use sudo to run iw, make sure it requires no password
+                               (default: false)
                          
                          Format of status string placeholders:
                              {bitrate} - Display bit rate

--- a/py3status/modules/README.md
+++ b/py3status/modules/README.md
@@ -766,7 +766,7 @@ Available modules:
                              - format_down : Output when disconnected (default: "down")
                              - format_up : See placeholders below
                                (default: "W: {bitrate} {signal_percent} {ssid}")
-                             - round_bitrate : If true, bitrate is rounded to the nearest whole number
+                             - round_bitrate : If true, bit rate is rounded to the nearest whole number
                                (default: true)
                              - signal_bad : Bad signal strength in percent (default: 29)
                              - signal_degraded : Degraded signal strength in percent (default: 49)

--- a/py3status/modules/wifi.py
+++ b/py3status/modules/wifi.py
@@ -44,8 +44,8 @@ class Py3status:
     cache_timeout = 5
     device = 'wlan0'
     down_color = 'bad'
-    signal_percent_bad = 29
-    signal_percent_degraded = 49
+    signal_bad = 29
+    signal_degraded = 49
     bitrate_bad = 26
     bitrate_degraded = 53
     round_bitrate = True
@@ -56,9 +56,8 @@ class Py3status:
         """
         Get WiFi status using iw.
         """
-        self.signal_dbm_bad = self._percent_to_dbm(self.signal_percent_bad)
-        self.signal_dbm_degraded = \
-            self._percent_to_dbm(self.signal_percent_degraded)
+        self.signal_dbm_bad = self._percent_to_dbm(self.signal_bad)
+        self.signal_dbm_degraded = self._percent_to_dbm(self.signal_degraded)
 
         iw = subprocess.check_output(['iw', self.device, 'link']).decode(
             'utf-8')

--- a/py3status/modules/wifi.py
+++ b/py3status/modules/wifi.py
@@ -5,7 +5,7 @@ Display WiFi bit rate, quality, signal and SSID using iw.
 Configuration parameters:
     - bitrate_bad : Bad bit rate in Mbit/s (default: 26)
     - bitrate_degraded : Degraded bit rate in Mbit/s (default: 53)
-    - cache_timeout : Update interval in seconds (default: 5)
+    - cache_timeout : Update interval in seconds (default: 10)
     - device : Wireless device name (default: "wlan0")
     - down_color : Output color when disconnected, possible values:
       "good", "degraded", "bad" (default: "bad")
@@ -41,7 +41,7 @@ class Py3status:
     # available configuration parameters
     bitrate_bad = 26
     bitrate_degraded = 53
-    cache_timeout = 5
+    cache_timeout = 10
     device = 'wlan0'
     down_color = 'bad'
     format_down = 'W: down'

--- a/py3status/modules/wifi.py
+++ b/py3status/modules/wifi.py
@@ -3,26 +3,24 @@
 Display WiFi bit rate, quality, signal and SSID using iw.
 
 Configuration parameters:
+    - bitrate_bad : Bad bit rate in Mbit/s (default: 26)
+    - bitrate_degraded : Degraded bit rate in Mbit/s (default: 53)
     - cache_timeout : Update interval in seconds (default: 5)
     - device : Wireless device name (default: "wlan0")
     - down_color : Output color when disconnected, possible values:
       "good", "degraded", "bad" (default: "bad")
-      percent (default: false)
-    - signal_bad : Bad signal strength in percent (default: 29)
-    - signal_degraded : Degraded signal strength in percent
-      (default: 49)
-    - bitrate_bad : Bad bit rate in Mbit/s (default: 26)
-    - bitrate_degraded : Degraded bit rate in Mbit/s (default: 53)
+    - format_down : Output when disconnected (default: "down")
+    - format_up : See placeholders below
+      (default: "W: {bitrate} {signal_percent} {ssid}")
     - round_bitrate : If true, bitrate is rounded to the nearest whole number
       (default: true)
-    - format_up : See placeholders below (default:
-      "W: {bitrate} {signal_percent} {ssid}").
-    - format_down : Output when disconnected (default: "down")
+    - signal_bad : Bad signal strength in percent (default: 29)
+    - signal_degraded : Degraded signal strength in percent (default: 49)
 
 Format of status string placeholders:
     {bitrate} - Display bit rate
-    {signal_percent} - Display signal in percent
     {signal_dbm} - Display signal in dBm
+    {signal_percent} - Display signal in percent
     {ssid} - Display SSID
 
 Requires:
@@ -41,16 +39,16 @@ class Py3status:
     """
     """
     # available configuration parameters
+    bitrate_bad = 26
+    bitrate_degraded = 53
     cache_timeout = 5
     device = 'wlan0'
     down_color = 'bad'
+    format_down = 'W: down'
+    format_up = 'W: {bitrate} {signal_percent} {ssid}'
+    round_bitrate = True
     signal_bad = 29
     signal_degraded = 49
-    bitrate_bad = 26
-    bitrate_degraded = 53
-    round_bitrate = True
-    format_up = 'W: {bitrate} {signal_percent} {ssid}'
-    format_down = 'W: down'
 
     def get_wifi(self, i3s_output_list, i3s_config):
         """

--- a/py3status/modules/wifi.py
+++ b/py3status/modules/wifi.py
@@ -60,7 +60,7 @@ class Py3status:
         self.signal_dbm_bad = self._percent_to_dbm(self.signal_bad)
         self.signal_dbm_degraded = self._percent_to_dbm(self.signal_degraded)
 
-        cmd = ['iw', self.device, 'link']
+        cmd = ['iw', 'dev', self.device, 'link']
         if self.use_sudo:
             cmd.insert(0, 'sudo')
         iw = subprocess.check_output(cmd).decode('utf-8')

--- a/py3status/modules/wifi.py
+++ b/py3status/modules/wifi.py
@@ -16,6 +16,8 @@ Configuration parameters:
       (default: true)
     - signal_bad : Bad signal strength in percent (default: 29)
     - signal_degraded : Degraded signal strength in percent (default: 49)
+    - use_sudo : Use sudo to run iw, make sure it requires no password
+      (default: false)
 
 Format of status string placeholders:
     {bitrate} - Display bit rate
@@ -49,6 +51,7 @@ class Py3status:
     round_bitrate = True
     signal_bad = 29
     signal_degraded = 49
+    use_sudo = False
 
     def get_wifi(self, i3s_output_list, i3s_config):
         """
@@ -57,8 +60,10 @@ class Py3status:
         self.signal_dbm_bad = self._percent_to_dbm(self.signal_bad)
         self.signal_dbm_degraded = self._percent_to_dbm(self.signal_degraded)
 
-        iw = subprocess.check_output(['iw', self.device, 'link']).decode(
-            'utf-8')
+        cmd = ['iw', self.device, 'link']
+        if self.use_sudo:
+            cmd.insert(0, 'sudo')
+        iw = subprocess.check_output(cmd).decode('utf-8')
 
         bitrate_out = re.search('tx bitrate: ([^\s]+) ([^\s]+)', iw)
         if bitrate_out:

--- a/py3status/modules/wifi.py
+++ b/py3status/modules/wifi.py
@@ -12,7 +12,7 @@ Configuration parameters:
     - format_down : Output when disconnected (default: "down")
     - format_up : See placeholders below
       (default: "W: {bitrate} {signal_percent} {ssid}")
-    - round_bitrate : If true, bitrate is rounded to the nearest whole number
+    - round_bitrate : If true, bit rate is rounded to the nearest whole number
       (default: true)
     - signal_bad : Bad signal strength in percent (default: 29)
     - signal_degraded : Degraded signal strength in percent (default: 49)

--- a/py3status/modules/wifi.py
+++ b/py3status/modules/wifi.py
@@ -16,7 +16,9 @@ Configuration parameters:
       (default: true)
     - signal_bad : Bad signal strength in percent (default: 29)
     - signal_degraded : Degraded signal strength in percent (default: 49)
-    - use_sudo : Use sudo to run iw, make sure it requires no password
+    - use_sudo : Use sudo to run iw, make sure iw requires no password by
+      adding a sudoers entry like
+      "<username> ALL=(ALL) NOPASSWD: /usr/bin/iw dev wl* link"
       (default: false)
 
 Format of status string placeholders:

--- a/py3status/modules/wifi.py
+++ b/py3status/modules/wifi.py
@@ -77,7 +77,7 @@ class Py3status:
         signal_out = re.search('signal: ([\-0-9]+)', iw)
         if signal_out:
             signal_dbm = int(signal_out.group(1))
-            signal_percent = self._dbm_to_percent(signal_dbm)
+            signal_percent = min(self._dbm_to_percent(signal_dbm), 100)
         else:
             signal_dbm = None
             signal_percent = None

--- a/py3status/modules/wifi.py
+++ b/py3status/modules/wifi.py
@@ -95,18 +95,33 @@ class Py3status:
             full_text = self.format_down
             color = i3s_config['color_{}'.format(self.down_color)]
         else:
-            if bitrate <= self.bitrate_bad or \
-                    signal_dbm <= self.signal_dbm_bad:
+            bad = False
+            degraded = False
+            if bitrate:
+                if bitrate <= self.bitrate_bad:
+                    bad = True
+                elif bitrate <= self.bitrate_degraded:
+                    degraded = True
+                bitrate = '{} {}'.format(bitrate, bitrate_unit)
+            else:
+                bitrate = '? MBit/s'
+            if signal_dbm:
+                if signal_dbm <= self.signal_dbm_bad:
+                    bad = True
+                elif signal_dbm <= self.signal_dbm_degraded:
+                    degraded = True
+                signal_dbm = '{} dBm'.format(signal_dbm)
+                signal_percent = '{}%'.format(signal_percent)
+            else:
+                signal_dbm = '? dBm'
+                signal_percent = '?%'
+
+            if bad:
                 color = i3s_config['color_bad']
-            elif bitrate <= self.bitrate_degraded or \
-                    signal_dbm <= self.signal_dbm_degraded:
+            elif degraded:
                 color = i3s_config['color_degraded']
             else:
                 color = i3s_config['color_good']
-
-            bitrate = '{} {}'.format(bitrate, bitrate_unit)
-            signal_percent = '{}%'.format(signal_percent)
-            signal_dbm = '{} dBm'.format(signal_dbm)
 
             full_text = self.format_up.format(bitrate=bitrate,
                                               signal_percent=signal_percent,

--- a/py3status/modules/wifi.py
+++ b/py3status/modules/wifi.py
@@ -1,0 +1,107 @@
+# -*- coding: utf-8 -*-
+"""
+Display WiFi quality or signal, and bitrate using iw.
+
+Configuration parameters:
+    - cache_timeout : Update interval in seconds (default: 5)
+    - device : Wireless device name (default: "wlan0")
+    - label : Left-sided label (default: "W: ")
+    - down_text : Output when disconnected (default: "down")
+    - down_color : Output color when disconnected, possible values:
+      "good", "degraded", "bad" (default: "bad")
+    - signal_dbm : If true, displays signal in dBm instead of quality in
+      percent (default: false)
+    - signal_bad : Bad signal strength in dBm, or percent if signal_quality is
+      true (default: -85)
+    - signal_degraded : Degraded signal strength in dBm, or percent if
+      signal_quality is true (default: -75)
+    - rate_bad : Bad bitrate in Mbit/s (default: 26)
+    - rate_degraded : Degraded bitrate in Mbit/s (default: 53)
+
+Requires:
+    - iw
+
+@author Markus Weimar <mail@markusweimar.de>
+@license BSD
+"""
+
+import re
+import subprocess
+from time import time
+
+
+class Py3status:
+    """
+    """
+    # available configuration parameters
+    cache_timeout = 5
+    device = 'wlan0'
+    label = 'W: '
+    down_text = 'down'
+    down_color = 'bad'
+    signal_dbm = False
+    signal_bad = -85
+    signal_degraded = -75
+    rate_bad = 26
+    rate_degraded = 53
+
+    def get_wifi(self, i3s_output_list, i3s_config):
+        """
+        Get signal and bitrate using iw.
+        """
+        wifi = subprocess.check_output(['iw', self.device, 'link']).decode(
+            'utf-8')
+
+        rate_out = re.search('tx bitrate: ([0-9\.]+)', wifi)
+        if rate_out:
+            rate_num = round(float(rate_out.group(1)))
+        else:
+            rate_num = None
+
+        signal_out = re.search('signal: ([\-0-9]+)', wifi)
+        if signal_out:
+            signal_num = int(signal_out.group(1))
+        else:
+            signal_num = None
+
+        if any(num is None for num in [rate_num, signal_num]):
+            full_text = self.label + self.down_text
+            color = i3s_config['color_{}'.format(self.down_color)]
+        else:
+            if rate_num <= self.rate_bad or signal_num <= self.signal_bad:
+                color = i3s_config['color_bad']
+            elif rate_num <= self.rate_degraded or \
+                    signal_num <= self.signal_degraded:
+                color = i3s_config['color_degraded']
+            else:
+                color = i3s_config['color_good']
+            if self.signal_dbm is True:
+                signal_unit = ' dBm'
+            else:
+                signal_unit = '%'
+                signal_num = 2 * (signal_num + 100)
+            full_text = self.label + str(rate_num) + ' MBit/s' + ' ' + \
+                str(signal_num) + signal_unit
+
+        response = {
+            'cached_until': time() + self.cache_timeout,
+            'full_text': full_text,
+            'color': color
+        }
+        return response
+
+if __name__ == "__main__":
+    """
+    Test this module by calling it directly.
+    This SHOULD work before contributing your module please.
+    """
+    from time import sleep
+    x = Py3status()
+    config = {
+        'color_bad': '#FF0000',
+        'color_degraded': '#FFFF00',
+        'color_good': '#00FF00'
+    }
+    while True:
+        print(x.get_wifi([], config))
+        sleep(1)

--- a/py3status/modules/wifi.py
+++ b/py3status/modules/wifi.py
@@ -124,8 +124,8 @@ class Py3status:
                 color = i3s_config['color_good']
 
             full_text = self.format_up.format(bitrate=bitrate,
-                                              signal_percent=signal_percent,
                                               signal_dbm=signal_dbm,
+                                              signal_percent=signal_percent,
                                               ssid=ssid)
 
         response = {
@@ -135,11 +135,11 @@ class Py3status:
         }
         return response
 
-    def _percent_to_dbm(self, percent):
-        return (percent / 2) - 100
-
     def _dbm_to_percent(self, dbm):
         return 2 * (dbm + 100)
+
+    def _percent_to_dbm(self, percent):
+        return (percent / 2) - 100
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The reason for this module is that it works for some cards (at least `iwlwifi`) that do not work with the default wireless status in i3status. In addition, this module is more configurable.

i3status issue: https://github.com/i3/i3status/issues/106