### PR TITLE
'Speedy' branch

### DIFF
--- a/py3status/core.py
+++ b/py3status/core.py
@@ -34,6 +34,7 @@ class Py3statusWrapper():
         self.last_refresh_ts = time()
         self.lock = Event()
         self.modules = {}
+        self.output_modules = {}
         self.py3_modules = []
         self.queue = deque()
 

--- a/py3status/core.py
+++ b/py3status/core.py
@@ -419,11 +419,13 @@ class Py3statusWrapper():
                                 time_module['date'] = date
                                 time_format = time_module.get('time_format')
 
-                                # set the full_text date on the json_list to be returned
+                                # set the full_text date on the json_list to be
+                                # returned
                                 output[index]['full_text'] = date.strftime(
                                     time_format)
-                                # reset the full_text date on the config object for next
-                                # iteration to be consistent with this one
+                                # reset the full_text date on the config object
+                                # for next iteration to be consistent with this
+                                # one
                                 time_module['response']['full_text'] = mod[
                                     'full_text']
                             updated = True

--- a/py3status/core.py
+++ b/py3status/core.py
@@ -5,7 +5,6 @@ import os
 import sys
 from datetime import datetime
 
-from copy import deepcopy
 from json import dumps
 from signal import signal
 from signal import SIGTERM, SIGUSR1
@@ -397,9 +396,11 @@ class Py3statusWrapper():
             for index, module_name in enumerate(config['order']):
                 if module_name in self.modules:
                     # py3status module update if needed
-                    if self.modules[module_name].check_updated(reset=True) or not output[index]:
+                    if self.modules[module_name].check_updated(
+                            reset=True) or not output[index]:
                         updated = True
-                        for method in self.modules[module_name].methods.values():
+                        for method in self.modules[module_name].methods.values(
+                        ):
                             output[index] = method['last_output']
                 else:
                     # i3status module
@@ -411,21 +412,25 @@ class Py3statusWrapper():
                             if not isinstance(time_module['date'], datetime):
                                 # something went wrong in the datetime parsing
                                 # output i3status' date string
-                                output[index]['full_text'] = time_module['date']
+                                output[index]['full_text'] = time_module[
+                                    'date']
                             else:
                                 date = datetime.utcnow() + time_module['delta']
                                 time_module['date'] = date
                                 time_format = time_module.get('time_format')
 
                                 # set the full_text date on the json_list to be returned
-                                output[index]['full_text'] = date.strftime(time_format)
+                                output[index]['full_text'] = date.strftime(
+                                    time_format)
                                 # reset the full_text date on the config object for next
                                 # iteration to be consistent with this one
-                                time_module['response']['full_text'] = mod['full_text']
+                                time_module['response']['full_text'] = mod[
+                                    'full_text']
                             updated = True
                             continue
 
-                    if i3status_updated and config.get(module_name, {}).get('response'):
+                    if i3status_updated and config.get(module_name,
+                                                       {}).get('response'):
                         output[index] = config[module_name]['response']
                         updated = True
 

--- a/py3status/core.py
+++ b/py3status/core.py
@@ -359,7 +359,6 @@ class Py3statusWrapper():
         signal(SIGTERM, self.terminate)
 
         # initialize usage variables
-        self.last_sec = 0
         i3status_thread = self.i3status_thread
         config = i3status_thread.config
 
@@ -412,7 +411,7 @@ class Py3statusWrapper():
                         err = 'events thread died, click events are disabled'
                         self.i3_nagbar(err, level='warning')
 
-                # update and i3status time/tztime items
+                # update i3status time/tztime items
                 if interval == 0 or sec % interval == 0:
                     i3status_thread.update_times()
 

--- a/py3status/core.py
+++ b/py3status/core.py
@@ -438,8 +438,10 @@ class Py3statusWrapper():
                     module_name = self.queue.popleft()
                     module = self.output_modules[module_name]
                     for index in module['position']:
