### PR TITLE
Arch status module

### DIFF
--- a/py3status/modules/arch_updates.py
+++ b/py3status/modules/arch_updates.py
@@ -1,0 +1,75 @@
+# -*- coding: utf-8 -*-
+
+"""
+Displays the number of package updates pending for an Arch Linux installation.
+
+This will display a count of how many 'pacman' updates are waiting
+to be installed and optionally a count of how many 'aur' updates are
+also waiting.
+
+To display pending 'aur' updates you need to have installed 'cower'.
+
+Configuration parameters:
+    - cache_timeout : how often we refresh this module in seconds (default 600)
+    - include_aur : set to 0 to use 'cower' to check for AUR updates (default 0)
+
+@author Iain Tatch <iain.tatch@gmail.com>
+@license BSD
+"""
+
+from time import time
+import sh
+
+
+class Py3status:
+    # available configuration parameters
+    cache_timeout = 600
+    include_aur = 0
+
+
+    def check_updates(self, i3s_output_list, i3s_config):
+        pacman_updates = self._check_pacman_updates()
+        if self.include_aur:
+            aur_updates = self._check_aur_updates()
+            results = "{0}/{1}".format(pacman_updates, aur_updates)
+        else:
+            results = str(pacman_updates)
+
+        response = {
+            'cached_until': time() + self.cache_timeout,
+            'full_text': 'UPD: ' + results
+        }
+        return response
+
+    def _check_pacman_updates(self):
+        """
+        This method will use the 'checkupdates' command line utility
+        to determine how many updates are waiting to be installed via
+        'pacman -Syu'.
+        """
+        pending_updates = sh.checkupdates()
+        return len(pending_updates)
+
+    def _check_aur_updates(self):
+        """
+        This method will use the 'cower' command line utility
+        to determine how many updates are waiting to be installed
+        from the AUR.
+        """
+        pending_updates = sh.cower('-u')
+        return len(pending_updates)
+
+if __name__ == "__main__":
+    """
+    Test this module by calling it directly.
+    """
+    from time import sleep
+    x = Py3status()
+    config = {
+        'color_bad': '#FF0000',
+        'color_degraded': '#FFFF00',
+        'color_good': '#00FF00'
+    }
+    while True:
+        print(x.check_updates([], config))
+        sleep(1)

--- a/py3status/modules/arch_updates.py
+++ b/py3status/modules/arch_updates.py
@@ -18,7 +18,8 @@ Configuration parameters:
 """
 
 from time import time
-import subprocess, sys
+import subprocess
+import sys
 
 
 class Py3status:
@@ -27,7 +28,6 @@ class Py3status:
     include_aur = 0
 
     _line_separator = "\\n" if sys.version_info > (3, 0) else "\n"
-
 
     def check_updates(self, i3s_output_list, i3s_config):
         pacman_updates = self._check_pacman_updates()

--- a/py3status/modules/arch_updates.py
+++ b/py3status/modules/arch_updates.py
@@ -18,13 +18,15 @@ Configuration parameters:
 """
 
 from time import time
-import subprocess
+import subprocess, sys
 
 
 class Py3status:
     # available configuration parameters
     cache_timeout = 600
     include_aur = 0
+
+    _line_separator = "\\n" if sys.version_info > (3, 0) else "\n"
 
 
     def check_updates(self, i3s_output_list, i3s_config):
@@ -48,7 +50,7 @@ class Py3status:
         'pacman -Syu'.
         """
         pending_updates = str(subprocess.check_output(["checkupdates"]))
-        return pending_updates.count("\\n")
+        return pending_updates.count(self._line_separator)
 
     def _check_aur_updates(self):
         """
@@ -67,7 +69,7 @@ class Py3status:
         except:
             pending_updates = '?'
 
-        return str(pending_updates).count("\\n")
+        return str(pending_updates).count(self._line_separator)
 
 if __name__ == "__main__":
     """

--- a/py3status/modules/arch_updates.py
+++ b/py3status/modules/arch_updates.py
@@ -12,6 +12,11 @@ To display pending 'aur' updates you need to have installed 'cower'.
 Configuration parameters:
     - cache_timeout : how often we refresh this module in seconds (default 600)
     - include_aur : set to 0 to use 'cower' to check for AUR updates (default 0)
+    - format : display format to use
+
+Format status string parameters:
+    - aur : number of pending aur updates
+    - pacman : number of pending pacman updates
 
 @author Iain Tatch <iain.tatch@gmail.com>
 @license BSD
@@ -26,20 +31,29 @@ class Py3status:
     # available configuration parameters
     cache_timeout = 600
     include_aur = 0
+    format = ''
 
+    _format_pacman_only = 'UPD: {pacman}'
+    _format_pacman_and_aur = 'UPD: {pacman}/{aur}'
     _line_separator = "\\n" if sys.version_info > (3, 0) else "\n"
+
+    if format == '':
+        if include_aur == 0:
+            format = _format_pacman_only
+        else:
+            format = _format_pacman_and_aur
 
     def check_updates(self, i3s_output_list, i3s_config):
         pacman_updates = self._check_pacman_updates()
         if self.include_aur:
             aur_updates = self._check_aur_updates()
-            results = "{0}/{1}".format(pacman_updates, aur_updates)
+            results = self.format.format(pacman=pacman_updates, aur=aur_updates)
         else:
-            results = str(pacman_updates)
+            results = self.format.format(pacman=str(pacman_updates))
 
         response = {
             'cached_until': time() + self.cache_timeout,
-            'full_text': 'UPD: ' + results
+            'full_text': results
         }
         return response
 


### PR DESCRIPTION
Adds a module which displays the number of pending updates waiting to be applied/installed on an Arch Linux installation.  As Arch is a rolling-update distribution there are frequently many updates released over any 24-hour period so it's convenient for Arch i3-users (and there are many of them!) to have an easy way to see if they should be downloading and installing updates.