### PR TITLE
Bugfix: modules that set a cache_until of 0

### DIFF
--- a/py3status/module.py
+++ b/py3status/module.py
@@ -255,7 +255,7 @@ class Module(Thread):
                         obj['cached_until'] = time()
                     group_module.run()
 
-            if not cache_time:
+            if cache_time is None:
                 cache_time = time() + self.config['cache_timeout']
             self.cache_time = cache_time
 


### PR DESCRIPTION
It seems some modules set a `cache_until` of `0` eg `window_title_async` 

This causes a delay of `config['cache_timeout']`

This patch makes the module update as soon as possible which is what the module is intending.