-                        # store the outupt as json
-                        output[index] = dumps(module['module'].get_latest())
+                        # store the output as json
+                        # modules can have more than one output
+                        out = module['module'].get_latest()
+                        output[index] = ', '.join([dumps(x) for x in out])
 
                 prefix = i3status_thread.last_prefix
                 # build output string

--- a/py3status/core.py
+++ b/py3status/core.py
@@ -354,16 +354,16 @@ class Py3statusWrapper():
 
         # initialize usage variables
         last_sec = 0
+        interval = self.config['interval']
 
         config = self.i3status_thread.config
-
         output = [None] * len(config['order'])
 
         # main loop
         while True:
             sec = int(time())
             # do we need to update time for i3status modules?
-            update_time = sec > last_sec or self.config['interval'] < 1
+            update_time = interval == 0 or sec % interval == 0
 
             # check every thing is good each second
             if sec > last_sec:

--- a/py3status/i3status.py
+++ b/py3status/i3status.py
@@ -33,7 +33,7 @@ class I3statusModule:
         self.time_date = None
 
     def get_latest(self):
-        return self.item
+        return [self.item]
 
     def update_from_item(self, item):
         """

--- a/py3status/i3status.py
+++ b/py3status/i3status.py
@@ -395,22 +395,32 @@ class I3status(Thread):
         self.json_list = deepcopy(self.last_output)
         self.json_list_ts = deepcopy(self.last_output_ts)
 
-    def get_modules_output(self, json_list, py3_modules):
+    def get_modules_output(self, json_list, py3_modules, output):
         """
         Return the final json list to be displayed on the i3bar by taking
         into account every py3status configured module and i3status'.
         Simply put, this method honors the initial 'order' configured by
         the user in his i3status.conf.
         """
-        ordered = []
-        for module_name in self.config['order']:
+        if len(self.config['order']) != len(output):
+            output = [None] * len(self.config['order'])
+        for index, module_name in enumerate(self.config['order']):
+       #     print_line(index)
             if module_name in py3_modules:
-                for method in py3_modules[module_name].methods.values():
-                    ordered.append(method['last_output'])
+                # kill any updated
+                if py3_modules[module_name].check_updated(reset=True) or not output[index]:
+                   # if module_name == 'weather_yahoo':
+                    #    print_line('## weather')
+                    for method in py3_modules[module_name].methods.values():
+                       # output.append(method['last_output'])
+                        output[index] = method['last_output']
+               # else:
+                #    print_line(module_name)
             else:
                 if self.config.get(module_name, {}).get('response'):
-                    ordered.append(self.config[module_name]['response'])
-        return ordered
+                    output[index] = self.config[module_name]['response']
+       # print_line(output)
+        return output
 
     @staticmethod
     def write_in_tmpfile(text, tmpfile):

--- a/py3status/i3status.py
+++ b/py3status/i3status.py
@@ -368,7 +368,6 @@ class I3status(Thread):
                     self.config[conf_name]['delta'] = delta
                     self.config[conf_name]['time_format'] = time_format
 
-
     def update_json_list(self):
         """
         Copy the last json list output from i3status so that any module
@@ -378,7 +377,6 @@ class I3status(Thread):
         """
         self.json_list = deepcopy(self.last_output)
         self.json_list_ts = deepcopy(self.last_output_ts)
-
 
     @staticmethod
     def write_in_tmpfile(text, tmpfile):

--- a/py3status/i3status.py
+++ b/py3status/i3status.py
@@ -24,12 +24,12 @@ class I3statusModule:
     `time` and `tztime`.
     """
 
-    def __init__(self, module_name, py3statusWrapper):
+    def __init__(self, module_name, py3_wrapper):
         self.module_name = module_name
-        self.i3status = py3statusWrapper.i3status_thread
+        self.i3status = py3_wrapper.i3status_thread
         self.is_time_module = module_name.split()[0] in ['time', 'tztime']
         self.item = {}
