### PR TITLE
Notification message fixes

### DIFF
--- a/py3status/__init__.py
+++ b/py3status/__init__.py
@@ -16,7 +16,7 @@ def main():
         py3 = Py3statusWrapper()
         py3.setup()
     except KeyboardInterrupt:
-        py3.notify_user('setup interrupted (KeyboardInterrupt)')
+        py3.notify_user('Setup interrupted (KeyboardInterrupt).')
         sys.exit(0)
     except Exception:
         py3.report_exception('Setup error')

--- a/py3status/core.py
+++ b/py3status/core.py
@@ -225,7 +225,7 @@ class Py3statusWrapper():
                                module))
             except Exception:
                 err = sys.exc_info()[1]
-                msg = 'loading module "{}" failed ({})'.format(module, err)
+                msg = 'Loading module "{}" failed ({}).'.format(module, err)
                 self.notify_user(msg, level='warning')
 
     def setup(self):
@@ -287,14 +287,14 @@ class Py3statusWrapper():
 
     def notify_user(self, msg, level='error'):
         """
-        Make use of i3-nagbar to display errors and warnings to the user.
+        Display notification to user via i3-nagbar or send-notify
         We also make sure to log anything to keep trace of it.
+
+        NOTE: Message should end with a '.' for consistency.
         """
         dbus = self.config.get('dbus_notify')
         if not dbus:
-            msg = 'py3status: {}.'.format(msg)
-        else:
-            msg = '{}.'.format(msg)
+            msg = 'py3status: {}'.format(msg)
         if level != 'info':
             msg += ' Please try to fix this and reload i3wm (Mod+Shift+R)'
         try:
@@ -391,9 +391,12 @@ class Py3statusWrapper():
         Report details of an exception to the user.
         This should only be called within an except: block Details of the
         exception are reported eg filename, line number and exception type.
+
         Because stack trace information outside of py3status or it's modules is
         not helpful in actually finding and fixing the error, we try to locate
         the first place that the exception affected our code.
+
+        NOTE: msg should not end in a '.' for consistency.
         """
         # Get list of paths that our stack trace should be found in.
         py3_paths = [os.path.dirname(__file__)]
@@ -419,11 +422,11 @@ class Py3statusWrapper():
                 if found:
                     break
             # all done!  create our message.
-            msg = '{} ({}) {} line {}'.format(
+            msg = '{} ({}) {} line {}.'.format(
                 msg, exc_type.__name__, filename, line_no)
         except:
             # something went wrong report what we can.
-            msg = '{} '.format(msg)
+            msg = '{}.'.format(msg)
         finally:
             # delete tb!
             del tb
@@ -502,7 +505,7 @@ class Py3statusWrapper():
                 if not i3status_thread.is_alive():
                     err = i3status_thread.error
                     if not err:
-                        err = 'i3status died horribly'
+                        err = 'I3status died horribly.'
                     self.notify_user(err)
                     break
 
@@ -511,7 +514,7 @@ class Py3statusWrapper():
                     # don't spam the user with i3-nagbar warnings
                     if not hasattr(self.events_thread, 'nagged'):
                         self.events_thread.nagged = True
-                        err = 'events thread died, click events are disabled'
+                        err = 'Events thread died, click events are disabled.'
                         self.notify_user(err, level='warning')
 
                 # update i3status time/tztime items

--- a/py3status/module.py
+++ b/py3status/module.py
@@ -334,7 +334,7 @@ class Module(Thread):
                         syslog(LOG_INFO,
                                'method {} returned {} '.format(meth, result))
                 except Exception:
-                    msg = 'Instance `{}`, user method `{}` Failed'
+                    msg = 'Instance `{}`, user method `{}` failed'
                     msg = msg.format(self.module_full_name, meth)
                     notify = not self.nagged
                     self._py3_wrapper.report_exception(msg, notify_user=notify)

--- a/py3status/module.py
+++ b/py3status/module.py
@@ -334,7 +334,7 @@ class Module(Thread):
                         syslog(LOG_INFO,
                                'method {} returned {} '.format(meth, result))
                 except Exception:
-                    msg = 'Instance `{}`, user method `{}` Failed.'
+                    msg = 'Instance `{}`, user method `{}` Failed'
                     msg = msg.format(self.module_full_name, meth)
                     notify = not self.nagged
                     self._py3_wrapper.report_exception(msg, notify_user=notify)


### PR DESCRIPTION
There were some inconsistencies between messages to the user.  Having two routes `i3-nagbar` and `notify-send` made some of this more noticeable.

This cleans up the messages.

I'm not sure if it is still too complicated.  eg `notify_user()` wants a sentence `This is my error.` whereas `report_exception()` wants a fragment `Error happened`.  Maybe we should just add/remove any full stops so that the user does not need to care so much.

I'd be happy to add that, but it might limit us in some circumstances.