### PR TITLE
Added a fix for incomplete acpi output

### DIFF
--- a/py3status/modules/battery_level.py
+++ b/py3status/modules/battery_level.py
@@ -3,68 +3,68 @@
 Display the battery level.
 
 Configuration parameters:
-    - battery_id : id of the battery to be displayed
-      set to 'all' for combined display of all batteries
-      default is 0
-    - blocks : a string, where each character represents battery level
-      especially useful when using icon fonts (e.g. FontAwesome)
-      default is "_▁▂▃▄▅▆▇█"
-    - cache_timeout : a timeout to refresh the battery state
-      default is 30
-    - charging_character : a character to represent charging battery
-      especially useful when using icon fonts (e.g. FontAwesome)
-      default is "⚡"
-    - color_bad : a color to use when the battery level is bad
-      None means get it from i3status config
-      default is None
-    - color_charging : a color to use when the battery is charging
-      None means get it from i3status config
-      default is "#FCE94F"
-    - color_degraded : a color to use when the battery level is degraded
-      None means get it from i3status config
-      default is None
-    - color_good : a color to use when the battery level is good
-      None means get it from i3status config
-      default is None
-    - format : string that formats the output. See placeholders below.
-      default is "{icon}"
-    - format_notify_charging : format of the notification received when you
-      click on the module while your computer is plugged
-      default is "Charging ({percent}%)"
-    - format_notify_discharging : format of the notification received when you
-      click on the module while your comupter is not plugged
-      default is "{time_remaining}"
-    - hide_when_full : hide any information when battery is fully charged
-      default is False
-    - hide_seconds : hide seconds in remaining time
-      default is False
-    - notification : show current battery state as notification on click
-      default is False
-    - notify_low_level : display notification when battery is running low.
-      default is False
+    battery_id: id of the battery to be displayed
+        set to 'all' for combined display of all batteries
+        default is 0
+    blocks: a string, where each character represents battery level
+        especially useful when using icon fonts (e.g. FontAwesome)
+        default is "_▁▂▃▄▅▆▇█"
+    cache_timeout: a timeout to refresh the battery state
+        default is 30
+    charging_character: a character to represent charging battery
+        especially useful when using icon fonts (e.g. FontAwesome)
+        default is "⚡"
+    color_bad: a color to use when the battery level is bad
+        None means get it from i3status config
+        default is None
+    color_charging: a color to use when the battery is charging
+        None means get it from i3status config
+        default is "#FCE94F"
+    color_degraded: a color to use when the battery level is degraded
+        None means get it from i3status config
+        default is None
+    color_good: a color to use when the battery level is good
+        None means get it from i3status config
+        default is None
+    format: string that formats the output. See placeholders below.
+        default is "{icon}"
+    format_notify_charging: format of the notification received when you click
+        on the module while your computer is plugged
+        default is "Charging ({percent}%)"
+    format_notify_discharging: format of the notification received when you
+        click on the module while your comupter is not plugged
+        default is "{time_remaining}"
+    hide_when_full: hide any information when battery is fully charged
+        default is False
+    hide_seconds: hide seconds in remaining time
+        default is False
+    notification: show current battery state as notification on click
+        default is False
+    notify_low_level: display notification when battery is running low.
+        default is False
 
 Format of status string placeholders:
     {ascii_bar} - a string of ascii characters representing the battery level,
-                  an alternative visualization to '{icon}' option
+        an alternative visualization to '{icon}' option
     {icon} - a character representing the battery level,
-             as defined by the 'blocks' and 'charging_character' parameters
+        as defined by the 'blocks' and 'charging_character' parameters
     {percent} - the remaining battery percentage (previously '{}')
     {time_remaining} - the remaining time until the battery is empty
 
 Obsolete configuration parameters:
-    - mode : an old way to define 'format' parameter. The current behavior is:
-      - if 'format' is specified, this parameter is completely ignored
-      - if the value is 'ascii_bar', the 'format' is set to "{ascii_bar}"
-      - if the value is 'text', the 'format' is set to "Battery: {percent}"
-      - all other values are ignored
-      - there is no default value for this parameter
-    - show_percent_with_blocks : an old way to define 'format' parameter:
-      - if 'format' is specified, this parameter is completely ignored
-      - if the value is True, the 'format' is set to "{icon} {percent}%"
-      - there is no default value for this parameter
+    mode: an old way to define `format` parameter. The current behavior is:
+        if 'format' is specified, this parameter is completely ignored
+        if the value is `ascii_bar`, the `format` is set to `"{ascii_bar}"`
+        if the value is `text`, the `format` is set to `"Battery: {percent}"`
+        all other values are ignored
+        there is no default value for this parameter
+    show_percent_with_blocks: an old way to define `format` parameter:
+        if `format` is specified, this parameter is completely ignored
+        if the value is True, the `format` is set to `"{icon} {percent}%"`
+        there is no default value for this parameter
 
 Requires:
-    - the 'acpi' command line
+    - the `acpi` command line
 
 @author shadowprince, AdamBSteele, maximbaz, 4iar
 @license Eclipse Public License
@@ -201,20 +201,20 @@ class Py3status:
 
     def _refresh_battery_info(self):
         # Example acpi -bi raw output:
-        # "Battery 0: Discharging, 94%, 09:23:28 remaining
-        #  Battery 0: design capacity 5703 mAh, last full capacity 5283 mAh = 92%
-        #  Battery 1: Unknown, 98%
-        #  Battery 1: design capacity 1880 mAh, last full capacity 1370 mAh = 72%"
+        #      "Battery 0: Discharging, 94%, 09:23:28 remaining
+        #       Battery 0: design capacity 5703 mAh, last full capacity 5283 mAh = 92%
+        #       Battery 1: Unknown, 98%
+        #       Battery 1: design capacity 1880 mAh, last full capacity 1370 mAh = 72%"
         acpi_raw = subprocess.check_output(
             ["acpi", "-b", "-i"],
             stderr=subprocess.STDOUT)
 