-        self.py3statusWrapper = py3statusWrapper
+        self.py3_wrapper = py3_wrapper
         self.time_date = None
 
     def get_latest(self):
@@ -58,7 +58,7 @@ class I3statusModule:
             # set the full_text date on the json_list to be
             # returned
             self.item['full_text'] = date.strftime(self.time_format)
-        self.py3statusWrapper.notify_update(self.module_name)
+        self.py3_wrapper.notify_update(self.module_name)
 
     def get_delta_from_format(self, i3s_time, time_format):
         """
@@ -171,7 +171,7 @@ class I3status(Thread):
     This class is responsible for spawning i3status and reading its output.
     """
 
-    def __init__(self, py3statusWrapper):
+    def __init__(self, py3_wrapper):
         """
         Our output will be read asynchronously from 'last_output'.
         """
@@ -188,15 +188,15 @@ class I3status(Thread):
         self.last_output = None
         self.last_output_ts = None
         self.last_prefix = None
-        self.lock = py3statusWrapper.lock
+        self.lock = py3_wrapper.lock
         self.new_update = False
-        self.py3statusWrapper = py3statusWrapper
+        self.py3_wrapper = py3_wrapper
         self.ready = False
-        self.standalone = py3statusWrapper.config['standalone']
+        self.standalone = py3_wrapper.config['standalone']
         self.time_modules = []
         self.tmpfile_path = None
         #
-        config_path = py3statusWrapper.config['i3status_config_path']
+        config_path = py3_wrapper.config['i3status_config_path']
         self.config = self.i3status_config_reader(config_path)
 
     def update_times(self):
@@ -449,10 +449,10 @@ class I3status(Thread):
             conf_name = self.config['i3s_modules'][index]
             if conf_name not in self.i3modules:
                 self.i3modules[conf_name] = I3statusModule(
-                    conf_name, self.py3statusWrapper)
+                    conf_name, self.py3_wrapper)
             if self.i3modules[conf_name].update_from_item(item):
                 updates.append(conf_name)
