### PR TITLE
TRIVIAL: remove repeated line in module.py

### DIFF
--- a/py3status/module.py
+++ b/py3status/module.py
@@ -39,7 +39,6 @@ class Module(Thread):
         self.module_inst = ''.join(module.split(' ')[1:])
         self.module_name = module.split(' ')[0]
         self.new_update = False
-        self.module_full_name = module
         self.nagged = False
         self.sleeping = False
         self.timer = None


### PR DESCRIPTION
You can't see it in the diff but this line is repeated just before the diff starts

```
        self.module_full_name = module      <---- HERE
        self.module_inst = ''.join(module.split(' ')[1:])
        self.module_name = module.split(' ')[0]
        self.new_update = False
        self.module_full_name = module      <---- HERE
```