### PR TITLE
Doc: update Arch Linux AUR packaging infos

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -88,10 +88,14 @@ Using emerge:
 
 Arch Linux
 ----------
-Thanks to @Horgix, py3status is present in the Arch User Repository using this URL:
-::
+Thanks to @Horgix, py3status is present in the Arch User Repository:
 
-    https://aur.archlinux.org/packages/py3status-git/
+- `py3status <https://aur.archlinux.org/packages/py3status>`_, which is a
+  stable version updated at each release
+- `py3status-git <https://aur.archlinux.org/packages/py3status-git/>`_, which
+  builds directly against the upstream master branch
+
+Thanks to @waaaaargh and @carstene1ns for initially creating the packages.
 
 Fedora
 ------


### PR DESCRIPTION
- README.rst: mention py3status and py3status-git packages

Only one package on the 2 was mentionned, and there wasn't any mention of initial packagers for Arch Linux AUR. rst format is a pain btw :(