### PR TITLE
Battery time remaining '' when unknown

### DIFF
--- a/py3status/modules/battery_level.py
+++ b/py3status/modules/battery_level.py
@@ -186,7 +186,7 @@ class Py3status:
             if self.hide_seconds:
                 battery["time_remaining"] = battery["time_remaining"][:-3]
         except IndexError:
-            battery["time_remaining"] = None
+            battery["time_remaining"] = ''
 
         return battery
 

--- a/py3status/modules/battery_level.py
+++ b/py3status/modules/battery_level.py
@@ -186,7 +186,7 @@ class Py3status:
             if self.hide_seconds:
                 battery["time_remaining"] = battery["time_remaining"][:-3]
         except IndexError:
-            battery["time_remaining"] = ''
+            battery["time_remaining"] = '?'
 
         return battery
 


### PR DESCRIPTION
```
acpi -b -i
Battery 0: Unknown, 99%
```
if `format = "bat: {time_remaining}"` 
with master we see `bat: None`
this changes it to show `bat: ` which feels better to me.