### PR TITLE
Module helpers, notify-send and cleaner clicks

### DIFF
--- a/py3status/__init__.py
+++ b/py3status/__init__.py
@@ -17,11 +17,11 @@ def main():
         py3.setup()
     except KeyboardInterrupt:
         err = sys.exc_info()[1]
-        py3.i3_nagbar('setup interrupted (KeyboardInterrupt)')
+        py3.notify_user('setup interrupted (KeyboardInterrupt)')
         sys.exit(0)
     except Exception:
         err = sys.exc_info()[1]
-        py3.i3_nagbar('setup error ({})'.format(err))
+        py3.notify_user('setup error ({})'.format(err))
         py3.stop()
         sys.exit(2)
 
@@ -29,7 +29,7 @@ def main():
         py3.run()
     except Exception:
         err = sys.exc_info()[1]
-        py3.i3_nagbar('runtime error ({})'.format(err))
+        py3.notify_user('runtime error ({})'.format(err))
         sys.exit(3)
     except KeyboardInterrupt:
         pass

--- a/py3status/core.py
+++ b/py3status/core.py
@@ -55,7 +55,7 @@ class Py3statusWrapper():
             'include_paths': ['{}/.i3/py3status/'.format(home_path)],
             'interval': 1,
             'minimum_interval': 0.1,  # minimum module update interval
-            'dbus': False,
+            'dbus_notify': False,
         }
 
         # package version
@@ -100,10 +100,11 @@ class Py3statusWrapper():
                             '--debug',
                             action="store_true",
                             help="be verbose in syslog")
-        parser.add_argument('--dbus-notifications',
+        parser.add_argument('-b',
+                            '--dbus-notify',
                             action="store_true",
                             default=False,
-                            dest="dbus_notifications",
+                            dest="dbus_notify",
                             help="use notify-send to send user notifications")
         parser.add_argument('-i',
                             '--include',
@@ -151,7 +152,7 @@ class Py3statusWrapper():
         # override configuration and helper variables
         config['cache_timeout'] = options.cache_timeout
         config['debug'] = options.debug
-        config['dbus'] = options.dbus_notifications
+        config['dbus_notify'] = options.dbus_notify
         if options.include_paths:
             config['include_paths'] = options.include_paths
         config['interval'] = int(options.interval)
@@ -287,14 +288,14 @@ class Py3statusWrapper():
         Make use of i3-nagbar to display errors and warnings to the user.
         We also make sure to log anything to keep trace of it.
         """
-        if not self.config['dbus']:
+        if not self.config['dbus_notify']:
             msg = 'py3status: {}. '.format(msg)
         if level != 'info':
             msg += 'please try to fix this and reload i3wm (Mod+Shift+R)'
         try:
             log_level = LOG_LEVELS.get(level, LOG_ERR)
             syslog(log_level, msg)
-            if self.config['dbus']:
+            if self.config['dbus_notify']:
                 # fix any html entities
                 msg = msg.replace('&', '&amp;')
                 msg = msg.replace('<', '&lt;')

--- a/py3status/core.py
+++ b/py3status/core.py
@@ -21,6 +21,10 @@ from py3status.i3status import I3status
 from py3status.module import Module
 from py3status.profiling import profile
 
+LOG_LEVELS = {'error': LOG_ERR, 'warning': LOG_WARNING, 'info': LOG_INFO, }
+
+DBUS_LEVELS = {'error': 'critical', 'warning': 'normal', 'info': 'low', }
+
 
 class Py3statusWrapper():
     """
@@ -50,7 +54,8 @@ class Py3statusWrapper():
             'cache_timeout': 60,
             'include_paths': ['{}/.i3/py3status/'.format(home_path)],
             'interval': 1,
-            'minimum_interval': 0.1  # minimum module update interval
+            'minimum_interval': 0.1,  # minimum module update interval
+            'dbus': False,
         }
 
         # package version
@@ -95,6 +100,11 @@ class Py3statusWrapper():
                             '--debug',
                             action="store_true",
                             help="be verbose in syslog")
