### PR TITLE
insync cleanups

### DIFF
--- a/py3status/modules/README.md
+++ b/py3status/modules/README.md
@@ -34,6 +34,8 @@
 
 **[imap](#imap)** — Display the unread messages count from your IMAP account.
 
+**[insync](#insync)** — Get current insync status
+
 **[keyboard_layout](#keyboard_layout)** — Display the current active keyboard layout.
 
 **[mpd_status](#mpd_status)** — Display information from mpd.
@@ -583,6 +585,30 @@ Format of status string placeholders:
   - `{unseen}` number of unread emails
 
 **author** obb
+
+---
+
+### <a name="insync"></a>insync
+
+Get current insync status
+
+Thanks to Iain Tatch <iain.tatch@gmail.com> for the script that this is based on.
+
+Configuration parameters:
+  - `cache_timeout` How often we refresh this module in seconds
+    *(default 10)*
+  - `format` Display format to use *(default '{status} {queued}')*
+
+Format status string parameters:
+  - `{status}` Status of Insync
+  - `{queued}` Number of files queued
+
+Requires:
+  - `insync` command line tool
+
+**author** Joshua Pratt <jp10010101010000@gmail.com>
+
+**license** BSD
 
 ---
 

--- a/py3status/modules/insync.py
+++ b/py3status/modules/insync.py
@@ -31,9 +31,7 @@ class Py3status:
     format = '{status} {queued}'
 
     def check_insync(self, i3s_output_list, i3s_config):
-        status = check_output(["insync", "get_status"]).decode()
-        if len(status) > 2:
-            status = status[:-2]
+        status = check_output(["insync", "get_status"]).decode().strip()
         color = i3s_config.get('color_degraded', '')
         if status == "OFFLINE":
             color = i3s_config.get('color_bad', '')
@@ -42,9 +40,9 @@ class Py3status:
             status = "INSYNC"
 
         queued = check_output(["insync", "get_sync_progress"]).decode()
-        queued = queued.split("\\n")
-        if len(queued) > 2 and "queued" in queued[-2]:
-            queued = queued[-2]
+        queued = [q for q in queued.split("\n") if q != '']
+        if len(queued) > 0 and "queued" in queued[-1]:
+            queued = queued[-1]
             queued = queued.split(" ")[0]
         else:
             queued = ""

--- a/py3status/modules/insync.py
+++ b/py3status/modules/insync.py
@@ -1,35 +1,39 @@
 # -*- coding: utf-8 -*-
 
 """
-Gets the current insync status
+Get current insync status
+
+Thanks to Iain Tatch <iain.tatch@gmail.com> for the script that this is based on.
 
 Configuration parameters:
-    format: Display format to use *(default
-        '{status} {queued}'
-        )*
+    cache_timeout: How often we refresh this module in seconds
+        (default 10)
+    format: Display format to use (default '{status} {queued}')
 
 Format status string parameters:
     {status} Status of Insync
     {queued} Number of files queued
 
+Requires:
+    insync: command line tool
+
 @author Joshua Pratt <jp10010101010000@gmail.com>
-Thanks to @author Iain Tatch <iain.tatch@gmail.com> for the script that this is based on
 @license BSD
 """
 
 from time import time
-import subprocess
+from subprocess import check_output
 
 
 class Py3status:
     # available configuration parameters
-    cache_timeout = 1
+    cache_timeout = 10
     format = '{status} {queued}'
 
     def check_insync(self, i3s_output_list, i3s_config):
-        status = str(subprocess.check_output(["/usr/bin/insync", "get_status"]))
-        if len(status) > 5:
-            status = status[2:-3]
+        status = check_output(["insync", "get_status"]).decode()
+        if len(status) > 2:
+            status = status[:-2]
         color = i3s_config.get('color_degraded', '')
         if status == "OFFLINE":
             color = i3s_config.get('color_bad', '')
@@ -37,13 +41,14 @@ class Py3status:
             color = i3s_config.get('color_good', '')
             status = "INSYNC"
 
-        queued = str(subprocess.check_output(["/usr/bin/insync", "get_sync_progress"]))
+        queued = check_output(["insync", "get_sync_progress"]).decode()
         queued = queued.split("\\n")
         if len(queued) > 2 and "queued" in queued[-2]:
             queued = queued[-2]
-            queued = queued.split(" ")[0].replace("b'", "")
+            queued = queued.split(" ")[0]
         else:
             queued = ""
+
         results = self.format.format(status=status, queued=queued)
 
         response = {


### PR DESCRIPTION
@ultrabug I made a few updates to the insync module (I cannot test it though)  Sorry I should have done this on the pull request before but was waiting for a reply on the outstanding comments I'd made first. 

Anyhow I did the following

* some docstring tweaks

* use `insync` not `/usr/bin/insync` to allow more flexible binary location.

* use `decode()` not `str()` for python2 support (and related fixes)

* cache_timeout now `10` rather that `1`

* added to `modules\README.md`


@Cypher1 could you see if this functions as expected and let us know, Thanks