### PR TITLE
allow groups to function with python2

### DIFF
--- a/py3status/modules/group.py
+++ b/py3status/modules/group.py
@@ -64,7 +64,7 @@ class Py3status:
     color = None
     cycle = 0
     fixed_width = True
-    format = "{output}"
+    format = u'{output}'
 
     def __init__(self):
         self.items = []


### PR DESCRIPTION
The groups module had a unicode issue and would fail under python2.

This resolves it.