### PR TITLE
imap module - local maildir implementation

### DIFF
--- a/py3status/modules/imap.py
+++ b/py3status/modules/imap.py
@@ -11,7 +11,6 @@ Configuration parameters:
     mailbox: name of the mailbox to check
     maildir: full path of your maildir location
     new_mail_color: what color to output on new mail
-    offline: set to 1 will only check for local maildir
     password: login password
     port: IMAP server port
     user: login user
@@ -39,7 +38,6 @@ class Py3status:
     maildir = ''
     format = 'Mail: {unseen}'
     new_mail_color = ''
-    offline = '0'
     password = '<PASSWORD>'
     port = '993'
     user = '<USERNAME>'
@@ -67,17 +65,17 @@ class Py3status:
 
     def _get_mail_count(self):
         mail_count = 0
+
         try:
+            # check for local maildir if variable is defined
             if len(self.maildir) > 0:
-                directories = self.maildir.split(',')
+                directories = self.maildir.split(';')
                 for directory in directories:
                     mbox = Maildir(directory, create=False)
                     mail_count += mbox.__len__()
-        except:
-            pass
 
-        if self.offline != '1':
-            try:
+            # check for remote mailbox if variable is defined
+            if self.imap_server != '<IMAP_SERVER>':
                 directories = self.mailbox.split(',')
                 connection = imaplib.IMAP4_SSL(self.imap_server, self.port)
                 connection.login(self.user, self.password)
@@ -89,8 +87,8 @@ class Py3status:
                     mail_count += len(mails)
 
                 connection.close()
-            except:
-                return 'N/A'
+        except:
+            return 'N/A'
 
         return mail_count
 

--- a/py3status/modules/imap.py
+++ b/py3status/modules/imap.py
@@ -8,6 +8,7 @@ Configuration parameters:
     format: format to display
     hide_if_zero: don't show on bar if 0
     imap_server: IMAP server to connect to
+    local_mailbox: full path of your mbox location
     mailbox: name of the mailbox to check
     maildir: full path of your maildir location
     new_mail_color: what color to output on new mail
@@ -22,7 +23,7 @@ Format of status string placeholders:
 """
 
 import imaplib
-from mailbox import Maildir
+from mailbox import Maildir, mbox as Mailbox
 from time import time
 
 
@@ -34,6 +35,7 @@ class Py3status:
     criterion = 'UNSEEN'
     hide_if_zero = False
     imap_server = '<IMAP_SERVER>'
+    local_mailbox = ''
     mailbox = 'INBOX'
     maildir = ''
     format = 'Mail: {unseen}'
@@ -72,6 +74,13 @@ class Py3status:
                 directories = self.maildir.split(';')
                 for directory in directories:
                     mbox = Maildir(directory, create=False)
+                    mail_count += mbox.__len__()
+
+            # check for local mbox if variable is defined
+            if len(self.local_mailbox) > 0:
+                directories = self.local_mailbox.split(';')
+                for directory in directories:
+                    mbox = Mailbox(directory, create=False)
                     mail_count += mbox.__len__()
 
             # check for remote mailbox if variable is defined


### PR DESCRIPTION
Following this issue: https://github.com/ultrabug/py3status/issues/143

This is a bit messy but it would add new emails to the unseen mail count if a user is having both offline and remote mailbox. If the user only wants to check for offline maildir he can set the offline parameter to '1'.

User can also specifiy multiple local maildir using comma separated full path. Maybe semi-colon would be more appropriate. It seems to work properly here but I would really like your input on this since it doesn't look really clean (at all).

Should the failure of retrieving local maildir stop the module from trying to retrive remote emails as well?
