### PR TITLE
Composites fun

### DIFF
--- a/py3status/events.py
+++ b/py3status/events.py
@@ -203,6 +203,13 @@ class Events(Thread):
                         dispatched = True
                         break
 
+        if not dispatched:
+            # find container that holds the module and call its onclick
+            module_groups = self.i3s_config['.module_groups']
+            containers = module_groups.get(module_name)
+            for container in containers:
+                self.process_event(container, event)
+
         # fall back to i3bar_click_events.py module if present
         if not dispatched:
             module = self.i3bar_click_events_module()

--- a/py3status/events.py
+++ b/py3status/events.py
@@ -313,6 +313,19 @@ class Events(Thread):
                     instance = event.get('instance', '')
                     name = event.get('name', '')
 
+                    # composites have an index which is passed to i3bar with
+                    # the instance.  We need to separate this out here and
+                    # clean up the event.  If index
+                    # is an integer type then cast it as such.
+                    if ' ' in instance:
+                        instance, index = instance.split(' ', 1)
+                        try:
+                            index = int(index)
+                        except ValueError:
+                            pass
+                        event['index'] = index
+                        event['instance'] = instance
+
                     # i3status module name guess
                     instance, name = self.i3status_mod_guess(instance, name)
                     if self.config['debug']:
@@ -322,7 +335,7 @@ class Events(Thread):
                                 '{} {}'.format(name, instance).strip()))
 
                     # guess the module config name
-                    module_name = '{} {}'.format(name, instance).strip()
+                    module_name = '{} {}'.format(name, instance.split(' ')[0]).strip()
                     # do the work
                     self.process_event(module_name, event)
 

--- a/py3status/events.py
+++ b/py3status/events.py
@@ -203,12 +203,11 @@ class Events(Thread):
                         dispatched = True
                         break
 
-        if not dispatched:
-            # find container that holds the module and call its onclick
-            module_groups = self.i3s_config['.module_groups']
-            containers = module_groups.get(module_name)
-            for container in containers:
-                self.process_event(container, event)
+        # find container that holds the module and call its onclick
+        module_groups = self.i3s_config['.module_groups']
+        containers = module_groups.get(module_name)
+        for container in containers:
+            self.process_event(container, event)
 
         # fall back to i3bar_click_events.py module if present
         if not dispatched:

--- a/py3status/module.py
+++ b/py3status/module.py
@@ -172,6 +172,9 @@ class Module(Thread):
         composite = response['composite']
         if not isinstance(composite, list):
             raise Exception('Expecting composite')
+        # if list is empty nothing to do
+        if not len(composite):
+            return
         if 'full_text' in response:
             raise Exception('Conflict "full_text" and "composite" in response')
         # set universal options on last component

