### PR TITLE
Allows non-strings to be notified on dbus

### DIFF
--- a/py3status/core.py
+++ b/py3status/core.py
@@ -302,7 +302,8 @@ class Py3statusWrapper():
         if not dbus:
             msg = 'py3status: {}'.format(msg)
         if level != 'info':
-            msg += ' Please try to fix this and reload i3wm (Mod+Shift+R)'
+            fix_msg = '{} Please try to fix this and reload i3wm (Mod+Shift+R)'
+            msg = fix_msg.format(msg)
         try:
             log_level = LOG_LEVELS.get(level, LOG_ERR)
             syslog(log_level, msg)


### PR DESCRIPTION
When using dbus for non `info` non-string messages would fail eg `notify_user([1, 2, 3])`

This fixes the issue.