### PR TITLE
Create xscreensaver.py

### DIFF
--- a/py3status/modules/xscreensaver.py
+++ b/py3status/modules/xscreensaver.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
 """
+Indicator for Xscreensaver, can be toggled by left clicking.
+
 This is a partial rewrite of dpms.py. Most credit
 goes to the original author Andre Doser. This module shows the status
 of Xscreensaver and activates or deactivates it upon left click.
@@ -11,18 +13,19 @@ Settings can be managed using "xscreensaver-demo".
 
 Configuration parameters:
     - format_off: string to display when Xscreensaver is disabled
-    - format_on: string to display when Xscreensaver is enabled
+    - format_on : string to display when Xscreensaver is enabled
 
 Example configuration in py3status.conf:
 
+```
 order += "xscreensaver"
 xscreensaver {
     format_off = "xscreensaver off"
     format_on = "xscreensaver on"
 }
+```
 
-@author Andre Doser <dosera AT tf.uni-freiburg.de> (dpms.py)
-@author neutronst4r <c7420{at}gmx{dot}net> (Xscreensaver rewrite)
+@author neutronst4r <c7420{at}gmx{dot}net>
 """
 from os import setpgrp
 from subprocess import call, Popen, DEVNULL
@@ -45,8 +48,8 @@ class Py3status:
                         stderr=DEVNULL, preexec_fn=setpgrp) == 0
         return {
             'full_text': self.format_on if self.run else self.format_off,
-            'color': self.color_on or i3s_config['color_good']
-            if self.run else self.color_off or i3s_config['color_bad']
+            'color': self.color_on or i3s_config['color_good'] if self.run
+                     else self.color_off or i3s_config['color_bad']
         }
 
     def on_click(self, i3s_output_list, i3s_config, event):

--- a/py3status/modules/xscreensaver.py
+++ b/py3status/modules/xscreensaver.py
@@ -44,12 +44,14 @@ class Py3status:
         """
         Display a colorful state of xscreensaver.
         """
-        self.run = call(["pidof", "xscreensaver"], stdout=DEVNULL,
-                        stderr=DEVNULL, preexec_fn=setpgrp) == 0
+        self.run = call(["pidof", "xscreensaver"],
+                        stdout=DEVNULL,
+                        stderr=DEVNULL,
+                        preexec_fn=setpgrp) == 0
         return {
             'full_text': self.format_on if self.run else self.format_off,
-            'color': self.color_on or i3s_config['color_good'] if self.run
-                     else self.color_off or i3s_config['color_bad']
+            'color': self.color_on or i3s_config['color_good']
+            if self.run else self.color_off or i3s_config['color_bad']
         }
 
     def on_click(self, i3s_output_list, i3s_config, event):
@@ -59,12 +61,18 @@ class Py3status:
         if event['button'] == 1:
             if self.run:
                 self.run = False
-                Popen(["killall", "xscreensaver"], stdout=DEVNULL,
-                      stderr=DEVNULL, preexec_fn=setpgrp)
+                Popen(["killall", "xscreensaver"],
+                      stdout=DEVNULL,
+                      stderr=DEVNULL,
+                      preexec_fn=setpgrp)
             else:
                 self.run = True
-                Popen(["xscreensaver", "-no-splash", "-no-capture-stderr"],
-                      stdout=DEVNULL, stderr=DEVNULL, preexec_fn=setpgrp)
+                Popen(
+                    ["xscreensaver", "-no-splash", "-no-capture-stderr"],
+                    stdout=DEVNULL,
+                    stderr=DEVNULL,
+                    preexec_fn=setpgrp)
+
 
 if __name__ == "__main__":
     """
@@ -72,10 +80,8 @@ if __name__ == "__main__":
     """
     from time import sleep
     x = Py3status()
-    config = {
-        'color_bad': '#FF0000',
-        'color_good': '#00FF00',
-    }
+    config = {'color_bad': '#FF0000', 'color_good': '#00FF00', }
     while True:
         print(x.xscreensaver([], config))
         sleep(1)
+

