### PR TITLE
Core to do all i3bar output communication

### DIFF
--- a/py3status/core.py
+++ b/py3status/core.py
@@ -490,6 +490,9 @@ class Py3statusWrapper():
         interval = self.config['interval']
         last_sec = 0
 
+        # start our output
+        print_line('{"version": 1, "click_events": true}[[]')
+
         # main loop
         while True:
             sec = int(time())
@@ -529,11 +532,10 @@ class Py3statusWrapper():
                         out = module['module'].get_latest()
                         output[index] = ', '.join([dumps(x) for x in out])
 
-                prefix = i3status_thread.last_prefix
                 # build output string
                 out = ','.join([x for x in output if x])
                 # dump the line to stdout
-                print_line('{}[{}]'.format(prefix, out))
+                print_line(',[{}]'.format(out))
 
             # sleep a bit before doing this again to avoid killing the CPU
             sleep(0.1)

--- a/py3status/helpers.py
+++ b/py3status/helpers.py
@@ -2,20 +2,6 @@ from __future__ import print_function
 
 import sys
 
-from json import loads
-from contextlib import contextmanager
-
-
-@contextmanager
-def jsonify(string):
-    """
-    Transform the given string to a JSON in a context manager fashion.
-    """
-    prefix = ''
-    if string.startswith(','):
-        prefix, string = ',', string[1:]
-    yield (prefix, loads(string))
-
 
 def print_line(line):
     """

--- a/py3status/i3status.py
+++ b/py3status/i3status.py
@@ -10,9 +10,9 @@ from syslog import syslog, LOG_INFO
 from tempfile import NamedTemporaryFile
 from threading import Thread
 from time import time
+from json import loads
 
 from py3status.profiling import profile
-from py3status.helpers import jsonify, print_line
 from py3status.events import IOPoller
 
 TIME_FORMAT = '%Y-%m-%d %H:%M:%S'
@@ -146,7 +146,6 @@ class I3status(Thread):
         self.json_list = None
         self.json_list_ts = None
         self.last_output = None
-        self.last_prefix = None
         self.lock = py3_wrapper.lock
         self.new_update = False
         self.py3_wrapper = py3_wrapper
@@ -529,24 +528,14 @@ class I3status(Thread):
                     while self.lock.is_set():
                         line = self.poller_inp.readline()
                         if line:
+                            # remove leading comma if present
+                            if line[0] == ',':
+                                line = line[1:]
                             if line.startswith('[{'):
-                                print_line(line)
-                                with jsonify(line) as (prefix, json_list):
-                                    self.last_output = json_list
-                                    self.last_prefix = ','
-                                    self.set_responses(json_list)
+                                json_list = loads(line)
+                                self.last_output = json_list
+                                self.set_responses(json_list)
                                 self.ready = True
-                            elif not line.startswith(','):
-                                if 'version' in line:
-                                    header = loads(line)
-                                    header.update({'click_events': True})
-                                    line = dumps(header)
-                                print_line(line)
-                            else:
-                                with jsonify(line) as (prefix, json_list):
-                                    self.last_output = json_list
-                                    self.last_prefix = prefix
-                                    self.set_responses(json_list)
                         else:
                             err = self.poller_err.readline()
                             code = i3status_pipe.poll()
@@ -579,12 +568,6 @@ class I3status(Thread):
         # mock thread is_alive() method
         self.is_alive = lambda: True
 
-        # mock i3status base output
-        init_output = ['{"click_events": true, "version": 1}', '[', '[]']
-        for line in init_output:
-            print_line(line)
-
         # mock i3status output parsing
         self.last_output = []
-        self.last_prefix = ','
         self.update_json_list()


### PR DESCRIPTION
Currently `i3status.py` reads the input from `i3status` and then either outputs it to `i3bar` or passes it to `core.py`.

This commit allows `core.py` to do all the out bound communication.

The basic output to i3bar is a json stream starting with version info dict and then an array of arrays.  Before we needed to worry about if we needed a comma between the items etc and would look at the i3status output to determine this.

Now we just send our 'version dict' followed by opening the array and sending an empty initial array.  After that i3bar just expects `,[......]` for each line which is simple to provide.

In turn this simplifies `i3status.py` and we can also remove the `jsonify` helper

One additional advantage (and actually the reason I started this) is that we no longer output the first json sent by `i3status` which makes the start-up a slightly cleaner user experience.

`events.py` is also 'cleaned' up to remove it's need for `jsonify()`