### PR TITLE
Do not set timer if no cache_time

### DIFF
--- a/py3status/module.py
+++ b/py3status/module.py
@@ -105,12 +105,13 @@ class Module(Thread):
 
     def wake(self):
         self.sleeping = False
-        cache_time = self.cache_time
+        if self.cache_time is None:
+            return
         # new style modules can signal they want to cache forever
-        if cache_time == PY3_CACHE_FOREVER:
+        if self.cache_time == PY3_CACHE_FOREVER:
             return
         # restart
-        delay = max(cache_time - time(), 0)
+        delay = max(self.cache_time - time(), 0)
         self.timer = Timer(delay, self.run)
         self.timer.start()
 


### PR DESCRIPTION
With #302 the problem appears to be when we wake a module that does not have its cache_time set 

This PR checks for a cache_time value.

