### PR TITLE
modules: sysdata: substract cached mem from the used mem

### DIFF
--- a/py3status/modules/sysdata.py
+++ b/py3status/modules/sysdata.py
@@ -81,6 +81,14 @@ class GetData:
         total_mem = int(mem_data[mem_index + 1]) / 1024.
         used_mem = int(mem_data[mem_index + 2]) / 1024.
 
+        # Substract cached memory from the used memory
+        try:
+            cached_index = mem_data.index('cached')
+            cached_mem = int(mem_data[mem_index + 1 + cached_index]) / 1024.
+            used_mem -= cached_mem
+        except:
+            pass
+
         # Caculate percentage
         used_mem_percent = int(used_mem / (total_mem / 100))
 


### PR DESCRIPTION
The `used memory` number reported by `free -m` is misleading, since it includes the memory used for disk cache. An OS kernel tries to allocate all spare memory for disk cache and readily gives it back to processes. The difference `(used_mem - cached_mem)` seems to be a more convinient measure of RAM usage.