-        self.py3statusWrapper.notify_update(updates)
+        self.py3_wrapper.notify_update(updates)
 
     def update_json_list(self):
         """

--- a/py3status/i3status.py
+++ b/py3status/i3status.py
@@ -9,11 +9,161 @@ from subprocess import Popen
 from subprocess import PIPE
 from syslog import syslog, LOG_ERR, LOG_INFO
 from tempfile import NamedTemporaryFile
-from threading import Thread, Lock
+from threading import Thread
+from time import time
 
 from py3status.profiling import profile
 from py3status.helpers import jsonify, print_line
 from py3status.events import IOPoller
+
+
+class I3statusModule:
+    """
+    This a wrapper for i3status items so that they mirror some of the methods
+    of the Module class.  It also helps encapsulate the auto time updating for
+    `time` and `tztime`.
+    """
+
+    def __init__(self, module_name, py3statusWrapper):
+        self.module_name = module_name
+        self.i3status = py3statusWrapper.i3status_thread
+        self.is_time_module = module_name.split()[0] in ['time', 'tztime']
+        self.item = {}
+        self.py3statusWrapper = py3statusWrapper
+        self.time_date = None
+
+    def get_latest(self):
+        return self.item
+
+    def update_from_item(self, item):
+        """
+        Update from i3status output. returns if item has changed.
+        """
+        is_updated = self.item != item
+        self.item = item
+        if self.is_time_module:
+            self.set_time_zone()
+        return is_updated
+
+    def update_time_value(self):
+        if not self.item:
+            return
+        if not isinstance(self.time_date, datetime):
+            # something went wrong in the datetime parsing
+            # output i3status' date string
+            self.item['full_text'] = self.time_date
+        else:
+            date = datetime.utcnow() + self.time_delta
+            self.time_date = date
+            # set the full_text date on the json_list to be
+            # returned
+            self.item['full_text'] = date.strftime(self.time_format)
+        self.py3statusWrapper.notify_update(self.module_name)
+
+    def get_delta_from_format(self, i3s_time, time_format):
+        """
+        Guess the time delta from %z time formats such as +0400.
+
+        When such a format is found, replace it in the string so we respect
+        i3status' output while being able to correctly adjust the time.
+        """
+        try:
+            if '%z' in time_format:
+                res = findall('[\-+]{1}[\d]{4}', i3s_time)[0]
+                if res:
+                    operator = res[0]
+                    hours = int(res[1:3])
+                    minutes = int(res[-2:])
+                    return (time_format.replace('%z', res), timedelta(
+                        hours=eval('{}{}'.format(operator, hours)),
+                        minutes=eval('{}{}'.format(operator, minutes))))
+        except Exception:
+            err = sys.exc_info()[1]
+            syslog(
+                LOG_ERR,
+                'i3status get_delta_from_format failed "{}" "{}" ({})'.format(
+                    i3s_time, time_format, err))
+        return (time_format, None)
+
+    def set_time_zone(self):
+        """
+        This method is executed only once after the first i3status output.
+
+        We parse all the i3status time and tztime modules and generate
+        a datetime for each of them while preserving (or defaulting) their
+        configured time format.
+
+        We also calculate a timedelta for each of them representing their
+        timezone offset. This is this delta that we'll be using from now on as
+        any future time or tztime update from i3status will be overwritten
+        thanks to our pre-parsed date here.
+        """
+        if self.time_date and int(time()) % 60 != 0:
+            return
+        default_time_format = '%Y-%m-%d %H:%M:%S'
+        default_tztime_format = '%Y-%m-%d %H:%M:%S %Z'
+        utcnow = self.i3status.last_output_ts
+        #
+        config = self.i3status.config
+        item = self.item
+        conf_name = self.module_name
+        time_name = item.get('name')
+        # time and tztime have different defaults
+        if time_name == 'time':
+            time_format = config.get(conf_name,
+                                     {}).get('format', default_time_format)
+        else:
+            time_format = config.get(conf_name,
+                                     {}).get('format', default_tztime_format)
+
+        # handle format_time parameter
+        if 'format_time' in config.get(conf_name, {}):
+            time_format = time_format.replace('%time',
+                                              config[conf_name]['format_time'])
+
+        # parse i3status date
+        i3s_time = item['full_text'].encode('UTF-8', 'replace')
+        try:
+            # python3 compatibility code
+            i3s_time = i3s_time.decode()
+        except:
+            pass
+
+        time_format, delta = self.get_delta_from_format(i3s_time, time_format)
+
+        try:
+            if '%Z' in time_format:
+                raise ValueError('%Z directive is not supported')
+
+            # add mendatory items in i3status time format wrt issue #18
+            time_fmt = time_format
+            for fmt in ['%Y', '%m', '%d']:
+                if fmt not in time_format:
+                    time_fmt = '{} {}'.format(time_fmt, fmt)
+                    i3s_time = '{} {}'.format(i3s_time,
+                                              datetime.now().strftime(fmt))
+
+            # get a datetime from the parsed string date
+            date = datetime.strptime(i3s_time, time_fmt)
+
+            # calculate the delta if needed
+            if not delta:
+                delta = (datetime(date.year, date.month, date.day, date.hour,
+                                  date.minute) -
+                         datetime(utcnow.year, utcnow.month, utcnow.day,
+                                  utcnow.hour, utcnow.minute))
+        except ValueError:
+            date = i3s_time
+        except Exception:
+            err = sys.exc_info()[1]
+            syslog(LOG_ERR,
+                   'i3status set_time_modules "{}" failed ({})'.format(
+                       conf_name, err))
+            date = i3s_time
+        finally:
+            self.time_date = date
+            self.time_delta = delta
+            self.time_format = time_format
 
 
 class I3status(Thread):
@@ -21,7 +171,7 @@ class I3status(Thread):
     This class is responsible for spawning i3status and reading its output.
     """
 
