### PR TITLE
Proposed vpn_status module

### DIFF
--- a/py3status/modules/vpn_status.py
+++ b/py3status/modules/vpn_status.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python3
+"""
+Drop-in replacement for i3status run_watch VPN module.
+
+Expands on the i3status module by displaying the name of the connected vpn
+using pydbus. Asynchronously updates on dbus signals unless check_pid is True.
+
+Configuration parameters:
+    cache_timeout: How often to refresh in seconds when check_pid is True.
+        (default 10)
+    check_pid: If True, act just like the default i3status module.
+        (default False)
+    format: Format of the output.
+        (default 'VPN: {name}')
+    pidfile: Same as i3status.conf pidfile, checked when check_pid is True.
+        (default '/sys/class/net/vpn0/dev_id')
+
+Format string parameters:
+    {name} The name and/or status of the VPN.
+
+Requires:
+    pydbus: Which further requires PyGi. Check your distribution's repositories.
+
+@author Nathan Smith <nathan AT praisetopia.org>
+"""
+
+from pydbus import SystemBus
+from gi.repository import GObject
+from threading import Thread
+from os import path
+from time import time, sleep
+
+
+class Py3status:
+    # Available Configuration Parameters
+    cache_timeout = 10
+    check_pid = False
+    format = "VPN: {name}"
+    pidfile = '/sys/class/net/vpn0/dev_id'
+
+    def __init__(self):
+        self.thread_started = False
+        self.active = []
+
+    def _start_handler_thread(self):
+        """Called once to start the event handler thread."""
+        # Create handler thread
+        t = Thread(target=self._start_loop)
+        t.daemon = True
+
+        # Start handler thread
+        t.start()
+        self.thread_started = True
+
+    def _start_loop(self):
+        """Starts main event handler loop, run in handler thread t."""
+        # Create our main loop, get our bus, and add the signal handler
+        loop = GObject.MainLoop()
+        bus = SystemBus()
+        manager = bus.get(".NetworkManager")
+        manager.onPropertiesChanged = self._vpn_signal_handler
+
+        # Loop forever
+        loop.run()
+
+    def _vpn_signal_handler(self, args):
+        """Called on NetworkManager PropertiesChanged signal"""
+        # Args is a dictionary of changed properties
+        # We only care about changes in ActiveConnections
+        active = "ActiveConnections"
+        # Compare current ActiveConnections to last seen ActiveConnections
+        if active in args.keys() and sorted(self.active) != sorted(args[active]):
+            self.active = args[active]
+            self.py3.update()
+
+    def _get_vpn_status(self):
+        """Returns None if no VPN active, Id if active."""
+        # Sleep for a bit to let any changes in state finish
+        sleep(0.3)
+        # Check if any active connections are a VPN
+        bus = SystemBus()
+        for name in self.active:
+            conn = bus.get(".NetworkManager", name)
+            if conn.Vpn:
+                return conn.Id
+        # No active VPN
+        return None
+
+    def _check_pid(self):
+        """Returns True if pidfile exists, False otherwise."""
+        return path.isfile(self.pidfile)
+
+    # Method run by py3status
+    def return_status(self, i3s_outputs, i3s_config):
+        """Returns response dict"""
+        # Start signal handler thread if it should be running
+        if not self.check_pid and not self.thread_started:
+            self._start_handler_thread()
+
+        # Set 'no', color_bad as default output. Replaced if VPN active.
+        name = "no"
+        color = i3s_config["color_bad"]
+
+        # If we are acting like the default i3status module
+        if self.check_pid:
+            if self._check_pid():
+                name = "yes"
+                color = i3s_config["color_good"]
+
+        # Otherwise, find the VPN name, if it is active
+        else:
+            vpn = self._get_vpn_status()
+            if vpn:
+                name = vpn
+                color = i3s_config["color_good"]
+
+        # Format and create the response dict
+        full_text = self.format.format(name=name)
+        response = {
+            'full_text': full_text,
+            'color': color,
+            'cached_until': self.py3.CACHE_FOREVER
+        }
+
+        # Cache forever unless in check_pid mode
+        if self.check_pid:
+            response["cached_until"] = time() + self.cache_timeout
+        return response
+
+
+if __name__ == "__main__":
+    x = Py3status()
+    config = {
+        'color_bad': '#FF0000',
+        'color_degraded': '#FFFF00',
+        'color_good': '#00FF00'
+    }
+    while True:
+        print(x.return_status([], config))
+        sleep(1)


### PR DESCRIPTION
The main reason I started using py3status was that I use multiple VPNs while at home (one for school, one for work) and it would help to know which is enabled, rather than i3status's unhelpful yes or no output. So, I wrote a small module that replaces the default vpn pidfile watch that i3status uses.

The only improvement is to display the active vpn name, which is retrieved with python-NetworkManager (which is just a wrapper for dbus-python). Otherwise, it's a drop-in replacement; there's even an option to act just like i3status and check if the given pidfile exists.

I tried my best to meet the docstring format. Let me know if I missed something. My only real concern is that I don't know how it acts without NetworkManager or python-NetworkManager installed. It's not a large or complicated module by any means, but I thought I'd share.