### PR TITLE
add screenshot_command configuration option

### DIFF
--- a/py3status/modules/screenshot.py
+++ b/py3status/modules/screenshot.py
@@ -9,6 +9,7 @@ When the screenshot has been taken, 'SHOT' is replaced by the file_name.
 This modules uses the 'gnome-screenshot' program to take the screenshot.
 
 Configuration parameters:
+    screenshot_command: the command used to generate the screenshot
     file_length: generated file_name length
     push: True/False if yo want to push your screenshot to your server
     save_path: Directory where to store your screenshots.
@@ -29,6 +30,7 @@ class Py3status:
     """
     """
     # available configuration parameters
+    screenshot_command = 'gnome-screenshot -f'
     cache_timeout = 5
     save_path = '%s%s' % (os.environ['HOME'], '/Pictures/')
     file_length = 4
@@ -44,7 +46,7 @@ class Py3status:
 
         file_name = self._filename_generator(self.file_length)
 
-        command = '%s %s/%s%s' % ('gnome-screenshot -f', self.save_path,
+        command = '%s %s/%s%s' % (self.screenshot_command, self.save_path,
                                   file_name, '.jpg')
 
         subprocess.Popen(command.split())

--- a/py3status/modules/screenshot.py
+++ b/py3status/modules/screenshot.py
@@ -6,7 +6,8 @@ Display a 'SHOT' button in your i3bar allowing you to take a screenshot and
 directly send (if wanted) the file to your online server.
 When the screenshot has been taken, 'SHOT' is replaced by the file_name.
 
-This modules uses the 'gnome-screenshot' program to take the screenshot.
+By default, this modules uses the 'gnome-screenshot' program to take the screenshot,
+but this can be configured with the `screenshot_command` configuration parameter.
 
 Configuration parameters:
     screenshot_command: the command used to generate the screenshot


### PR DESCRIPTION
Short version:
Adds the ability to configure what application is used to take the screenshot 

Longer version:
I do not use Gnome, and gnome-screenshot was not working for me when using the plugin. I like the idea behind the plugin, so I thought I would extend it to allow the screenshot command to be configurable. 