### PR TITLE
fix for xrandr_rotate issue

### DIFF
--- a/py3status/modules/xrandr_rotate.py
+++ b/py3status/modules/xrandr_rotate.py
@@ -84,8 +84,8 @@ class Py3status:
         rotation = self.horizontal_rotation if self.displayed == self.horizontal_icon else self.vertical_rotation
         outputs = [self.screen] if self.screen else self._get_all_outputs()
         for output in outputs:
-            cmd = 'xrandr --output ' + output + ' --rotate ' + rotation
-            self._call(cmd)
+            cmd = 'exec xrandr --output ' + output + ' --rotate ' + rotation
+            Popen(['i3-msg', cmd], stdout=PIPE)
 
     def _switch_selection(self):
         self.displayed = self.vertical_icon if self.displayed == self.horizontal_icon else self.horizontal_icon


### PR DESCRIPTION
@maximbaz 

I have done some playing around and have managed to fix the issue that I was having with `xrandr_rotate`.  The fix is to run the command via `i3-msg` I'm not quite sure why this works but it does.

Could you see if it works for you too.

This fixes  #227 as far as I'm concerned, unless there have been other problems reported.  And we should remove the warning in the docstring too.