-    def __init__(self, lock, i3status_config_path, standalone):
+    def __init__(self, py3statusWrapper):
         """
         Our output will be read asynchronously from 'last_output'.
         """
@@ -38,35 +188,24 @@ class I3status(Thread):
         self.last_output = None
         self.last_output_ts = None
         self.last_prefix = None
-        self.lock = lock
+        self.lock = py3statusWrapper.lock
         self.new_update = False
+        self.py3statusWrapper = py3statusWrapper
         self.ready = False
-        self.standalone = standalone
+        self.standalone = py3statusWrapper.config['standalone']
         self.time_modules = []
         self.tmpfile_path = None
-        self.update_lock = Lock()
         #
-        self.config = self.i3status_config_reader(i3status_config_path)
+        config_path = py3statusWrapper.config['i3status_config_path']
+        self.config = self.i3status_config_reader(config_path)
 
-    def set_updated(self):
+    def update_times(self):
         """
-        Mark the status as updated
+        Update time for any i3status time/tztime items.
         """
-        self.update_lock.acquire()
-        self.new_update = True
-        self.update_lock.release()
-
-    def check_updated(self, reset=False):
-        """
-        Check if the status is updated and clear if requested.
-        """
-        if not reset:
-            return self.new_update
-        self.update_lock.acquire()
-        updated = self.new_update
-        self.new_update = False
-        self.update_lock.release()
-        return updated
+        for module in self.i3modules.values():
+            if module.is_time_module:
+                module.update_time_value()
 
     def valid_config_param(self, param_name, cleanup=False):
         """
@@ -260,118 +399,16 @@ class I3status(Thread):
         """
         Set the given i3status responses on their respective configuration.
         """
+        self.update_json_list()
+        updates = []
         for index, item in enumerate(self.json_list):
             conf_name = self.config['i3s_modules'][index]
-            self.config[conf_name]['response'] = item
-            self.i3modules[conf_name] = item
-
-    def get_delta_from_format(self, i3s_time, time_format):
-        """
-        Guess the time delta from %z time formats such as +0400.
-
-        When such a format is found, replace it in the string so we respect
-        i3status' output while being able to correctly adjust the time.
-        """
-        try:
-            if '%z' in time_format:
-                res = findall('[\-+]{1}[\d]{4}', i3s_time)[0]
-                if res:
-                    operator = res[0]
-                    hours = int(res[1:3])
-                    minutes = int(res[-2:])
-                    return (time_format.replace('%z', res), timedelta(
-                        hours=eval('{}{}'.format(operator, hours)),
-                        minutes=eval('{}{}'.format(operator, minutes))))
-        except Exception:
-            err = sys.exc_info()[1]
-            syslog(
-                LOG_ERR,
-                'i3status get_delta_from_format failed "{}" "{}" ({})'.format(
-                    i3s_time, time_format, err))
-        return (time_format, None)
-
-    def set_time_modules(self):
-        """
-        This method is executed only once after the first i3status output.
-
-        We parse all the i3status time and tztime modules and generate
-        a datetime for each of them while preserving (or defaulting) their
-        configured time format.
-
-        We also calculate a timedelta for each of them representing their
-        timezone offset. This is this delta that we'll be using from now on as
-        any future time or tztime update from i3status will be overwritten
-        thanks to our pre-parsed date here.
-        """
-        default_time_format = '%Y-%m-%d %H:%M:%S'
-        default_tztime_format = '%Y-%m-%d %H:%M:%S %Z'
-        utcnow = self.last_output_ts
-        #
-        for index, item in enumerate(self.json_list):
-            if item.get('name') in ['time', 'tztime']:
-
-                conf_name = self.config['i3s_modules'][index]
-                time_name = item.get('name')
-                if index not in self.time_modules:
-                    self.time_modules.append(index)
-                # time and tztime have different defaults
-                if time_name == 'time':
-                    time_format = self.config.get(
-                        conf_name, {}).get('format', default_time_format)
-                else:
-                    time_format = self.config.get(
-                        conf_name, {}).get('format', default_tztime_format)
-
-                # handle format_time parameter
-                if 'format_time' in self.config.get(conf_name, {}):
-                    time_format = time_format.replace(
-                        '%time', self.config[conf_name]['format_time'])
-
-                # parse i3status date
-                i3s_time = item['full_text'].encode('UTF-8', 'replace')
-                try:
-                    # python3 compatibility code
-                    i3s_time = i3s_time.decode()
-                except:
-                    pass
-
-                time_format, delta = self.get_delta_from_format(i3s_time,
-                                                                time_format)
-
-                try:
-                    if '%Z' in time_format:
-                        raise ValueError('%Z directive is not supported')
-
-                    # add mendatory items in i3status time format wrt issue #18
-                    time_fmt = time_format
-                    for fmt in ['%Y', '%m', '%d']:
-                        if fmt not in time_format:
-                            time_fmt = '{} {}'.format(time_fmt, fmt)
-                            i3s_time = '{} {}'.format(
-                                i3s_time, datetime.now().strftime(fmt))
-
-                    # get a datetime from the parsed string date
-                    date = datetime.strptime(i3s_time, time_fmt)
-
-                    # calculate the delta if needed
-                    if not delta:
-                        delta = (
-                            datetime(date.year, date.month, date.day,
-                                     date.hour, date.minute) - datetime(
-                                         utcnow.year, utcnow.month, utcnow.day,
-                                         utcnow.hour, utcnow.minute))
-                except ValueError:
-                    date = i3s_time
-                except Exception:
-                    err = sys.exc_info()[1]
-                    syslog(LOG_ERR,
-                           'i3status set_time_modules "{}" failed ({})'.format(
-                               conf_name, err))
-                    date = i3s_time
-                finally:
-                    self.config[conf_name]['date'] = date
-                    self.config[conf_name]['delta'] = delta
-                    self.config[conf_name]['time_format'] = time_format
+            if conf_name not in self.i3modules:
+                self.i3modules[conf_name] = I3statusModule(
+                    conf_name, self.py3statusWrapper)
+            if self.i3modules[conf_name].update_from_item(item):
+                updates.append(conf_name)
+        self.py3statusWrapper.notify_update(updates)
 
     def update_json_list(self):
         """