-        # Example list:
-        # ['Battery 0: Charging, 96%, 00:20:40 until charged',
-        #  'Battery 0: design capacity 5566 mAh, last full capacity 5156 mAh = 92%',
-        #  'Battery 1: Unknown, 98%',
-        #  'Battery 1: design capacity 1879 mAh, last full capacity 1370 mAh = 72%',
-        #  '']
+        #  Example list:
+        #       ['Battery 0: Charging, 96%, 00:20:40 until charged',
+        #       'Battery 0: design capacity 5566 mAh, last full capacity 5156 mAh = 92%',
+        #       'Battery 1: Unknown, 98%',
+        #       'Battery 1: design capacity 1879 mAh, last full capacity 1370 mAh = 72%',
+        #       '']
         acpi_list = acpi_raw.decode("UTF-8").split('\n')
 
         # check for faulty acpi output

--- a/py3status/modules/battery_level.py
+++ b/py3status/modules/battery_level.py
@@ -217,6 +217,17 @@ class Py3status:
         #       '']
         acpi_list = acpi_raw.decode("UTF-8").split('\n')
 
+        # check for faulty acpi output
+        for i, line in reversed(list(enumerate(acpi_list))):
+            if len(line)==0:
+                acpi_list.pop(i)
+        # if there is an uneven number of lines, someonething is wrong...        
+        # search for the battery with only one line and remove it.
+        if len(acpi_list)%2==1:
+            for i, line in reversed(list(enumerate(acpi_list[0:-1]))):
+                if acpi_list[i][0:10]!=acpi_list[i+1][0:10]:
+                    acpi_list.pop(i)
+        
         # Separate the output because each pair of lines corresponds to a single battery.
         # Now the list index will correspond to the index of the battery we want to look at
         acpi_list = [acpi_list[i:i + 2]

--- a/py3status/modules/battery_level.py
+++ b/py3status/modules/battery_level.py
@@ -28,8 +28,8 @@ Configuration parameters:
       default is None
     - format : string that formats the output. See placeholders below.
       default is "{icon}"
-    - format_notify_charging : format of the notification received when you click
-      on the module while your computer is plugged
+    - format_notify_charging : format of the notification received when you
+      click on the module while your computer is plugged
       default is "Charging ({percent}%)"
     - format_notify_discharging : format of the notification received when you
       click on the module while your comupter is not plugged
@@ -201,33 +201,33 @@ class Py3status:
 
     def _refresh_battery_info(self):
         # Example acpi -bi raw output:
-        #      "Battery 0: Discharging, 94%, 09:23:28 remaining
-        #       Battery 0: design capacity 5703 mAh, last full capacity 5283 mAh = 92%
-        #       Battery 1: Unknown, 98%
-        #       Battery 1: design capacity 1880 mAh, last full capacity 1370 mAh = 72%"
+        # "Battery 0: Discharging, 94%, 09:23:28 remaining
+        #  Battery 0: design capacity 5703 mAh, last full capacity 5283 mAh = 92%
+        #  Battery 1: Unknown, 98%
+        #  Battery 1: design capacity 1880 mAh, last full capacity 1370 mAh = 72%"
         acpi_raw = subprocess.check_output(
             ["acpi", "-b", "-i"],
             stderr=subprocess.STDOUT)
 
-        #  Example list:
-        #       ['Battery 0: Charging, 96%, 00:20:40 until charged',
-        #       'Battery 0: design capacity 5566 mAh, last full capacity 5156 mAh = 92%',
-        #       'Battery 1: Unknown, 98%',
-        #       'Battery 1: design capacity 1879 mAh, last full capacity 1370 mAh = 72%',
-        #       '']
+        # Example list:
+        # ['Battery 0: Charging, 96%, 00:20:40 until charged',
+        #  'Battery 0: design capacity 5566 mAh, last full capacity 5156 mAh = 92%',
+        #  'Battery 1: Unknown, 98%',
+        #  'Battery 1: design capacity 1879 mAh, last full capacity 1370 mAh = 72%',
+        #  '']
         acpi_list = acpi_raw.decode("UTF-8").split('\n')
 
         # check for faulty acpi output
         for i, line in reversed(list(enumerate(acpi_list))):
-            if len(line)==0:
+            if len(line) == 0:
                 acpi_list.pop(i)
-        # if there is an uneven number of lines, someonething is wrong...        
+        # if there is an uneven number of lines, someonething is wrong...
         # search for the battery with only one line and remove it.
-        if len(acpi_list)%2==1:
+        if len(acpi_list) % 2 == 1:
             for i, line in reversed(list(enumerate(acpi_list[0:-1]))):
-                if acpi_list[i][0:10]!=acpi_list[i+1][0:10]:
+                if acpi_list[i][0:10] != acpi_list[i+1][0:10]:
                     acpi_list.pop(i)
-        
+
         # Separate the output because each pair of lines corresponds to a single battery.
         # Now the list index will correspond to the index of the battery we want to look at
         acpi_list = [acpi_list[i:i + 2]


### PR DESCRIPTION
Sometimes "acpi -b -i" puts out uneven numbers of lines, for example:
Battery 0: Discharging, 0%, rate information unavailable
Battery 1: Full, 100%
Battery 1: design capacity 5600 mAh, last full capacity 4876 mAh = 87%

The proposed change implements a check that removes the first line.