### PR TITLE
Py3status sleep

### DIFF
--- a/py3status/core.py
+++ b/py3status/core.py
@@ -236,9 +236,9 @@ class Py3statusWrapper():
         # set the Event lock
         self.lock.set()
 
-        # SIGUSR2 will be recieced from i3bar indicating that all output should
+        # SIGUSR2 will be received from i3bar indicating that all output should
         # stop and we should consider py3status suspended.  It is however
-        # important that any processes using i3 ipc should continue to recieve
+        # important that any processes using i3 ipc should continue to receive
         # those events otherwise it can lead to a stall in i3.
         signal(SIGUSR2, self.i3bar_stop)
         # SIGCONT indicates output should be resumed.

--- a/py3status/core.py
+++ b/py3status/core.py
@@ -486,9 +486,23 @@ class Py3statusWrapper():
         self.i3bar_running = False
         # i3status should be stopped
         self.i3status_thread.suspend_i3status()
+        self.sleep_modules()
 
     def i3bar_start(self, signum, frame):
         self.i3bar_running = True
+        self.wake_modules()
+
+    def sleep_modules(self):
+        # Put all py3modules to sleep so they stop updating
+        for module in self.output_modules.values():
+            if module['type'] == 'py3status':
+                module['module'].sleep()
+
+    def wake_modules(self):
+        # Wake up all py3modules.
+        for module in self.output_modules.values():
+            if module['type'] == 'py3status':
+                module['module'].wake()
 
     @profile
     def run(self):


### PR DESCRIPTION
This extends SIGUSR2 to sleep py3status modules.  We should really sleep when we have been told to.

When sleeping we stop the update timer.  On waking we reset the timer for the requested cache_until if in the future, else do an update immediately.

```
# pause py3status
killall -USR2 py3status

# restart py3status
killall -CONT py3status
```