@@ -448,11 +485,7 @@ class I3status(Thread):
                                     self.last_output = json_list
                                     self.last_output_ts = datetime.utcnow()
                                     self.last_prefix = ','
-                                    self.update_json_list()
                                     self.set_responses(json_list)
-                                    # on first i3status output, we parse
-                                    # the time and tztime modules
-                                    self.set_time_modules()
                                 self.ready = True
                             elif not line.startswith(','):
                                 if 'version' in line:
@@ -465,9 +498,7 @@ class I3status(Thread):
                                     self.last_output = json_list
                                     self.last_output_ts = datetime.utcnow()
                                     self.last_prefix = prefix
-                                    self.update_json_list()
                                     self.set_responses(json_list)
-                            self.set_updated()
                         else:
                             err = self.poller_err.readline()
                             code = i3status_pipe.poll()

--- a/py3status/i3status.py
+++ b/py3status/i3status.py
@@ -32,6 +32,7 @@ class I3status(Thread):
             'ethernet', 'ipv6', 'load', 'path_exists', 'run_watch', 'time',
             'tztime', 'volume', 'wireless'
         ]
+        self.i3modules = {}
         self.json_list = None
         self.json_list_ts = None
         self.last_output = None
@@ -41,6 +42,7 @@ class I3status(Thread):
         self.new_update = False
         self.ready = False
         self.standalone = standalone
+        self.time_modules = []
         self.tmpfile_path = None
         self.update_lock = Lock()
         #
