### PR TITLE
cache async modules until event was received

### DIFF
--- a/py3status/modules/scratchpad_async.py
+++ b/py3status/modules/scratchpad_async.py
@@ -37,7 +37,7 @@ class Py3status:
         t.start()
 
     def scratchpad_counter(self, i3s_output_list, i3s_config):
-        response = {'cached_until': 0}
+        response = {'cached_until': self.py3.CACHE_FOREVER}
 
         if self.urgent:
             response['color'] = self.color_urgent
@@ -54,6 +54,7 @@ class Py3status:
             cons = conn.get_tree().scratchpad().leaves()
             self.urgent = any(con for con in cons if con.urgent)
             self.count = len(cons)
+            self.py3.update()
 
         conn = i3ipc.Connection()
 

--- a/py3status/modules/window_title_async.py
+++ b/py3status/modules/window_title_async.py
@@ -81,13 +81,16 @@ class Py3status:
 
             if title_changed or layout_changed:
                 self.title = get_title(conn)
+                self.py3.update()
 
         def clear_title(*args):
             self.title = self.empty_title
+            self.py3.update()
 
         conn = i3ipc.Connection()
 
         self.title = get_title(conn)  # set title on startup
+        self.py3.update()
 
         # The order of following callbacks is important!
 
@@ -106,7 +109,7 @@ class Py3status:
 
     def window_title(self, i3s_output_list, i3s_config):
         resp = {
-            'cached_until': 0,  # update ASAP
+            'cached_until': self.py3.CACHE_FOREVER,  # cache until event received
             'full_text': self.title,
         }
 


### PR DESCRIPTION
Use the new py3 style for async modules to cache their responses forever and force an update as soon as an event was received.