### PR TITLE
Nice module errors

### DIFF
--- a/py3status/core.py
+++ b/py3status/core.py
@@ -289,9 +289,9 @@ class Py3statusWrapper():
         We also make sure to log anything to keep trace of it.
         """
         if not self.config['dbus_notify']:
-            msg = 'py3status: {}. '.format(msg)
+            msg = 'py3status: {}.'.format(msg)
         if level != 'info':
-            msg += 'please try to fix this and reload i3wm (Mod+Shift+R)'
+            msg += ' Please try to fix this and reload i3wm (Mod+Shift+R)'
         try:
             log_level = LOG_LEVELS.get(level, LOG_ERR)
             syslog(log_level, msg)

--- a/py3status/core.py
+++ b/py3status/core.py
@@ -290,6 +290,8 @@ class Py3statusWrapper():
         """
         if not self.config['dbus_notify']:
             msg = 'py3status: {}.'.format(msg)
+        else:
+            msg = '{}.'.format(msg)
         if level != 'info':
             msg += ' Please try to fix this and reload i3wm (Mod+Shift+R)'
         try:

--- a/py3status/module.py
+++ b/py3status/module.py
@@ -324,8 +324,25 @@ class Module(Thread):
                         syslog(LOG_INFO,
                                'method {} returned {} '.format(meth, result))
                 except Exception:
-                    err = sys.exc_info()[1]
-                    msg = 'user method {} failed ({})'.format(meth, err)
+                    try:
+                        # Try to get nice feedback info
+                        # we need to make sure to delete tb even if things go
+                        # wrong.
+                        exc_type, exc_obj, tb = sys.exc_info()
+                        import traceback
+                        stack = traceback.extract_tb(tb)
+                        filename = os.path.basename(stack[-1][0])
+                        line_no = stack[-1][1]
+                        msg = '{}, instance, {}, user method {}, failed ({}) line {}'.format(
+                            filename, self.module_full_name, meth, exc_type,
+                            line_no)
+                    except:
+                        msg = 'instance {}, user method {}, failed.'.format(
+                            self.module_full_name, meth)
+                    finally:
+                        # delete tb!
+                        del tb
+
                     syslog(LOG_WARNING, msg)
                     if not self.nagged:
                         self.helper_notification(msg, level='error')

--- a/py3status/module.py
+++ b/py3status/module.py
@@ -7,6 +7,7 @@ from threading import Thread, Timer
 from collections import OrderedDict
 from syslog import syslog, LOG_INFO, LOG_WARNING
 from time import time
+from traceback import extract_tb
 
 from py3status.profiling import profile
 
@@ -329,8 +330,7 @@ class Module(Thread):
                         # we need to make sure to delete tb even if things go
                         # wrong.
                         exc_type, exc_obj, tb = sys.exc_info()
-                        import traceback
-                        stack = traceback.extract_tb(tb)
+                        stack = extract_tb(tb)
                         filename = os.path.basename(stack[-1][0])
                         line_no = stack[-1][1]
                         msg = '{}, instance, {}, user method {}, failed ({}) line {}'.format(

--- a/py3status/module.py
+++ b/py3status/module.py
@@ -333,7 +333,7 @@ class Module(Thread):
                         stack = extract_tb(tb)
                         filename = os.path.basename(stack[-1][0])
                         line_no = stack[-1][1]
-                        msg = '{}, instance, {}, user method {}, failed ({}) line {}'.format(
+                        msg = '{}, instance {}, user method {}, failed ({}) line {}'.format(
                             filename, self.module_full_name, meth, exc_type.__name__,
                             line_no)
                     except:

--- a/py3status/module.py
+++ b/py3status/module.py
@@ -334,7 +334,7 @@ class Module(Thread):
                         filename = os.path.basename(stack[-1][0])
                         line_no = stack[-1][1]
                         msg = '{}, instance, {}, user method {}, failed ({}) line {}'.format(
-                            filename, self.module_full_name, meth, exc_type,
+                            filename, self.module_full_name, meth, exc_type.__name__,
                             line_no)
                     except:
                         msg = 'instance {}, user method {}, failed.'.format(


### PR DESCRIPTION
Currently when a module raises an error we are just informed of the method and a vague error.

This PR improves on this situation.  We have more information on the error:

* filename
* instance
* line number
* exception type

This makes finding/fixing errors in modules much simpler.

The code is a little nasty with the `finally` but this is to prevent circular references https://docs.python.org/2/library/sys.html#sys.exc_info