### PR TITLE
flake8 line length max 79

### DIFF
--- a/py3status/docstrings.py
+++ b/py3status/docstrings.py
@@ -241,7 +241,8 @@ def update_docstrings():
                 out.append(row)
                 if not replaced:
                     out = out + [
-                        ''.join(_to_docstring(modules_dict[mod])).strip() + '\n'
+                        ''.join(_to_docstring(modules_dict[mod])).strip() +
+                        '\n'
                     ]
                     replaced = True
                 if lines:
@@ -285,7 +286,8 @@ def check_docstrings(show_diff=False, config=None):
                 create_readme(readme).split('\n'), create_readme(
                     modules_readme).split('\n'))))
         else:
-            print_stderr('\nUse `py3status docstring check diff` to view diff.')
+            print_stderr()
+            print_stderr('Use `py3status docstring check diff` to view diff.')
 
 
 def update_readme_for_modules(modules):

--- a/py3status/i3status.py
+++ b/py3status/i3status.py
@@ -340,7 +340,9 @@ class I3status(Thread):
                     if group_name:
                         # update the items in the group
                         config[group_name]['items'].append(section_name)
-                        section = config['.module_groups'].setdefault(section_name, [])
+                        section = config['.module_groups'].setdefault(
+                            section_name, []
+                        )
                         if group_name not in section:
                             section.append(group_name)
                         if not self.valid_config_param(section_name):

--- a/py3status/module.py
+++ b/py3status/module.py
@@ -141,21 +141,27 @@ class Module(Thread):
         if 'separator' in mod_config:
             separator = mod_config['separator']
             if not isinstance(separator, bool):
-                raise TypeError("invalid 'separator' attribute, should be a bool")
+                err = "invalid 'separator' attribute, should be a bool"
+                raise TypeError(err)
 
             self.module_options['separator'] = separator
 
         if 'separator_block_width' in mod_config:
-            separator_block_width = mod_config['separator_block_width']
-            if not isinstance(separator_block_width, int):
-                raise TypeError("invalid 'separator_block_width' attribute, should be an int")
+            sep_block_width = mod_config['separator_block_width']
+            if not isinstance(sep_block_width, int):
+                err = "invalid 'separator_block_width' attribute, "
+                err += "should be an int"
+                raise TypeError(err)
 
-            self.module_options['separator_block_width'] = separator_block_width
+            self.module_options['separator_block_width'] = sep_block_width
 
         if 'align' in mod_config:
             align = mod_config['align']
-            if not (isinstance(align, str) and align.lower() in ("left", "center", "right")):
-                raise ValueError("invalid 'align' attribute, valid values are: left, center, right")
+            if not (isinstance(align, str) and
+                    align.lower() in ("left", "center", "right")):
+                err = "invalid 'align' attribute, valid values are:"
+                err += ' left, center, right'
+                raise ValueError(err)
 
             self.module_options['align'] = align
 
@@ -385,7 +391,8 @@ class Module(Thread):
             # don't be hasty mate
             # set timer to do update next time one is needed
             if not self.sleeping:
-                delay = max(cache_time - time(), self.config['minimum_interval'])
+                delay = max(cache_time - time(),
+                            self.config['minimum_interval'])
                 self.timer = Timer(delay, self.run)
                 self.timer.start()
 

--- a/py3status/modules/arch_updates.py
+++ b/py3status/modules/arch_updates.py
@@ -49,7 +49,8 @@ class Py3status:
         pacman_updates = self._check_pacman_updates()
         if self.include_aur:
             aur_updates = self._check_aur_updates()
-            results = self.format.format(pacman=pacman_updates, aur=aur_updates)
+            results = self.format.format(pacman=pacman_updates,
+                                         aur=aur_updates)
         else:
             results = self.format.format(pacman=str(pacman_updates))
 

--- a/py3status/modules/clementine.py
+++ b/py3status/modules/clementine.py
@@ -12,6 +12,8 @@ Requires:
 from time import time
 from subprocess import check_output
 
