### PR TITLE
thunderbird calendar tasks module

### DIFF
--- a/py3status/modules/keyboard_layout.py
+++ b/py3status/modules/keyboard_layout.py
@@ -87,10 +87,10 @@ class Py3status:
             return layouts[0]
         xset_output = check_output(["xset", "-q"]).decode("utf-8")
         led_mask = re.match(ledmask_re, xset_output).group(1)
-        if led_mask == "00000000":
-            return layouts[0]
-        elif led_mask == "00001000":
-            return layouts[1]
+        if len(led_mask) == 8:
+            lang = int(led_mask[4])
+            if layouts[lang] is not None:
+                return layouts[lang]
         return "Err"
 
 

--- a/py3status/modules/keyboard_layout.py
+++ b/py3status/modules/keyboard_layout.py
@@ -88,7 +88,7 @@ class Py3status:
         xset_output = check_output(["xset", "-q"]).decode("utf-8")
         led_mask = re.match(ledmask_re, xset_output).group(1)
         if len(led_mask) == 8:
-            lang = int(led_mask[4])
+            lang = int(led_mask[4], 16)
             if layouts[lang] is not None:
                 return layouts[lang]
         return "Err"

--- a/py3status/modules/keyboard_layout.py
+++ b/py3status/modules/keyboard_layout.py
@@ -89,7 +89,7 @@ class Py3status:
         led_mask = re.match(ledmask_re, xset_output).group(1)
         if len(led_mask) == 8:
             lang = int(led_mask[4], 16)
-            if layouts[lang] is not None:
+            if lang < len(layouts):
                 return layouts[lang]
         return "Err"
 

--- a/py3status/modules/thunderbird_calendar.py
+++ b/py3status/modules/thunderbird_calendar.py
@@ -1,0 +1,85 @@
+# -*- coding: utf-8 -*-
+"""
+Display tasks in thunderbird calendar.
+
+Configuration parameters:
+    - cache_timeout : how often we refresh usage in seconds (default: 120s)
+    - profile_path : path to the user thunderbird profile (not optional)
+    - format : see placeholders below
+
+Format of status string placeholders:
+    {due} : due tasks
+    {completed} : completed tasks
+    {current} : title of current running task (sorted by priority and stamp)
+
+Make sure to configure profile_path in your i3status config using the full
+path or this module will not be able to retrieve any information from your
+calendar.
+
+ex: profile_path = "/home/user/.thunderbird/1yawevtp.default"
+
+@author mrt-prodz
+"""
+from sqlite3 import connect
+from os import access, R_OK
+from time import time
+
+
+class Py3status:
+    # available configuration parameters
+    cache_timeout = 120
+    # user must configure the path to thunderbird profile_path
+    # ex: /home/user/.thunderbird/1yawevtp.default
+    profile_path = ''
+    format = 'tasks:[{due}] current:{current}'
+
+    # return error occurs
+    def _error_response(self, color):
+        response = {
+            'cached_until': time() + self.cache_timeout,
+            'full_text': 'Err',
+            'color': color
+        }
+        return response
+
+    # return calendar data
+    def get_calendar(self, i3s_output_list, i3s_config):
+        db = self.profile_path + '/calendar-data/local.sqlite'
+        due = completed = 0
+        current = ''
+        if not access(db, R_OK):
+            return self._error_response(i3s_config['color_bad'])
+
+        try:
+            con = connect(db)
+            cur = con.cursor()
+            cur.execute('SELECT title, todo_completed FROM cal_todos '
+                        'ORDER BY priority DESC, todo_stamp DESC')
+            tasks = cur.fetchall()
+            con.close()
+
+            # t = title, c = completed
+            duetasks = [t for t in tasks for c in t if c is None]
+            due = len(duetasks)
+            completed = len(tasks) - due
+            if due > 0 and type(duetasks[0] is tuple):
+                current = duetasks[0][0]
+
+            response = {
+                'cached_until': time() + self.cache_timeout,
+                'full_text': self.format.format(due=due,
+                                                completed=completed,
+                                                current=current)
+            }
+            return response
+        except:
+            return self._error_response(i3s_config['color_bad'])
+
+if __name__ == "__main__":
+    x = Py3status()
+    config = {
+        'color_good': '#00FF00',
+        'color_degraded': '#00FFFF',
+        'color_bad': '#FF0000'
+    }
+    print(x.get_calendar([], config))

--- a/py3status/modules/thunderbird_calendar.py
+++ b/py3status/modules/thunderbird_calendar.py
@@ -4,15 +4,15 @@ Display tasks in thunderbird calendar.
 
 Configuration parameters:
     cache_timeout: how often we refresh usage in seconds (default: 120s)
-    profile_path: path to the user thunderbird profile (not optional)
-    err_profile: error message regarding profile path and read access
     err_exception: error message when an exception is raised
+    err_profile: error message regarding profile path and read access
     format: see placeholders below
+    profile_path: path to the user thunderbird profile (not optional)
 
 Format of status string placeholders:
-    {due} due tasks
     {completed} completed tasks
     {current} title of current running task (sorted by priority and stamp)
+    {due} due tasks
 
 Make sure to configure profile_path in your i3status config using the full
 path or this module will not be able to retrieve any information from your
@@ -30,10 +30,10 @@ from time import time
 class Py3status:
     # available configuration parameters
     cache_timeout = 120
-    profile_path = ''
-    err_profile = 'error: profile not readable'
     err_exception = 'error: calendar parsing failed'
+    err_profile = 'error: profile not readable'
     format = 'tasks:[{due}] current:{current}'
+    profile_path = ''
 
     def _response(self, text, color=None):
         response = {

--- a/py3status/modules/thunderbird_calendar.py
+++ b/py3status/modules/thunderbird_calendar.py
@@ -42,13 +42,13 @@ class Py3status:
         }
         if color is not None:
             response['color'] = color
-        
+
         return response
 
     # return calendar data
     def get_calendar(self, i3s_output_list, i3s_config):
         _err_color = i3s_config['color_bad']
-        
+
         db = self.profile_path + '/calendar-data/local.sqlite'
         if not access(db, R_OK):
             return self._response(self.err_profile, _err_color)
@@ -67,7 +67,7 @@ class Py3status:
             due = len(duetasks)
             completed = len(tasks) - due
             current = duetasks[0] if due else ''
-            
+
             return self._response(self.format.format(due=due,
                                                      completed=completed,
                                                      current=current))


### PR DESCRIPTION
This module displays Thunderbird Calendar tasks:

>    {due} : due tasks
>    {completed} : completed tasks
>    {current} : title of current running task (sorted by priority and stamp)

Caution, in order to work user must set **profile_path** and enter the full path of his/her thunderbird profile folder in the i3satus config:

> ...
> order += "thunderbird_calendar"
> ...
> thunderbird_calendar {
>     profile_path = "/home/user/.thunderbird/1yawevtp.default"
>     format = "✔ {due} - {current}"
> }
> ...

Any input would be greatly appreciated.