--- a/py3status/modules/xscreensaver.py
+++ b/py3status/modules/xscreensaver.py
@@ -17,8 +17,8 @@ Example configuration in py3status.conf:
 
 order += "xscreensaver"
 xscreensaver {
-	    format_off = "xscreensaver off"
-	    format_on = "xscreensaver on"
+    format_off = "xscreensaver off"
+    format_on = "xscreensaver on"
 }
 
 @author Andre Doser <dosera AT tf.uni-freiburg.de> (dpms.py)

--- a/py3status/modules/xscreensaver.py
+++ b/py3status/modules/xscreensaver.py
@@ -1,0 +1,78 @@
+# -*- coding: utf-8 -*-
+"""
+This is a partial rewrite of dpms.py. Most credit
+goes to the original author Andre Doser. This module shows the status
+of Xscreensaver and activates or deactivates it upon left click.
+
+This script is useful for people who let Xscreensaver manage dpms
+settings. Xscreensaver has its own dpms variables separate from xset.
+Dpms can be savely turned of in xset as long as xscreensaver is running.
+Settings can be managed using "xscreensaver-demo".
+
+Configuration parameters:
+    - format_off: string to display when Xscreensaver is disabled
+    - format_on: string to display when Xscreensaver is enabled
+
+Example configuration in py3status.conf:
+
+order += "xscreensaver"
+xscreensaver {
+	    format_off = "xscreensaver off"
+	    format_on = "xscreensaver on"
+}
+
+@author Andre Doser <dosera AT tf.uni-freiburg.de> (dpms.py)
+@author neutronst4r <c7420{at}gmx{dot}net> (Xscreensaver rewrite)
+"""
+from os import setpgrp
+from subprocess import call, Popen, DEVNULL
+
+
+class Py3status:
+    """
+    """
+    # available configuration parameters
+    format_off = "xscreensaver off"
+    format_on = "xscreensaver on"
+    color_on = None
+    color_off = None
+
+    def xscreensaver(self, i3s_output_list, i3s_config):
+        """
+        Display a colorful state of xscreensaver.
+        """
+        self.run = call(["pidof", "xscreensaver"], stdout=DEVNULL,
+                        stderr=DEVNULL, preexec_fn=setpgrp) == 0
+        return {
+            'full_text': self.format_on if self.run else self.format_off,
+            'color': self.color_on or i3s_config['color_good']
+            if self.run else self.color_off or i3s_config['color_bad']
+        }
+
+    def on_click(self, i3s_output_list, i3s_config, event):
+        """
+        Enable/Disable xscreensaver on left click.
+        """
+        if event['button'] == 1:
+            if self.run:
+                self.run = False
+                Popen(["killall", "xscreensaver"], stdout=DEVNULL,
+                      stderr=DEVNULL, preexec_fn=setpgrp)
+            else:
+                self.run = True
+                Popen(["xscreensaver", "-no-splash", "-no-capture-stderr"],
+                      stdout=DEVNULL, stderr=DEVNULL, preexec_fn=setpgrp)
+
+if __name__ == "__main__":
+    """
+    Test this module by calling it directly.
+    """
+    from time import sleep
+    x = Py3status()
+    config = {
+        'color_bad': '#FF0000',
+        'color_good': '#00FF00',
+    }
+    while True:
+        print(x.xscreensaver([], config))
+        sleep(1)

--- a/py3status/modules/xscreensaver.py
+++ b/py3status/modules/xscreensaver.py
@@ -84,4 +84,3 @@ if __name__ == "__main__":
     while True:
         print(x.xscreensaver([], config))
         sleep(1)
-


### PR DESCRIPTION
I have addapted the dpms.py module to work with xscreensaver instead. I changed a lot of the original system calls. It would have been very painful to add it as an option in dpms.py. I also switched from using the system package to subprocess, which is in my opinion superior. Calling xscreensaver without messing up the standard output in the py3status did not seem possible with "system". Using Popen and sending its output to DEVNULL, however, works nicely. Furthermore, the new xscreensaver needs to be forked by assigning it its own process group.