### PR TITLE
Add __repr__ to Module and I3StatusModule

### DIFF
--- a/py3status/i3status.py
+++ b/py3status/i3status.py
@@ -58,6 +58,9 @@ class I3statusModule:
             self.tz = None
             self.set_time_format()
 
+    def __repr__(self):
+        return '<I3statusModule {}>'.format(self.module_name)
+
     def get_latest(self):
         return [self.item]
 

--- a/py3status/module.py
+++ b/py3status/module.py
@@ -47,6 +47,9 @@ class Module(Thread):
         self.set_module_options(module)
         self.load_methods(module, user_modules)
 
+    def __repr__(self):
+        return '<Module {}>'.format(self.module_full_name)
+
     @staticmethod
     def load_from_file(filepath):
         """


### PR DESCRIPTION
Make `Module` and `I3StatusModule` `__repr__` easier to read.  I've found this helpful for debugging and developing.

before
```
<py3status.i3status.I3statusModule instance at 0x7f785be571b8>
<Module(Thread-5, stopped 140154880657152)>
```
after
```
<I3statusModule ipv6>
<Module battery_level>
```