+CMD = 'qdbus org.mpris.clementine /TrackList org.freedesktop.MediaPlayer'
+
 
 class Py3status:
     """
@@ -23,8 +25,10 @@ class Py3status:
         """
         Get the current song metadatas (artist - title)
         """
-        track_id = check_output('qdbus org.mpris.clementine /TrackList org.freedesktop.MediaPlayer.GetCurrentTrack', shell=True)
-        metadatas = check_output('qdbus org.mpris.clementine /TrackList org.freedesktop.MediaPlayer.GetMetadata {}'.format(track_id.decode()), shell=True)
+        track_id = check_output(CMD + '.GetCurrentTrack', shell=True)
+        metadatas = check_output(
+            CMD + '.GetMetadata {}'.format(track_id.decode()), shell=True
+        )
         lines = metadatas.decode('utf-8').split('\n')
         lines = filter(None, lines)
 

--- a/py3status/modules/dpms.py
+++ b/py3status/modules/dpms.py
@@ -34,7 +34,8 @@ class Py3status:
 
         return {
             'full_text': self.format_on if self.run else self.format_off,
-            'color': self.color_on or i3s_config['color_good'] if self.run else self.color_off or i3s_config['color_bad']
+            'color': self.color_on or i3s_config['color_good'] if self.run
+            else self.color_off or i3s_config['color_bad']
         }
 
     def on_click(self, i3s_output_list, i3s_config, event):

--- a/py3status/modules/icinga2.py
+++ b/py3status/modules/icinga2.py
@@ -6,10 +6,12 @@ Configuration Parameters:
     base_url: the base url to the icinga-web2 services list
     cache_timeout: how often the data should be updated
     color: define a color for the output
-    disable_acknowledge: enable or disable counting of acknowledged service problems
+    disable_acknowledge: enable or disable counting of acknowledged
+        service problems
     format: define a format string like "CRITICAL: %d"
     password: password to authenticate against the icinga-web2 interface
-    status: set the status you want to optain (0=OK,1=WARNING,2=CRITICAL,3=UNKNOWN)
+    status: set the status you want to obtain
+        (0=OK,1=WARNING,2=CRITICAL,3=UNKNOWN)
     user: username to authenticate against the icinga-web2 interface
 
 @author Ben Oswald <ben.oswald@root-space.de>

--- a/py3status/modules/net_rate.py
+++ b/py3status/modules/net_rate.py
@@ -5,7 +5,8 @@ Display the current network transfer rate.
 Configuration parameters:
     all_interfaces: ignore self.interfaces, but not self.interfaces_blacklist
     devfile: location of dev file under /proc
-    format_no_connection: when there is no data transmitted from the start of the plugin
+    format_no_connection: when there is no data transmitted from the
+        start of the plugin
     hide_if_zero: hide indicator if rate == 0
     interfaces: comma separated list of interfaces to track
     interfaces_blacklist: comma separated list of interfaces to ignore
@@ -24,10 +25,16 @@ Format of status string placeholders:
 from __future__ import division  # python2 compatibility
 from time import time
 
-INITIAL_MULTI = 1024  # initial multiplier, if you want to get rid of first bytes, set to 1 to disable
-MULTIPLIER_TOP = 999  # if value is greater, divide it with UNIT_MULTI and get next unit from UNITS
-UNIT_MULTI = 1024  # value to divide if rate is greater than MULTIPLIER_TOP
-UNITS = ["kb/s", "mb/s", "gb/s", "tb/s", ]  # list of units, first one - value/INITIAL_MULTI, second - value/1024, third - value/1024^2, etc...
+# initial multiplier, if you want to get rid of first bytes, set to 1 to
+# disable
+INITIAL_MULTI = 1024
+# if value is greater, divide it with UNIT_MULTI and get next unit from UNITS
+MULTIPLIER_TOP = 999
+# value to divide if rate is greater than MULTIPLIER_TOP
+UNIT_MULTI = 1024
+# list of units, first one - value/INITIAL_MULTI, second - value/1024, third -
+# value/1024^2, etc...
+UNITS = ["kb/s", "mb/s", "gb/s", "tb/s", ]
 
 
 class Py3status:
@@ -68,7 +75,9 @@ class Py3status:
             self.left_align = len(str(MULTIPLIER_TOP)) + 1 + self.precision
         else:
             self.left_align = len(str(MULTIPLIER_TOP))
-        self.value_format = "{value:%s.%sf} {unit}" % (self.left_align, self.precision)
+        self.value_format = "{value:%s.%sf} {unit}" % (
+            self.left_align, self.precision
+        )
 
         ns = self._get_stat()
         deltas = {}

--- a/py3status/modules/ns_checker.py
+++ b/py3status/modules/ns_checker.py
@@ -3,8 +3,9 @@
 Display DNS resolution success on a configured domain.
 
 This module launch a simple query on each nameservers for the specified domain.
-Nameservers are dynamically retrieved. The FQDN is the only one mandatory parameter.
-It's also possible to add additional nameservers by appending them in nameservers list.
+Nameservers are dynamically retrieved. The FQDN is the only one mandatory
+parameter.  It's also possible to add additional nameservers by appending them
+in nameservers list.
 
 The default resolver can be overwritten with my_resolver.nameservers parameter.
 

--- a/py3status/modules/nvidia_temp.py
+++ b/py3status/modules/nvidia_temp.py
@@ -38,9 +38,6 @@ class Py3status:
     temp_separator = '|'
 
     def nvidia_temp(self, i3s_output_list, i3s_config):
-        # The whole command:
-        # nvidia-smi -q -d TEMPERATURE | sed -nr 's/.*Current Temp.*:[[:space:]]*([0-9]+).*/\1/p'
-
         out = check_output(shlex.split("nvidia-smi -q -d TEMPERATURE"))
         temps = re.findall(TEMP_RE, out.decode("utf-8"))
 

--- a/py3status/modules/player_control.py
+++ b/py3status/modules/player_control.py
@@ -10,7 +10,8 @@ Provides an icon to control simple functions of audio/video players:
 Configuration parameters:
     debug: enable verbose logging (bool) (default: False)
     supported_players: supported players (str) (comma separated list)
-    volume_tick: percentage volume change on mouse wheel (int) (positive number or None to disable it)
+    volume_tick: percentage volume change on mouse wheel (int) (positive number
+        or None to disable it)
 
 @author Federico Ceratto <federico.ceratto@gmail.com>, rixx
 @license BSD

--- a/py3status/modules/spaceapi.py
+++ b/py3status/modules/spaceapi.py
@@ -5,7 +5,8 @@ Display if your favorite hackerspace is open or not.
 Configuration Parameters:
     cache_timeout: Set timeout between calls in seconds
     closed_color: color if space is closed
-    closed_text: text if space is closed, strftime parameters will be translated
+    closed_text: text if space is closed, strftime parameters
+        will be translated
     open_color: color if space is open
     open_text: text if space is open, strftime parmeters will be translated
     url: URL to SpaceAPI json file of your space
@@ -75,7 +76,9 @@ class Py3status:
 
             if 'lastchange' in data['state'].keys():
                 # apply strftime to full and short text
-                dt = datetime.datetime.fromtimestamp(data['state']['lastchange'])
+                dt = datetime.datetime.fromtimestamp(
+                    data['state']['lastchange']
+                )
                 response['full_text'] = dt.strftime(response['full_text'])
                 response['short_text'] = dt.strftime(response['short_text'])
 

--- a/py3status/modules/spotify.py
+++ b/py3status/modules/spotify.py
@@ -4,8 +4,10 @@ Display information about the current song playing on Spotify.
 
 Configuration parameters:
     cache_timeout: how often to update the bar
-    color_offline: text color when spotify is not running, defaults to color_bad
-    color_paused: text color when song is stopped or paused, defaults to color_degraded
+    color_offline: text color when spotify is not running,
+        defaults to color_bad
+    color_paused: text color when song is stopped or paused,
+        defaults to color_degraded
     color_playing: text color when song is playing, defaults to color_good
     format: see placeholders below
     format_down: define output if spotify is not running
@@ -68,8 +70,9 @@ class Py3status:
                 microtime = metadata.get('mpris:length')
                 rtime = str(timedelta(microseconds=microtime))[:-7]
                 title = metadata.get('xesam:title')
-                playback_status = self.player.Get('org.mpris.MediaPlayer2.Player',
-                                                  'PlaybackStatus')
+                playback_status = self.player.Get(
+                    'org.mpris.MediaPlayer2.Player', 'PlaybackStatus'
+                )
                 if playback_status.strip() == 'Playing':
                     color = self.color_playing or i3s_config['color_good']
                 else:

--- a/py3status/modules/sysdata.py
+++ b/py3status/modules/sysdata.py
@@ -155,7 +155,8 @@ class Py3status:
 
         if max(cpu_usage, mem_used_percent/100) <= self.med_threshold / 100.0:
             response['color'] = i3s_config['color_good']
-        elif max(cpu_usage, mem_used_percent/100) <= self.high_threshold / 100.0:
+        elif (max(cpu_usage, mem_used_percent/100) <=
+                self.high_threshold / 100.0):
             response['color'] = i3s_config['color_degraded']
         else:
             response['color'] = i3s_config['color_bad']

--- a/py3status/modules/vnstat.py
+++ b/py3status/modules/vnstat.py
@@ -4,7 +4,9 @@ Display vnstat statistics.
 
 Coloring rules.
 
-If value is bigger that dict key, status string will turn to color, specified in the value.
+If value is bigger that dict key, status string will turn to color, specified
+in the value.
+
 Example:
         coloring = {
         800: "#dddd00",
@@ -34,7 +36,8 @@ def get_stat(statistics_type):
     Get statistics from devfile in list of lists of words
     """
     def filter_stat():
