### PR TITLE
prevent error when group is empty

### DIFF
--- a/py3status/modules/group.py
+++ b/py3status/modules/group.py
@@ -137,6 +137,15 @@ class Py3status:
         """
         Display a output of current module
         """
+
+        # hide if no contents
+        # FIXME the module shouldn't even run if no content
+        if not self.items:
+            return {
+                'cached_until': time() + 36000,
+                'full_text': '',
+            }
+
         ready = self.initialized
         if not ready:
             self._init()

--- a/py3status/modules/group.py
+++ b/py3status/modules/group.py
@@ -79,7 +79,9 @@ class Py3status:
             self.py3_wrapper = self.py3_module.py3_wrapper
         except AttributeError:
             self.py3_wrapper = None
-
+        # if no items don't cycle
+        if not self.items:
+            self.cycle = 0
         self._cycle_time = time() + self.cycle
         self.initialized = True
 


### PR DESCRIPTION
If a group is empty we get a modulo zero error when it cycles.  This prevents this from happening.

example config to cause issue
```
group bad {
    cycle = 1
}
```