### PR TITLE
Fix not initialized 'displayed' field in xrandr_rotate

### DIFF
--- a/py3status/modules/xrandr_rotate.py
+++ b/py3status/modules/xrandr_rotate.py
@@ -58,6 +58,9 @@ class Py3status:
     vertical_icon = 'V'
     vertical_rotation = 'left'
 
+    def __init__(self):
+        self.displayed = ''
+
     def _call(self, cmd):
         process = Popen(cmd, stdout=PIPE, shell=True)
         output = process.communicate()[0] or ""
@@ -106,9 +109,10 @@ class Py3status:
         all_outputs = self._get_all_outputs()
         selected_screen_disconnected = self.screen is not None and self.screen not in all_outputs
         if selected_screen_disconnected and self.hide_if_disconnected:
+            self.displayed = ''
             full_text = ''
         else:
-            if not hasattr(self, 'displayed'):
+            if not self.displayed:
                 self.displayed = self._get_current_rotation_icon(all_outputs)
 
             screen = self.screen or all_outputs[0] if len(all_outputs) == 1 else 'ALL'


### PR DESCRIPTION
Discovered a couple of small glitches, this is a fix for them.

Repro steps:
- set `screen` property to an output name that is not currently connected.
- set `hide_if_disconnected` to true.
- restart i3

Expected: icon will not show up
Actual: the module crashes, since `self.displayed` is not initialized but later is being accessed.

-----

And another super-tiny one:

- set `screen` property to an output name that is not currently connected.
- set `hide_if_disconnected` to true.
- while in H mode, left click to select V mode, but do not apply it
- disconnect the screen (icon hides)
- connect the screen (icon appears)

Expected: icon shows the current rotation of the screen (H)
Actual: icon remembers your choice and still shows V even though the screen is in H mode.