### PR TITLE
move -b runtime option alphabetically and add to README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -110,6 +110,8 @@ You can see the help of py3status by issuing `py3status -h`:
 ::
 
     -h, --help            show this help message and exit
+    -b, --dbus-notify     use notify-send to send user notifications rather than
+                        i3-nagbar, requires a notification daemon eg dunst
     -c I3STATUS_CONF, --config I3STATUS_CONF
                           path to i3status config file
     -d, --debug           be verbose in syslog

--- a/py3status/core.py
+++ b/py3status/core.py
@@ -92,6 +92,14 @@ class Py3statusWrapper():
         parser = argparse.ArgumentParser(
             description='The agile, python-powered, i3status wrapper')
         parser = argparse.ArgumentParser(add_help=True)
+        parser.add_argument('-b',
+                            '--dbus-notify',
+                            action="store_true",
+                            default=False,
+                            dest="dbus_notify",
+                            help="""use notify-send to send user notifications
+                                    rather than i3-nagbar,
+                                    requires a notification daemon eg dunst""")
         parser.add_argument('-c',
                             '--config',
                             action="store",
@@ -103,12 +111,6 @@ class Py3statusWrapper():
                             '--debug',
                             action="store_true",
                             help="be verbose in syslog")
-        parser.add_argument('-b',
-                            '--dbus-notify',
-                            action="store_true",
-                            default=False,
-                            dest="dbus_notify",
-                            help="use notify-send to send user notifications")
         parser.add_argument('-i',
                             '--include',
                             action="append",


### PR DESCRIPTION
This should be in the main readme

* add -b, --dbus-notify option to README.rst

* move option so they are alphabetical for `py3status -h`