+        parser.add_argument('--dbus-notifications',
+                            action="store_true",
+                            default=False,
+                            dest="dbus_notifications",
+                            help="use notify-send to send user notifications")
         parser.add_argument('-i',
                             '--include',
                             action="append",
@@ -141,6 +151,7 @@ class Py3statusWrapper():
         # override configuration and helper variables
         config['cache_timeout'] = options.cache_timeout
         config['debug'] = options.debug
+        config['dbus'] = options.dbus_notifications
         if options.include_paths:
             config['include_paths'] = options.include_paths
         config['interval'] = int(options.interval)
@@ -212,7 +223,7 @@ class Py3statusWrapper():
             except Exception:
                 err = sys.exc_info()[1]
                 msg = 'loading module "{}" failed ({})'.format(module, err)
-                self.i3_nagbar(msg, level='warning')
+                self.notify_user(msg, level='warning')
 
     def setup(self):
         """
@@ -271,17 +282,28 @@ class Py3statusWrapper():
             # load and spawn i3status.conf configured modules threads
             self.load_modules(self.py3_modules, user_modules)
 
-    def i3_nagbar(self, msg, level='error'):
+    def notify_user(self, msg, level='error'):
         """
         Make use of i3-nagbar to display errors and warnings to the user.
         We also make sure to log anything to keep trace of it.
         """
-        msg = 'py3status: {}. '.format(msg)
-        msg += 'please try to fix this and reload i3wm (Mod+Shift+R)'
+        if not self.config['dbus']:
+            msg = 'py3status: {}. '.format(msg)
+        if level != 'info':
+            msg += 'please try to fix this and reload i3wm (Mod+Shift+R)'
         try:
-            log_level = LOG_ERR if level == 'error' else LOG_WARNING
+            log_level = LOG_LEVELS.get(level, LOG_ERR)
             syslog(log_level, msg)
-            Popen(['i3-nagbar', '-m', msg, '-t', level],
+            if self.config['dbus']:
+                # fix any html entities
+                msg = msg.replace('&', '&amp;')
+                msg = msg.replace('<', '&lt;')
+                msg = msg.replace('>', '&gt;')
+                cmd = ['notify-send', '-u', DBUS_LEVELS.get(level, 'normal'),
+                       '-t', '10000', 'py3status', msg]
+            else:
+                cmd = ['i3-nagbar', '-m', msg, '-t', level]
+            Popen(cmd,
                   stdout=open('/dev/null', 'w'),
                   stderr=open('/dev/null', 'w'))
         except:
@@ -416,16 +438,16 @@ class Py3statusWrapper():
                     err = i3status_thread.error
                     if not err:
                         err = 'i3status died horribly'
-                    self.i3_nagbar(err)
+                    self.notify_user(err)
                     break
 
                 # check events thread
                 if not self.events_thread.is_alive():
                     # don't spam the user with i3-nagbar warnings
-                    if not hasattr(self.events_thread, 'i3_nagbar'):
-                        self.events_thread.i3_nagbar = True
+                    if not hasattr(self.events_thread, 'nagged'):
+                        self.events_thread.nagged = True
                         err = 'events thread died, click events are disabled'
-                        self.i3_nagbar(err, level='warning')
+                        self.notify_user(err, level='warning')
 
                 # update i3status time/tztime items
                 if interval == 0 or sec % interval == 0:

--- a/py3status/core.py
+++ b/py3status/core.py
@@ -390,12 +390,14 @@ class Py3statusWrapper():
                 output_modules[name] = {}
                 output_modules[name]['position'] = positions.get(name, [])
                 output_modules[name]['module'] = self.modules[name]
+                output_modules[name]['type'] = 'py3status'
         # i3status modules
         for name in i3modules:
             if name not in output_modules:
                 output_modules[name] = {}
                 output_modules[name]['position'] = positions.get(name, [])
                 output_modules[name]['module'] = i3modules[name]
+                output_modules[name]['type'] = 'i3status'
 
         self.output_modules = output_modules
 

--- a/py3status/core.py
+++ b/py3status/core.py
@@ -249,8 +249,7 @@ class Py3statusWrapper():
                 self.i3status_thread.config))
 
         # setup input events thread
-        self.events_thread = Events(self.lock, self.config, self.modules,
-                                    self.i3status_thread.config)
+        self.events_thread = Events(self)
         self.events_thread.start()
         if self.config['debug']:
             syslog(LOG_INFO, 'events thread started')

--- a/py3status/i3status.py
+++ b/py3status/i3status.py
@@ -327,7 +327,6 @@ class I3status(Thread):
                             # py3status module add a reference to the group and
                             # make sure we have it in the list of modules to
                             # run
-                            config[section_name]['.group'] = group_name
                             if section_name not in config['py3_modules']:
                                 config['py3_modules'].append(section_name)
                         else:

--- a/py3status/module.py
+++ b/py3status/module.py
@@ -43,9 +43,6 @@ class Module(Thread):
         # py3wrapper this is private and any modules accessing their instance
         # should only use it on the understanding that it is not supported.
         self._py3_wrapper = py3_wrapper
-
-        # if the module is part of a group then we want to store it's name
-        self.group = self.i3status_thread.config.get(module, {}).get('.group')
         #
         self.load_methods(module, user_modules)
 

--- a/py3status/module.py
+++ b/py3status/module.py
@@ -38,8 +38,12 @@ class Module(Thread):
         self.new_update = False
         self.module_full_name = module
         self.nagged = False
-        self.py3_wrapper = py3_wrapper
         self.timer = None
+
+        # py3wrapper this is private and any modules accessing their instance
+        # should only use it on the understanding that it is not supported.
+        self._py3_wrapper = py3_wrapper
+
         # if the module is part of a group then we want to store it's name
         self.group = self.i3status_thread.config.get(module, {}).get('.group')
         #
@@ -86,12 +90,37 @@ class Module(Thread):
         """
         Mark the module as updated
         """
-        self.py3_wrapper.notify_update(self.module_full_name)
+        self._py3_wrapper.notify_update(self.module_full_name)
 
     def get_latest(self):
         for method in self.methods.values():
             output = method['last_output']
         return output
+
+    def helper_get_module_info(self, module_name):
+        """
+        Helper function to get info for named module. info comes back as a dict
+        containing.
+
+        'module': the instance of the module,
+        'position': list of places in i3bar, usually only one item
+        'type': module type py3status/i3status
+        """
+        return self._py3_wrapper.output_modules.get(module_name)
+
+    def helper_trigger_event(self, module_name, event):
+        """
+        Trigger the event on named module
+        """
+        if module_name:
+            self._py3_wrapper.events_thread.process_event(module_name, event)
+
+    def helper_notification(self, msg, level='info'):
+        """
+        Send notification to user.
+        level can be 'info', 'error' or 'warning'
+        """
+        self._py3_wrapper.notify_user(msg, level=level)
 
     def load_methods(self, module, user_modules):
         """
@@ -265,12 +294,12 @@ class Module(Thread):
                     msg = 'user method {} failed ({})'.format(meth, err)
                     syslog(LOG_WARNING, msg)
                     if not self.nagged:
-                        self.py3_wrapper.i3_nagbar(msg, level='warning')
+                        self.helper_notification(msg, level='error')
                         self.nagged = True
 
             # if in a group then force the group to update
             if self.group:
-                group_module = self.py3_wrapper.modules.get(self.group)
+                group_module = self._py3_wrapper.modules.get(self.group)
                 if group_module:
                     for obj in group_module.methods.values():
                         obj['cached_until'] = time()
@@ -282,8 +311,7 @@ class Module(Thread):
 
             # don't be hasty mate
             # set timer to do update next time one is needed
-            delay = max(cache_time - time(),
-                        self.config['minimum_interval'])
+            delay = max(cache_time - time(), self.config['minimum_interval'])
             self.timer = Timer(delay, self.run)
             self.timer.start()
 

--- a/py3status/modules/group.py
+++ b/py3status/modules/group.py
@@ -75,11 +75,6 @@ class Py3status:
         self.initialized = False
 
     def _init(self):
-        try:
-            self.py3_wrapper = self.py3_module.py3_wrapper
-        except AttributeError:
-            self.py3_wrapper = None
-
         self._cycle_time = time() + self.cycle
         self.initialized = True
 
@@ -105,25 +100,15 @@ class Py3status:
     def _get_current_output(self, item):
         output = None
         current = self.items[item]
-        py3_wrapper = self.py3_wrapper
-        if current in py3_wrapper.output_modules:
-            output = py3_wrapper.output_modules[current]['module'].get_latest()
+        module_info = self.py3_module.helper_get_module_info(current)
+        if module_info:
+            output = module_info['module'].get_latest()
         return output
 
     def _get_current_module_name(self):
         if not self.items:
             return
         return self.items[self.active]
-
-    def _get_current_module(self):
-        if not self.items:
-            return
-        current = self.items[self.active]
-        py3_wrapper = self.py3_wrapper
-        if current in py3_wrapper.modules:
-            return py3_wrapper.modules[current]
-        else:
-            return py3_wrapper.config.get(current)
 
     def _next(self):
         self.active = (self.active + 1) % len(self.items)
@@ -166,20 +151,6 @@ class Py3status:
             response['color'] = self.color
         return response
 
-    def _call_i3status_config_on_click(self, module_name, event):
-        """
-        call any on_click event set in the config for the named module
-        """
-        config = self.py3_module.py3_wrapper.i3status_thread.config[
-            'on_click']
-        click_info = config.get(module_name, None)
-        if click_info:
-            action = click_info.get(event['button'])
-            if action:
-                # we have an action so call it
-                self.py3_module.py3_wrapper.events_thread.i3_msg(
-                    module_name, action)
-
     def on_click(self, i3s_output_list, i3s_config, event):
         """
         Switch the displayed module or pass the event on to the active module
@@ -193,19 +164,9 @@ class Py3status:
         if self.button_prev and event['button'] == self.button_prev:
             self._prev()
 
-        # any event set in the config for the group
-        name = self.py3_module.module_full_name
-        self._call_i3status_config_on_click(name, event)
-
-        # any event set in the config for the active module
-        current_module = self.items[self.active]
-        self._call_i3status_config_on_click(current_module, event)
-
-        # try the modules own click event
-        current_module = self._get_current_module()
-        current_module.click_event(event)
-        self.py3_wrapper.events_thread.refresh(
-            current_module.module_full_name)
+        # pass the event to the current module
+        module_name = self._get_current_module_name()
+        self.py3_module.helper_trigger_event(module_name, event)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
In some ways this should be separate pull requests but there is some overlap.  I've tried to keep the commits independent, but they aren't quite.

What this does

**events**

* As shown by the group click events fun, the events logic in py3status is quite complex.  This patch moves the event processing out of the main loop into it's own function.  This allows events to be triggered on modules using the same code path.  The groups module may be the only user, other than the event loop, but it means that they will stay consistent if the logic is changed.  eg group clicks now use `i3bar_click_events.py` fallback .

**notify-send**

* `i3_nagbar()` is renamed to `notify_user()` all parameters stay as before.

* New `--dbus-notifications` option for `py3status` command if set this switches from using the i3 nagbar to using `notify-send` currently there is a fixed timeout of 10 seconds for these messages.

**module helpers**

* Now that modules can get hold of their instance class, they can access all of py3status.  While this is good on many levels, if users start relying on py3status methods etc then this makes refactoring hard and becomes a potential support nightmare.

* `Module.py3_wrapper` becomes `Module._py3_wrapper` along with comment that its use is not supported.

* some helper functions are added to `Module` to allow useful functionality

  *helper_get_module_info(module_name)* - Get info for named module.

  *helper_trigger_event(module_name, event)* - Trigger the event on named module

  *helper_notification(msg, level)* - Send notification to user.


The names could probably be improved.