-        for x in check_output(["vnstat", "--dumpdb"]).decode("utf-8").splitlines():
+        out = check_output(["vnstat", "--dumpdb"]).decode("utf-8").splitlines()
+        for x in out:
             if x.startswith("{};0;".format(statistics_type)):
                 return x
 
@@ -44,7 +47,9 @@ def get_stat(statistics_type):
         print("Looks like you haven't installed or configured vnstat!")
         raise e
     except ValueError:
-        raise RuntimeError("vnstat returned wrong output, maybe it's configured wrong or module is outdated")
+        err = "vnstat returned wrong output, "
+        err += "maybe it's configured wrong or module is outdated"
+        raise RuntimeError(err)
 
     up = (int(txm) * 1024 + int(txk)) * 1024
     down = (int(rxm) * 1024 + int(rxk)) * 1024
@@ -63,9 +68,13 @@ class Py3status:
     cache_timeout = 180
     coloring = {}
     format = "{total}"
-    initial_multi = 1024  # initial multiplier, if you want to get rid of first bytes, set to 1 to disable
+    # initial multiplier, if you want to get rid of first bytes, set to 1 to
+    # disable
+    initial_multi = 1024
     left_align = 0
-    multiplier_top = 1024  # if value is greater, divide it with unit_multi and get next unit from units
+    # if value is greater, divide it with unit_multi and get next unit from
+    # units
+    multiplier_top = 1024
     precision = 1
     statistics_type = "d"  # d for daily, m for monthly
     unit_multi = 1024  # value to divide if rate is greater than multiplier_top