@@ -56,7 +58,7 @@ class I3status(Thread):
 
     def check_updated(self, reset=False):
         """
-        Check if the status is updated and clear flag if reset.
+        Check if the status is updated and clear if requested.
         """
         if not reset:
             return self.new_update
@@ -261,6 +263,7 @@ class I3status(Thread):
         for index, item in enumerate(self.json_list):
             conf_name = self.config['i3s_modules'][index]
             self.config[conf_name]['response'] = item
+            self.i3modules[conf_name] = item
 
     def get_delta_from_format(self, i3s_time, time_format):
         """
@@ -306,9 +309,11 @@ class I3status(Thread):
         #
         for index, item in enumerate(self.json_list):
             if item.get('name') in ['time', 'tztime']:
+
                 conf_name = self.config['i3s_modules'][index]
                 time_name = item.get('name')
-
+                if index not in self.time_modules:
+                    self.time_modules.append(index)
                 # time and tztime have different defaults
                 if time_name == 'time':
                     time_format = self.config.get(

--- a/py3status/module.py
+++ b/py3status/module.py
@@ -89,8 +89,9 @@ class Module(Thread):
         self.py3_wrapper.notify_update(self.module_full_name)
 
     def get_latest(self):
+        output = []
         for method in self.methods.values():
-            output = method['last_output']
+            output.append(method['last_output'])
         return output
 
     def load_methods(self, module, user_modules):

--- a/py3status/module.py
+++ b/py3status/module.py
@@ -82,6 +82,11 @@ class Module(Thread):
         """
         self.py3wrapper.notify_update(self.module_full_name)
 
+    def get_latest(self):
+        for method in self.methods.values():
+            output = method['last_output']
+        return output
+
     def load_methods(self, module, user_modules):
         """
         Read the given user-written py3status class file and store its methods.

--- a/py3status/modules/group.py
+++ b/py3status/modules/group.py
@@ -106,14 +106,8 @@ class Py3status:
         output = None
         current = self.items[item]
         py3_wrapper = self.py3_wrapper
-        if current in py3_wrapper.modules:
-            for method in py3_wrapper.modules[current].methods.values():
-                output = method['last_output']
-        else:
-            if py3_wrapper.i3status_thread.config.get(current,
-                                                      {}).get('response'):
-                output = (
-                    py3_wrapper.i3status_thread.config[current]['response'])
+        if current in py3_wrapper.output_modules:
+            output = py3_wrapper.output_modules[current]['module'].get_latest()
         return output
 
     def _get_current_module_name(self):

--- a/py3status/modules/group.py
+++ b/py3status/modules/group.py
@@ -107,7 +107,7 @@ class Py3status:
         current = self.items[item]
         py3_wrapper = self.py3_wrapper
         if current in py3_wrapper.output_modules:
-            output = py3_wrapper.output_modules[current]['module'].get_latest()
+            output = py3_wrapper.output_modules[current]['module'].get_latest()[0]
         return output
 
     def _get_current_module_name(self):


### PR DESCRIPTION
Hi,

This pull request does the following:

* move non `i3status` stuff out of `i3status.py` still more to be done.

* hopefully makes the code a little easier to  follow.

* adds a `check_update` helper to see when modules/i3status need updating.

* reduce the general cpu workload.

```
$ git checkout master
Switched to branch 'master'
Your branch is up-to-date with 'origin/master'.
$ time timeout -sHUP 10m  py3status -c ~/.i3/i3status.conf > /dev/null

real	10m0.007s
user	0m7.822s
sys 	0m2.089s
$ git checkout speedy
Switched to branch 'speedy'
Your branch is up-to-date with 'origin/speedy'.
$ time timeout -sHUP 10m  py3status -c ~/.i3/i3status.conf > /dev/null

real	10m0.006s
user	0m4.967s
sys 	0m2.070s
```

Let me know any thoughts on this