### PR TITLE
Only update modules when they need to be

### DIFF
--- a/py3status/core.py
+++ b/py3status/core.py
@@ -47,7 +47,7 @@ class Py3statusWrapper():
         config = {
             'cache_timeout': 60,
             'include_paths': ['{}/.i3/py3status/'.format(home_path)],
-            'interval': 1,  # no longer used but is an existing cli option
+            'interval': 1,
             'minimum_interval': 0.1  # minimum module update interval
         }
 

--- a/py3status/core.py
+++ b/py3status/core.py
@@ -47,7 +47,8 @@ class Py3statusWrapper():
         config = {
             'cache_timeout': 60,
             'include_paths': ['{}/.i3/py3status/'.format(home_path)],
-            'interval': 1
+            'interval': 1,  # no longer used but is an existing cli option
+            'minimum_interval': 0.1  # minimum module update interval
         }
 
         # package version
@@ -296,6 +297,9 @@ class Py3statusWrapper():
             self.lock.clear()
             if self.config['debug']:
                 syslog(LOG_INFO, 'lock cleared, exiting')
+            # run kill() method on all py3status modules
+            for module in self.modules.values():
+                module.kill()
             self.i3status_thread.cleanup_tmpfile()
         except:
             pass
@@ -369,16 +373,6 @@ class Py3statusWrapper():
                     self.events_thread.i3_nagbar = True
                     err = 'events thread died, click events are disabled'
                     self.i3_nagbar(err, level='warning')
-
-            # check that every module thread is alive
-            for module in self.modules.values():
-                if not module.is_alive():
-                    # don't spam the user with i3-nagbar warnings
-                    if not hasattr(module, 'i3_nagbar'):
-                        module.i3_nagbar = True
-                        msg = 'output frozen for dead module(s) {}'.format(
-                            ','.join(module.methods.keys()))
-                        self.i3_nagbar(msg, level='warning')
 
             # get output from i3status
             prefix = self.i3status_thread.last_prefix

--- a/py3status/events.py
+++ b/py3status/events.py
@@ -112,6 +112,8 @@ class Events(Thread):
                 syslog(LOG_INFO, 'refresh module {}'.format(module_name))
             for obj in module.methods.values():
                 obj['cached_until'] = time()
+            # get module to update
+            module.run()
         else:
             if time() > (self.last_refresh_ts + 0.1):
                 if self.config['debug']:

--- a/py3status/module.py
+++ b/py3status/module.py
@@ -233,9 +233,8 @@ class Module(Thread):
             # don't be hasty mate
             # set timer to do update next time one is needed
             if cache_time:
-                delay = cache_time - time()
-                if delay < self.config['minimum_interval']:
-                    delay = self.config['minimum_interval']
+                delay = max(cache_time - time(),
+                            self.config['minimum_interval'])
                 self.timer = Timer(delay, self.run)
                 self.timer.start()
 


### PR DESCRIPTION
**Issues addressed:**

1) I have a world clock user module.  With the current setup the time displayed is out of sync as it can take 1 second for the updated info to be used due to `sleep(self.config['interval'])`.

2) When clicking on a module it can take up to `config['interval']` for the result of the of the click to update eg `dpms`

3) Modules that have no update for long time periods eg `weather_yahoo` spend lots of time checking if they need to update when they don't need to (minor issue)

**This pull request allows these updates to be shown immediately**

I could change `config['interval']` but then my modules are working mainly doing nothing.


**changes:**

Instead of sleeping we use a timer to wake up and do the update when needed. Modules set their own timers. Triggering an update via a click event, cancels any pending timer and in turn will set a new one.

`config['interval']`  is no longer used.  I've left it for now as it is a cli option but I'd like to depreciate that if you are happy with the idea.

`config['minimum_interval']` has been added to stop module updates happening too frequently (not that I've seen this problem).  Currently this is set at 0.1 (seconds)

`Module.kill()` is now it's own function and is called on termination for all py3status modules.  It clears any timer and calls the modules `kill()`

Modules are no longer 'alive' as such so that test is removed from `Py3statusWrapper.run()`.

From the limited testing I've done py3status does not use any more cpu time than before, slightly less if anything.  Most time is still spent in `Py3statusWrapper.run()` from what I can see.

Non-scientific testing by running on cli and pressing ^C after ~10 seconds
```
git checkout master

time py3status -s -c ~/.i3/i3status.conf
real	0m9.694s
user	0m0.349s
sys	0m0.106s

git checkout deadline

time py3status -s -c ~/.i3/i3status.conf

real	0m10.555s
user	0m0.317s
sys	0m0.084s
```