### PR TITLE
write_tmp_i3status_config() rewrite

### DIFF
--- a/py3status/i3status.py
+++ b/py3status/i3status.py
@@ -497,8 +497,11 @@ class I3status(Thread):
             for key, value in section.items():
                 # Set known fixed format for time and tztime so we can work
                 # out the timezone
-                if module.split()[0] in TIME_MODULES and key == 'format':
-                    value = TZTIME_FORMAT
+                if module.split()[0] in TIME_MODULES:
+                    if key == 'format':
+                        value = TZTIME_FORMAT
+                    if key == 'format_time':
+                        continue
                 if isinstance(value, bool):
                     value = '{}'.format(value).lower()
                 self.write_in_tmpfile('    %s = "%s"\n' % (key, value),


### PR DESCRIPTION
This PR makes some changes to the generation of the `i3status.conf` created to send to `i3status`.

Changes:

* Instead of using the user provided `general` section we just create our own from a template `I3STATUS_CONF_GENERAL`.  (less likely to break i3status)

* The interval is from the users config if set, else `DEFAULT_I3STATUS_INTERVAL` is used.

* The config file is then created using `I3Status.config['i3s_modules']`.  Before `config['order']` and `config['.group_extras']` where used.  
 
`I3Status.set_responses()` uses `config['i3s_modules']` to work out the order of the i3status modules.  In the current setup this is fine because 

```config['order'] + config['.group_extras'] == config['i3s_modules']``` 

However this is almost by chance.  This corrects this issue.

The main reason for this is that I have a new config parser that I want to submit and with that, the above assumption fails causing issues.  Including this change really complicates that pull request. 
So I've separated it out into this PR.

I've tested this across various configs for the last week or so without problems.