### PR TITLE
fix XDG_CONFIG_HOME #204

### DIFF
--- a/py3status/core.py
+++ b/py3status/core.py
@@ -55,11 +55,19 @@ class Py3statusWrapper():
         # defaults
         config = {
             'cache_timeout': 60,
-            'include_paths': ['{}/.i3/py3status/'.format(home_path)],
             'interval': 1,
             'minimum_interval': 0.1,  # minimum module update interval
             'dbus_notify': False,
         }
+
+        # include path to search for user modules
+        config['include_paths'] = [
+            '{}/.i3/py3status/'.format(home_path),
+            '{}/i3status/py3status'.format(os.environ.get(
+                'XDG_CONFIG_HOME', '{}/.config'.format(home_path))),
+            '{}/i3/py3status'.format(os.environ.get(
+                'XDG_CONFIG_HOME', '{}/.config'.format(home_path))),
+        ]
 
         # package version
         try:
@@ -175,7 +183,7 @@ class Py3statusWrapper():
         }
         """
         user_modules = {}
-        for include_path in sorted(self.config['include_paths']):
+        for include_path in self.config['include_paths']:
             include_path = os.path.abspath(include_path) + '/'
             if not os.path.isdir(include_path):
                 continue
@@ -183,6 +191,9 @@ class Py3statusWrapper():
                 if not f_name.endswith('.py'):
                     continue
                 module_name = f_name[:-3]
+                # do not overwrite modules if already found
+                if module_name in user_modules:
+                    pass
                 user_modules[module_name] = (include_path, f_name)
         return user_modules
 

--- a/py3status/core.py
+++ b/py3status/core.py
@@ -73,8 +73,9 @@ class Py3statusWrapper():
         # respect i3status' file detection order wrt issue #43
         i3status_config_file_candidates = [
             '{}/.i3status.conf'.format(home_path),
-            '{}/.config/i3status/config'.format(os.environ.get(
-                'XDG_CONFIG_HOME', home_path)), '/etc/i3status.conf',
+            '{}/i3status/config'.format(os.environ.get(
+                'XDG_CONFIG_HOME', '{}/.config'.format(home_path))),
+            '/etc/i3status.conf',
             '{}/i3status/config'.format(os.environ.get('XDG_CONFIG_DIRS',
                                                        '/etc/xdg'))
         ]


### PR DESCRIPTION
This fixes the XDG_CONFIG_HOME issue.

I'm not sure what other paths if any we want to add from that issue #204 

It looks like we cover all the i3status default locations https://i3wm.org/i3status/manpage.html#_options