### PR TITLE
New module: xrandr_rotate

### DIFF
--- a/py3status/modules/xrandr_rotate.py
+++ b/py3status/modules/xrandr_rotate.py
@@ -51,7 +51,8 @@ class Py3status:
     vertical_rotation = 'left'
 
     def _call(self, cmd):
-        output = Popen(cmd, stdout=PIPE, shell=True).stdout.read()
+        process = Popen(cmd, stdout=PIPE, shell=True)
+        output = process.communicate()[0] or ""
         try:
             # python3
             output = output.decode()

--- a/py3status/modules/xrandr_rotate.py
+++ b/py3status/modules/xrandr_rotate.py
@@ -29,6 +29,12 @@ Available placeholders for formatting the output:
     {icon} a rotation icon, specified by `horizontal_icon` or `vertical_icon`.
 
 
+Remarks:
+    There have been cases when rotating a screen using this module made i3 unusabe.
+    If you experience a similar behavior, please report as many details as you can:
+    https://github.com/ultrabug/py3status/issues/227
+
+
 @author Maxim Baz (https://github.com/maximbaz)
 @license BSD
 """

--- a/py3status/modules/xrandr_rotate.py
+++ b/py3status/modules/xrandr_rotate.py
@@ -1,0 +1,115 @@
+# -*- coding: utf-8 -*-
+
+"""
+Switch between horizontal and vertical screen rotation on a single click.
+
+Configuration parameters:
+    - cache_timeout: how often to refresh this module.
+        default is 10
+    - format: a string that formats the output, can include placeholders.
+        default is '{icon}'
+    - horizontal_icon: a character to represent horizontal rotation.
+        default is 'H'
+    - horizontal_rotation: a horizontal rotation for xrandr to use.
+        available options: 'normal' or 'inverted'.
+        default is 'normal'
+    - vertical_icon: a character to represent vertical rotation.
+        default is 'V'
+    - vertical_rotation: a vertical rotation for xrandr to use.
+        available options: 'left' or 'right'.
+        default is 'left'
+
+Available placeholders for formatting the output:
+    - {icon} a rotation icon, specified by `horizontal_icon` or `vertical_icon`.
+
+
+@author Maxim Baz (https://github.com/maximbaz)
+@license BSD
+"""
+
+from subprocess import Popen, PIPE
+from time import sleep, time
+
+
+class Py3status:
+    """
+    """
+    # available configuration parameters
+    cache_timeout = 10
+    format = '{icon}'
+    horizontal_icon = 'H'
+    horizontal_rotation = 'normal'
+    vertical_icon = 'V'
+    vertical_rotation = 'left'
+
+    def _call(self, cmd):
+        output = Popen(cmd, stdout=PIPE, shell=True).stdout.readline()
+        try:
+            # python3
+            output = output.decode()
+        except:
+            pass
+        return output.strip()
+
+    def _get_first_output(self):
+        cmd = 'xrandr -q --verbose | grep " connected [^(]" | cut -d " " -f1'
+        return self._call(cmd)
+
+    def _get_current_rotation_icon(self):
+        output = self._get_first_output()
+        cmd = 'xrandr -q --verbose | grep "^' + output + '" | cut -d " " -f5'
+        is_horizontal = self._call(cmd) in ['normal', 'inverted']
+        return self.horizontal_icon if is_horizontal else self.vertical_icon
+
+    def _apply(self):
+        rotation = self.horizontal_rotation if self.displayed == self.horizontal_icon else self.vertical_rotation
+        output = self._get_first_output()
+        cmd = 'xrandr --output ' + output + ' --rotate ' + rotation
+        self._call(cmd)
+
+    def _switch_selection(self):
+        self.displayed = self.vertical_icon if self.displayed == self.horizontal_icon else self.horizontal_icon
+
+    def on_click(self, i3s_output_list, i3s_config, event):
+        """
+        Click events
+            - left click & scroll up/down: switch between rotations
+            - right click: apply selected rotation
+        """
+        button = event['button']
+        if button in [1, 4, 5]:
+            self._switch_selection()
+        elif button == 3:
+            self._apply()
+
+    def xrandr_rotate(self, i3s_output_list, i3s_config):
+        if not hasattr(self, 'displayed'):
+            self.displayed = self._get_current_rotation_icon()
+
+        full_text = self.format.format(icon=self.displayed or '?')
+
+        response = {
+            'cached_until': time() + self.cache_timeout,
+            'full_text': full_text
+        }
+
+        # coloration
+        if self.displayed == self._get_current_rotation_icon():
+            response['color'] = i3s_config['color_good']
+
+        return response
+
+
+if __name__ == "__main__":
+    """
+    Test this module by calling it directly.
+    """
+    x = Py3status()
+    config = {
+        'color_bad': '#FF0000',
+        'color_degraded': '#FFFF00',
+        'color_good': '#00FF00'
+    }
+    while True:
+        print(x.xrandr_rotate([], config))
+        sleep(1)

--- a/py3status/modules/xrandr_rotate.py
+++ b/py3status/modules/xrandr_rotate.py
@@ -27,6 +27,8 @@ Configuration parameters:
 
 Available placeholders for formatting the output:
     {icon} a rotation icon, specified by `horizontal_icon` or `vertical_icon`.
+    {screen} a screen name, specified by `screen` option or detected automatically
+        if only one screen is connected, otherwise 'ALL'.
 
 
 Remarks:
@@ -109,7 +111,8 @@ class Py3status:
             if not hasattr(self, 'displayed'):
                 self.displayed = self._get_current_rotation_icon(all_outputs)
 
-            full_text = self.format.format(icon=self.displayed or '?')
+            screen = self.screen or all_outputs[0] if len(all_outputs) == 1 else 'ALL'
+            full_text = self.format.format(icon=self.displayed or '?', screen=screen)
 
         response = {
             'cached_until': time() + self.cache_timeout,

--- a/py3status/modules/xrandr_rotate.py
+++ b/py3status/modules/xrandr_rotate.py
@@ -4,29 +4,29 @@
 Switch between horizontal and vertical screen rotation on a single click.
 
 Configuration parameters:
-    - cache_timeout: how often to refresh this module.
-        default is 10
-    - format: a string that formats the output, can include placeholders.
-        default is '{icon}'
-    - hide_if_disconnected: a boolean flag to hide icon when `screen` is disconnected.
+    cache_timeout: how often to refresh this module.
+        (default is 10)
+    format: a string that formats the output, can include placeholders.
+        (default is '{icon}')
+    hide_if_disconnected: a boolean flag to hide icon when `screen` is disconnected.
         it has no effect unless `screen` option is also configured.
-        default: None
-    - horizontal_icon: a character to represent horizontal rotation.
-        default is 'H'
-    - horizontal_rotation: a horizontal rotation for xrandr to use.
+        (default: None)
+    horizontal_icon: a character to represent horizontal rotation.
+        (default is 'H')
+    horizontal_rotation: a horizontal rotation for xrandr to use.
         available options: 'normal' or 'inverted'.
-        default is 'normal'
-    - screen: display output name to rotate, as detected by xrandr.
+        (default is 'normal')
+    screen: display output name to rotate, as detected by xrandr.
         if not provided, all enabled screens will be rotated.
-        default: None
-    - vertical_icon: a character to represent vertical rotation.
-        default is 'V'
-    - vertical_rotation: a vertical rotation for xrandr to use.
+        (default: None)
+    vertical_icon: a character to represent vertical rotation.
+        (default is 'V')
+    vertical_rotation: a vertical rotation for xrandr to use.
         available options: 'left' or 'right'.
-        default is 'left'
+        (default is 'left')
 
 Available placeholders for formatting the output:
-    - {icon} a rotation icon, specified by `horizontal_icon` or `vertical_icon`.
+    {icon} a rotation icon, specified by `horizontal_icon` or `vertical_icon`.
 
 
 @author Maxim Baz (https://github.com/maximbaz)

--- a/py3status/modules/xrandr_rotate.py
+++ b/py3status/modules/xrandr_rotate.py
@@ -60,13 +60,15 @@ class Py3status:
         return output.strip()
 
     def _get_all_outputs(self):
-        cmd = 'xrandr -q --verbose | grep " connected [^(]" | cut -d " " -f1'
+        cmd = 'xrandr -q | grep " connected [^(]" | cut -d " " -f1'
         return self._call(cmd).split()
 
     def _get_current_rotation_icon(self, all_outputs):
         output = self.screen or all_outputs[0]
-        cmd = 'xrandr -q --verbose | grep "^' + output + '" | cut -d " " -f5'
-        is_horizontal = self._call(cmd) in ['normal', 'inverted']
+        cmd = 'xrandr -q | grep "^' + output + '" | cut -d " " -f4'
+        output = self._call(cmd)
+        # xrandr may skip printing the 'normal', in which case the output would start from '('
+        is_horizontal = output.startswith('(') or output in ['normal', 'inverted']
         return self.horizontal_icon if is_horizontal else self.vertical_icon
 
     def _apply(self):

--- a/py3status/modules/xrandr_rotate.py
+++ b/py3status/modules/xrandr_rotate.py
@@ -63,8 +63,8 @@ class Py3status:
         cmd = 'xrandr -q --verbose | grep " connected [^(]" | cut -d " " -f1'
         return self._call(cmd).split()
 
-    def _get_current_rotation_icon(self):
-        output = self.screen or self._get_all_outputs()[0]
+    def _get_current_rotation_icon(self, all_outputs):
+        output = self.screen or all_outputs[0]
         cmd = 'xrandr -q --verbose | grep "^' + output + '" | cut -d " " -f5'
         is_horizontal = self._call(cmd) in ['normal', 'inverted']
         return self.horizontal_icon if is_horizontal else self.vertical_icon
@@ -92,12 +92,13 @@ class Py3status:
             self._apply()
 
     def xrandr_rotate(self, i3s_output_list, i3s_config):
-        selected_screen_disconnected = self.screen is not None and self.screen not in self._get_all_outputs()
+        all_outputs = self._get_all_outputs()
+        selected_screen_disconnected = self.screen is not None and self.screen not in all_outputs
         if selected_screen_disconnected and self.hide_if_disconnected:
             full_text = ''
         else:
             if not hasattr(self, 'displayed'):
-                self.displayed = self._get_current_rotation_icon()
+                self.displayed = self._get_current_rotation_icon(all_outputs)
 
             full_text = self.format.format(icon=self.displayed or '?')
 
@@ -109,7 +110,7 @@ class Py3status:
         # coloration
         if selected_screen_disconnected and not self.hide_if_disconnected:
             response['color'] = i3s_config['color_degraded']
-        elif self.displayed == self._get_current_rotation_icon():
+        elif self.displayed == self._get_current_rotation_icon(all_outputs):
             response['color'] = i3s_config['color_good']
 
         return response


### PR DESCRIPTION
Hey guys, I've got an idea of a module to rotate screen horizontally/vertically on a single click that I want to share with you. 

My main desire is: I want it to be **simple and intuitive**, which includes:

- As a user I see it behaving just like the `xrandr` module, in terms of selecting the rotation using mouse left click or wheel and applying the selected rotation using mouse right click.
- Even though there are four different rotations possible (normal, left, right, inverted), on a daily basis I want to think of my screen as either in "horizontal" or in "vertical" mode. Therefore the configuration parameters `horizontal_rotation` and `vertical_rotation` to choose the preferred rotation modes (clockwise or counter-clockwise).

-------

*The module looks like this with the default setup (look in the middle)*

DP1 output (provided by `xrandr` module) is in H (horizontal) rotation.

![selection_052](https://cloud.githubusercontent.com/assets/1177900/13940578/18f812ee-efdf-11e5-9459-85d68f4a4cc9.png)

Left mouse click, and DP1 output is about to be switched to V (vertical) rotation.

![selection_053](https://cloud.githubusercontent.com/assets/1177900/13940593/354038e6-efdf-11e5-9104-b83cfa353ce6.png)

Right click to confirm, and DP1 output is now in V (vertical) rotation.

![selection_055](https://cloud.githubusercontent.com/assets/1177900/13940682/03e5abc2-efe0-11e5-8322-80c5c78e1828.png)

-------

If you are a fan of icon fonts, the options `horizontal_icon` and `vertical_icon` are available for you. The module may look like the following:

![selection_056](https://cloud.githubusercontent.com/assets/1177900/13972047/a264766a-f095-11e5-8b88-89cd19fc41e6.png)

![selection_058](https://cloud.githubusercontent.com/assets/1177900/13972051/a45f800e-f095-11e5-9494-4b4100b5865d.png)


-------

*Multi-monitor setup is an open question though.* 

I see this as a non-trivial question: I doubt that it is reasonable to rotate all screens, I don't want to hardcode output name in config, and I don't want to make the selection mechanism complicated. 

As of now, the rotation happens on the *first* detected output. It works fine for the single monitor setup (which I happen to have), but I'm sure people with several screens would want to have some flexibility.

*Let me know what you think.* As for the multi-monitor question, unless some great idea comes during the review, I'm tempted to suggest to keep it as it is and improve in future as more people give their feedback on how they want it to behave.