@@ -81,8 +90,12 @@ class Py3status:
         self.last_stat = get_stat(self.statistics_type)
         self.last_time = time()
         self.last_interface = None
-        self.value_format = "{value:%s.%sf} {unit}" % (self.left_align, self.precision)
-        self.units = ["kb", "mb", "gb", "tb", ]  # list of units, first one - value/initial_multi, second - value/1024, third - value/1024^2, etc...
+        self.value_format = "{value:%s.%sf} {unit}" % (
+            self.left_align, self.precision
+        )
+        # list of units, first one - value/initial_multi, second - value/1024,
+        # third - value/1024^2, etc...
+        self.units = ["kb", "mb", "gb", "tb", ]
 
     def _divide_and_format(self, value):
         """

--- a/py3status/modules/window_title_async.py
+++ b/py3status/modules/window_title_async.py
@@ -74,10 +74,12 @@ class Py3status:
 
             # check if we need to update title due to changes
             # in the workspace layout
-            layout_changed = (hasattr(e, "binding") and
-                              (e.binding.command.startswith("layout") or
-                               e.binding.command.startswith("move container") or
-                               e.binding.command.startswith("border")))
+            layout_changed = (
+                hasattr(e, "binding") and
+                (e.binding.command.startswith("layout") or
+                 e.binding.command.startswith("move container") or
+                 e.binding.command.startswith("border"))
+            )
 
             if title_changed or layout_changed:
                 self.title = get_title(conn)
@@ -109,7 +111,7 @@ class Py3status:
 
     def window_title(self, i3s_output_list, i3s_config):
         resp = {
-            'cached_until': self.py3.CACHE_FOREVER,  # cache until event received
+            'cached_until': self.py3.CACHE_FOREVER,
             'full_text': self.title,
         }
 

--- a/py3status/modules/xrandr.py
+++ b/py3status/modules/xrandr.py
@@ -175,7 +175,8 @@ class Py3status:
 
         # Preserve the order in which user defined the output combinations
         if whitelist:
-            available = reversed([comb for comb in whitelist if comb in available])
+            available = reversed([comb for comb in whitelist
+                                  if comb in available])
 
         self.available_combinations = deque(available)
         self.combinations_map = combinations_map

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(
     version='2.9',
     author='Ultrabug',
     author_email='ultrabug@ultrabug.net',
-    description='py3status is an extensible i3status wrapper written in python',
+    description='py3status: an extensible i3status wrapper written in python',
     long_description=read('README.rst'),
     url='https://github.com/ultrabug/py3status',
     download_url='https://github.com/ultrabug/py3status/tags',

--- a/tox.ini
+++ b/tox.ini
@@ -9,6 +9,6 @@ commands=
     flake8
 
 [flake8]
-max-line-length = 160
+max-line-length = 79
 exclude = .ropeproject,.tox
 show-source = True


### PR DESCRIPTION
This PR fixes line lengths to the PEP8 recommended max length of 79.

I have tried to do it in a way that minimizes the changes and maintains readability (something that yapf often fails at imho)

There are a few places where some refactoring was needed ( `xrandr_rotate.py`) but again I've tried to avoid this where possible.
