### PR TITLE
nicer module updates fixes #241

### DIFF
--- a/py3status/core.py
+++ b/py3status/core.py
@@ -353,7 +353,7 @@ class Py3statusWrapper():
         For every module, reset the 'cached_until' of all its methods.
         """
         for module in self.modules.values():
-            module.clear_cache()
+            module.force_update()
 
     def terminate(self, signum, frame):
         """
@@ -379,8 +379,7 @@ class Py3statusWrapper():
         for group in groups_to_update:
             group_module = self.output_modules.get(group)
             if group_module:
-                group_module['module'].clear_cache()
-                group_module['module'].run()
+                group_module['module'].force_update()
 
     def create_output_modules(self):
         """

--- a/py3status/events.py
+++ b/py3status/events.py
@@ -111,10 +111,7 @@ class Events(Thread):
         if module is not None:
             if self.config['debug']:
                 syslog(LOG_INFO, 'refresh module {}'.format(module_name))
-            for obj in module.methods.values():
-                obj['cached_until'] = time()
-            # get module to update
-            module.run()
+            module.force_update()
         else:
             if time() > (self.last_refresh_ts + 0.1):
                 if self.config['debug']:

--- a/py3status/module.py
+++ b/py3status/module.py
@@ -75,14 +75,21 @@ class Module(Thread):
         class_inst = py_mod.Py3status()
         return class_inst
 
-    def clear_cache(self):
+    def force_update(self):
         """
-        Reset the cache for all methods of this module.
+        Forces an update of the module.
         """
+        # clear cached_until for each method to allow update
         for meth in self.methods:
             self.methods[meth]['cached_until'] = time()
             if self.config['debug']:
                 syslog(LOG_INFO, 'clearing cache for method {}'.format(meth))
+        # cancel any existing timer
+        if self.timer:
+            self.timer.cancel()
+        # get the thread to update itself
+        self.timer = Timer(0, self.run)
+        self.timer.start()
 
     def set_updated(self):
         """


### PR DESCRIPTION
Renames `Module.clear_cache()` to `Module.force_update()`

This method now as well as clearing the cache sets a Timer to update the module.

Change py3status to only use this to force modules to update eg on click events.

As well as being cleaner it should fix #241 @neutronst4r could you see if this fixes your issue.  In my testing it works as expected.