### PR TITLE
show more info on errors

### DIFF
--- a/py3status/__init__.py
+++ b/py3status/__init__.py
@@ -16,20 +16,16 @@ def main():
         py3 = Py3statusWrapper()
         py3.setup()
     except KeyboardInterrupt:
-        err = sys.exc_info()[1]
         py3.notify_user('setup interrupted (KeyboardInterrupt)')
         sys.exit(0)
     except Exception:
-        err = sys.exc_info()[1]
-        py3.notify_user('setup error ({})'.format(err))
-        py3.stop()
+        py3.report_exception('Setup error')
         sys.exit(2)
 
     try:
         py3.run()
     except Exception:
-        err = sys.exc_info()[1]
-        py3.notify_user('runtime error ({})'.format(err))
+        py3.report_exception('Runtime error')
         sys.exit(3)
     except KeyboardInterrupt:
         pass

--- a/py3status/core.py
+++ b/py3status/core.py
@@ -13,6 +13,7 @@ from subprocess import call
 from threading import Event
 from time import sleep, time
 from syslog import syslog, LOG_ERR, LOG_INFO, LOG_WARNING
+from traceback import extract_tb
 
 import py3status.docstrings as docstrings
 from py3status.events import Events
@@ -35,6 +36,7 @@ class Py3statusWrapper():
         """
         Useful variables we'll need.
         """
+        self.config = {}
         self.last_refresh_ts = time()
         self.lock = Event()
         self.modules = {}
@@ -288,7 +290,8 @@ class Py3statusWrapper():
         Make use of i3-nagbar to display errors and warnings to the user.
         We also make sure to log anything to keep trace of it.
         """
-        if not self.config['dbus_notify']:
+        dbus = self.config.get('dbus_notify')
+        if not dbus:
             msg = 'py3status: {}.'.format(msg)
         else:
             msg = '{}.'.format(msg)
@@ -297,7 +300,7 @@ class Py3statusWrapper():
         try:
             log_level = LOG_LEVELS.get(level, LOG_ERR)
             syslog(log_level, msg)
-            if self.config['dbus_notify']:
+            if dbus:
                 # fix any html entities
                 msg = msg.replace('&', '&amp;')
                 msg = msg.replace('<', '&lt;')
@@ -382,6 +385,31 @@ class Py3statusWrapper():
             group_module = self.output_modules.get(group)
             if group_module:
                 group_module['module'].force_update()
+
+    def report_exception(self, msg, notify_user=True):
+        """
+        Report details of an exception to the user.
+        This should only be called within an except: block Details of the
+        exception are reported eg filename, line number and exception type.
+        """
+        try:
+            # we need to make sure to delete tb even if things go wrong.
+            exc_type, exc_obj, tb = sys.exc_info()
+            stack = extract_tb(tb)
+            filename = os.path.basename(stack[-1][0])
+            line_no = stack[-1][1]
+            msg = '{} ({}) {} line {}'.format(
+                msg, exc_type.__name__, filename, line_no)
+        except:
+            # something went wrong report what we can.
+            msg = '{} '.format(msg)
+        finally:
+            # delete tb!
+            del tb
+        # log the exception and notify user
+        syslog(LOG_WARNING, msg)
+        if notify_user:
+            self.notify_user(msg, level='error')
 
     def create_output_modules(self):
         """


### PR DESCRIPTION
Following on from the improved module errors.  This PR adds better information to exceptions that occur inside py3status.

Again we show `filename` and `line number` which really help with debugging issues.

```
self.config = {}
```
has been added just in case the exception happens before it has been set in `setup()`