### PR TITLE
fixed color & playbackstatus check

### DIFF
--- a/py3status/modules/spotify.py
+++ b/py3status/modules/spotify.py
@@ -74,7 +74,7 @@ class Py3status:
             except Exception:
                 return (
                     self.format_stopped,
-                    self.color_paused or i3s_config['color_paused'])
+                    self.color_paused or i3s_config['color_degraded'])
 
             return (
                 self.format.format(title=title,

--- a/py3status/modules/spotify.py
+++ b/py3status/modules/spotify.py
@@ -50,7 +50,7 @@ class Py3status:
     def _get_text(self, i3s_config):
         """
         Get the current song metadatas (artist - title)
-        
+
         there is a known bug for dbus property PlaybackStatus:
           https://community.spotify.com/t5/Help-Desktop-Linux-Windows-Web/DBus-MPRIS-interface-bug/td-p/1262889
           retested on : 2016-02-22


### PR DESCRIPTION
- disabled PlaybackStatus code as it cannot be read using dbus (see
  https://community.spotify.com/t5/Help-Desktop-Linux-Windows-Web/DBus-MPRIS-interface-bug/td-p/1262889
  )
- implemented (ugly) workaround code for stopped state
- code for paused state is still missing as there is no property
  to track the current play status of a song
  according to my tests only Metadata can be requested using dbus all 
  other properties result in time-out
- fixed return of normal state
  variable color does not exist
  replaced it with self.color_playing and using color_good as fallback