--- a/py3status/module.py
+++ b/py3status/module.py
@@ -170,8 +170,10 @@ class Module(Thread):
         We need to respect the universal options too.
         """
         composite = response['composite']
-        if not composite:
+        if not isinstance(composite, list):
             raise Exception('Expecting composite')
+        if 'full_text' in response:
+            raise Exception('Conflict "full_text" and "composite" in response')
         # set universal options on last component
         composite[-1].update(self.module_options)
         # calculate any min width (we split this across components)

--- a/py3status/modules/README.md
+++ b/py3status/modules/README.md
@@ -445,25 +445,50 @@ shown in the i3bar.  The active group can be changed by a user click.  If the
 click is not used by the group module then it will be passed down to the
 displayed module.
 
-Modules can be i3status core modules or py3status modules.
+Modules can be i3status core modules or py3status modules.  The active group
+can be cycled through automatically.
 
-Additionally the active group can be cycled through automatically.
+The group can handle clicks by reacting to any that are made on it or its
+content or it can use a button and only respond to clicks on that.
+The way it does this is selected via the `click_mode` option.
 
 Configuration parameters:
+  - `align` Text alignment when fixed_width is set
+    can be 'left', 'center' or 'right' *(default 'left')*
   - `button_next` Button that when clicked will switch to display next module.
     Setting to `0` will disable this action. *(default 4)*
   - `button_prev` Button that when clicked will switch to display previous
     module.  Setting to `0` will disable this action. *(default 5)*
-  - `color` If the active module does not supply a color use this if set.
-    Format as hex value eg `'#0000FF'` *(default None)*
+  - `button_toggle` Button that when clicked toggles the group content being
+    displayed between open and closed.
+    This action is ignored if `{button}` is not in the format.
+    Setting to `0` will disable this action *(default 1)*
+  - `click_mode` This defines how clicks are handled by the group.
+    If set to `all` then the group will respond to all click events.  This
+    may cause issues with contained modules that use the same clicks that
+    the group captures.  If set to `button` then only clicks that are
+    directly on the `{button}` are acted on.  The group
+    will need `{button}` in its format.
+    *(default 'all')*
   - `cycle` Time in seconds till changing to next module to display.
     Setting to `0` will disable cycling. *(default 0)*
   - `fixed_width` Reduce the size changes when switching to new group
     *(default True)*
-  - `format` Format for module output. *(default "{output}")*
+  - `format` Format for module output.
+    (default "{output}" if click_mode is 'all',
+    "{output} {button}" if click_mode 'button')
+  - `format_button_open` Format for the button when group closed
+    *(default '+')*
+  - `format_button_closed` Format for the button when group open
+    *(default  '-')*
+  - `format_closed` Format for module output when closed.
+    *(default "{button}")*
+  - `open` Is the group open and displaying its content. Has no effect if
+    `{button}` not in format *(default True)*
 
 
 Format of status string placeholders:
+  - `{button}` The button to open/close or change the displayed group
   - `{output}` Output of current active module
 
 Example:
@@ -477,7 +502,8 @@ order += "group disks"
 
 group disks {
     cycle = 30
-    format = "Disks: {output}"
+    format = "Disks: {output} {button}"
+    click_mode = "button"
 
     disk "/" {
         format = "/ %avail"

--- a/py3status/modules/group.py
+++ b/py3status/modules/group.py
@@ -26,9 +26,9 @@ Configuration parameters:
         (default True)
     format: Format for module output. (default "{output}{button}")
     format_button_open: Format for the button when group closed
-        (default ' 🡙')
+        (default '*')
     format_button_closed: Format for the button when group open
-        (default  '🡘')
+        (default  '*')
     format_closed: Format for module output when closed. (default "{button}")
     open: Is the group open and displaying its content (default True)
 
@@ -76,8 +76,8 @@ class Py3status:
     cycle = 0
     fixed_width = False
     format = u'{output} {button}'
-    format_button_open = u'🡙'
-    format_button_closed = u'🡘'
+    format_button_open = u'*'
+    format_button_closed = u'*'
     format_closed = u'{button}'
     open = True
 

--- a/py3status/modules/group.py
+++ b/py3status/modules/group.py
@@ -77,8 +77,8 @@ class Py3status:
     cycle = 0
     fixed_width = True
     format = u'{output}{control}'
-    format_control_open = ' 🡙'
-    format_control_closed = '🡘'
+    format_control_open = u' 🡙'
+    format_control_closed = u'🡘'
     open = True
 
     def __init__(self):

--- a/py3status/modules/timer.py
+++ b/py3status/modules/timer.py
@@ -1,0 +1,149 @@
+# -*- coding: utf-8 -*-
+"""
+A simple countdown timer.
+
+This is a very basic countdown timer.  You can change the timer length as well
+as pausing, restarting and resetting it.  Currently this is more of a demo of a
+composite and not really ready for production usage.
+
+As well as a general clean it would be nice to have it play an alarm when the
+time is up.  Ideally it should also run as a thread so that the alarm will go
+off at the correct time.  It would be nice too if it could also survive a
+py3status restart.
+
+"""
+
+from time import time
+
+
+class Py3status:
+    """
+    """
+    # available configuration parameters
+
+    def __init__(self):
+        self.time = 60
+        self.running = False
+        self.end_time = None
+        self.time_left = None
+        self.color = None
+
+    def timer(self, i3s_output_list, i3s_config):
+
+        def make_2_didget(value):
+            value = str(value)
+            if len(value) == 1:
+                value = '0' + value
+            return value
+
+        if self.running:
+            t = int(self.end_time - time())
+            if t <= 0:
+                t = 0
+                self.running = False
+                self.color = '#FF0000'
+                self.time_left = None
+        else:
+            if self.time_left:
+                t = self.time_left
+            else:
+                t = self.time
+
+        # Hours
+        hours, t = divmod(t, 3600)
+        # Minutes
+        mins, t = divmod(t, 60)
+        # Seconds
+        seconds = t
+
+        if self.running:
+            cached_until = time() + 1
+        else:
+            cached_until = self.py3.CACHE_FOREVER
+
+        response = {
+            'cached_until': cached_until,
+            'composite': [
+                {
+                    'color': '#CCCCCC',
+                    'full_text': 'Timer ',
+                },
+                {
+                    'color': self.color,
+                    'full_text': str(hours),
+                    'index': 'hours',
+                },
+                {
+                    'color': '#CCCCCC',
+                    'full_text': ':',
+                },
+                {
+                    'color': self.color,
+                    'full_text': make_2_didget(mins),
+                    'index': 'mins',
+                },
+                {
+                    'color': '#CCCCCC',
+                    'full_text': ':',
+                },
+                {
+                    'color': self.color,
+                    'full_text': make_2_didget(seconds),
+                    'index': 'seconds',
+                },
+            ]
+        }
+        return response
+
+    def on_click(self, i3s_output_list, i3s_config, event):
+        deltas = {
+            'hours': 3600,
+            'mins': 60,
+            'seconds': 1
+        }
+        index = event['index']
+        button = event['button']
+
+        if button == 1:
+            if self.running:
+                self.running = False
+                self.time_left = int(self.end_time - time())
+                self.color = '#FFFF00'
+            else:
+                self.running = True
+                if self.time_left:
+                    self.end_time = time() + self.time_left
+                else:
+                    self.end_time = time() + self.time
+                self.color = '#00FF00'
+
+        if button == 2:
+            self.running = False
+            self.time_left = None
+            self.color = None
+
+        if not self.running:
+            if self.time_left:
+                t = self.time_left
+            else:
+                t = self.time
+            if button == 4:
+                t += deltas.get(index, 0)
+            if button == 5:
+                t -= deltas.get(index, 0)
+                if t < 0:
+                    t = 0
+            if self.time_left:
+                self.time_left = t
+            else:
+                self.time = t
+
+        self.text = str(event['index'])
+
+if __name__ == "__main__":
+    x = Py3status()
+    config = {
+        'color_good': '#00FF00',
+        'color_bad': '#FF0000',
+    }
+    print(x.timer([], config))


### PR DESCRIPTION
This PR introduces composites, this was inspired by  #176 by @cornerman 

For full functionality i3bar 4.12 is needed but it will work (though degraded) for previous versions.

__What does this offer?__

* py3status treats a composite as it would any other normal module output (so can be added to groups etc).

* a modules response can be split into parts that together make a composite.

* each part of a composite can define it's own color.

* each part of a composite can catch it's own click events.

* the whole module can still catch events for any component part.

* `group` module now no longer conflicts with the click events of its contents

* `group` module can now be opened/closed to hide show its content.


__Demo__

The power of composites can be seen by adding the following to your `i3status.conf`.  It introduces the `timer` module.  You can change the time via mouse wheel by hours/minutes/seconds clicking starts/pauses and resets the timer.  The timer is in an updated group that can be opened/closed as well as changing the displayed content (timer or static_string)

```
order += "group demo"

group demo {
    timer {}
    static_string hello { format = 'Hello' }
}
```

for old i3bar versions that do not support `separator` and `separator_block_width` the separator will be shown but otherwise it will function as expected.

The changes to core py3status are not that big, but the group module did need quite a few changes.

__Changes__

* Instead of a response containing `full_text` it can contain `composite` which is a list of responses.

* Events now include `index` which is either the part count of a composite or the index name supplied in the response