### PR TITLE
Py3 testing framework

### DIFF
--- a/py3status/module.py
+++ b/py3status/module.py
@@ -286,9 +286,7 @@ class Module(Thread):
 
             # Add the py3 module helper if modules self.py3 is not defined
             if not hasattr(self.module_class, 'py3'):
-                i3s_config = self.i3status_thread.config['general']
-                py3 = Py3(module=self, i3s_config=i3s_config)
-                setattr(self.module_class, 'py3', py3)
+                setattr(self.module_class, 'py3', Py3(self))
 
             # get the available methods for execution
             for method in sorted(dir(class_inst)):

--- a/py3status/module.py
+++ b/py3status/module.py
@@ -286,7 +286,9 @@ class Module(Thread):
 
             # Add the py3 module helper if modules self.py3 is not defined
             if not hasattr(self.module_class, 'py3'):
-                setattr(self.module_class, 'py3', Py3(self))
+                i3s_config = self.i3status_thread.config['general']
+                py3 = Py3(module=self, i3s_config=i3s_config)
+                setattr(self.module_class, 'py3', py3)
 
             # get the available methods for execution
             for method in sorted(dir(class_inst)):

--- a/py3status/module_test.py
+++ b/py3status/module_test.py
@@ -1,0 +1,46 @@
+import inspect
+from time import sleep
+from py3status.py3 import Py3
+
+
+def module_test(module_class, config=None):
+    i3s_config = {
+        'color_bad': '#FF0000',
+        'color_degraded': '#FFFF00',
+        'color_good': '#00FF00'
+    }
+    module = module_class()
+    setattr(module, 'py3', Py3(i3s_config=i3s_config))
+    if config:
+        for key, value in config.items():
+            setattr(module, key, value)
+    methods = []
+    for method_name in sorted(dir(module)):
+        if method_name.startswith('_'):
+            continue
+        if method_name in ['on_click', 'kill', 'py3']:
+            continue
+        if not hasattr(getattr(module_class, method_name, ''), '__call__'):
+            continue
+
+        method = getattr(module, method_name, None)
+        args, vargs, kw, defaults = inspect.getargspec(method)
+        if len(args) == 1:
+            methods.append((method_name, []))
+        else:
+            methods.append((method_name, [[], i3s_config]))
+    while True:
+        try:
+            for method, method_args in methods:
+                print(getattr(module, method)(*method_args))
+            sleep(1)
+        except KeyboardInterrupt:
+            break
+            if hasattr(module, 'kill'):
+                method = getattr(module, 'kill', None)
+                args, vargs, kw, defaults = inspect.getargspec(method)
+                if len(args) == 1:
+                    module.kill()
+                else:
+                    module.kill([], i3s_config)
+            break

--- a/py3status/modules/fedora_updates.py
+++ b/py3status/modules/fedora_updates.py
@@ -44,7 +44,7 @@ class Py3status:
         self._updates = None
         self._security_notice = False
 
-    def check_updates(self):
+    def check_updates(self, i3s_output_list, i3s_config):
         if self._first:
             self._first = False
             response = {
@@ -53,7 +53,6 @@ class Py3status:
             }
             return response
 
-        i3s_config = self.py3.i3s_config()
         output, error = subprocess.Popen(
             ['dnf', 'check-update'],
             stdout=subprocess.PIPE,

--- a/py3status/modules/fedora_updates.py
+++ b/py3status/modules/fedora_updates.py
@@ -25,7 +25,6 @@ Format status string parameters:
 @license BSD
 """
 
-from time import time
 import subprocess
 import re
 
@@ -45,15 +44,16 @@ class Py3status:
         self._updates = None
         self._security_notice = False
 
-    def check_updates(self, i3s_output_list, i3s_config):
+    def check_updates(self):
         if self._first:
             self._first = False
             response = {
-                'cached_until': time(),
+                'cached_until': self.py3.time_in(),
                 'full_text': self.format.format(updates='?')
             }
             return response
 
+        i3s_config = self.py3.i3s_config()
         output, error = subprocess.Popen(
             ['dnf', 'check-update'],
             stdout=subprocess.PIPE,
@@ -80,7 +80,7 @@ class Py3status:
                 color = self.color_degraded or i3s_config['color_degraded']
 
         response = {
-            'cached_until': time() + self.cache_timeout,
+            'cached_until': self.py3.time_in(self.cache_timeout),
             'color': color,
             'full_text': self.format.format(updates=updates)
         }
@@ -91,13 +91,8 @@ if __name__ == "__main__":
     """
     Test this module by calling it directly.
     """
-    from time import sleep
-    x = Py3status()
-    config = {
-        'color_bad': '#FF0000',
-        'color_degraded': '#FFFF00',
-        'color_good': '#00FF00'
-    }
-    while True:
-        print(x.check_updates([], config))
-        sleep(1)
+    """
+    Run module in test mode.
+    """
+    from py3status.module_test import module_test
+    module_test(Py3status)

--- a/py3status/modules/github.py
+++ b/py3status/modules/github.py
@@ -220,3 +220,11 @@ class Py3status:
             cmd = 'xdg-open {}'.format(url)
             call(split(cmd))
             self.py3.prevent_refresh()
+
+
+if __name__ == "__main__":
+    """
+    Run module in test mode.
+    """
+    from py3status.module_test import module_test
+    module_test(Py3status)

--- a/py3status/modules/group.py
+++ b/py3status/modules/group.py
@@ -250,12 +250,7 @@ class Py3status:
 
 if __name__ == "__main__":
     """
-    Test this module by calling it directly.
+    Run module in test mode.
     """
-    from time import sleep
-    x = Py3status()
-    config = {}
-
-    while True:
-        print(x.group([], config))
-        sleep(1)
+    from py3status.module_test import module_test
+    module_test(Py3status)

--- a/py3status/modules/pomodoro.py
+++ b/py3status/modules/pomodoro.py
@@ -218,7 +218,7 @@ class Py3status:
         bar = bar.ljust(self.num_progress_bars)
         return bar
 
-    def pomodoro(self):
+    def pomodoro(self, i3s_output_list, i3s_config):
         """
         Pomodoro response handling and countdown
         """
@@ -269,8 +269,6 @@ class Py3status:
         if self._alert:
             response['urgent'] = True
             self._alert = False
-
-        i3s_config = self.py3.i3s_config()
 
         if not self._running:
             response['color'] = i3s_config['color_bad']

--- a/py3status/modules/pomodoro.py
+++ b/py3status/modules/pomodoro.py
@@ -213,7 +213,7 @@ class Py3status:
         bar = bar.ljust(self.num_progress_bars)
         return bar
 
-    def pomodoro(self, i3s_output_list, i3s_config):
+    def pomodoro(self):
         """
         Pomodoro response handling and countdown
         """
@@ -259,6 +259,8 @@ class Py3status:
             response['urgent'] = True
             self._alert = False
 
+        i3s_config = self.py3.i3s_config()
+
         if not self._running:
             response['color'] = i3s_config['color_bad']
         else:
@@ -288,15 +290,7 @@ class Py3status:
 
 if __name__ == "__main__":
     """
-    Test this module by calling it directly.
+    Run module in test mode.
     """
-    from time import sleep
-    x = Py3status()
-    config = {
-        'color_bad': '#FF0000',
-        'color_degraded': '#FFFF00',
-        'color_good': '#00FF00'
-    }
-    while True:
-        print(x.pomodoro([], config))
-        sleep(1)
+    from py3status.module_test import module_test
+    module_test(Py3status)

--- a/py3status/modules/scratchpad_async.py
+++ b/py3status/modules/scratchpad_async.py
@@ -26,7 +26,7 @@ class Py3status:
     # available configuration parameters
     always_show = False
     color_urgent = "#900000"
-    format = "{} ⌫"
+    format = u"{} ⌫"
 
     def __init__(self):
         self.count = 0
@@ -36,7 +36,7 @@ class Py3status:
         t.daemon = True
         t.start()
 
-    def scratchpad_counter(self, i3s_output_list, i3s_config):
+    def scratchpad_counter(self):
         response = {'cached_until': self.py3.CACHE_FOREVER}
 
         if self.urgent:
@@ -68,15 +68,10 @@ class Py3status:
 
 if __name__ == "__main__":
     """
-    Test this module by calling it directly.
+    Run module in test mode.
     """
-    from time import sleep
-    x = Py3status()
     config = {
-        'color_bad': '#FF0000',
-        'color_degraded': '#FFFF00',
-        'color_good': '#00FF00'
+        'always_show': True
     }
-    while True:
-        print(x.scratchpad_counter([], config))
-        sleep(1)
+    from py3status.module_test import module_test
+    module_test(Py3status, config=config)

--- a/py3status/modules/scratchpad_async.py
+++ b/py3status/modules/scratchpad_async.py
@@ -36,7 +36,7 @@ class Py3status:
         t.daemon = True
         t.start()
 
-    def scratchpad_counter(self):
+    def scratchpad_counter(self, i3s_output_list, i3s_config):
         response = {'cached_until': self.py3.CACHE_FOREVER}
 
         if self.urgent:

--- a/py3status/modules/static_string.py
+++ b/py3status/modules/static_string.py
@@ -9,8 +9,6 @@ Configuration parameters:
 @author frimdo ztracenastopa@centrum.cz
 """
 
-from time import time
-
 
 class Py3status:
     """
@@ -19,9 +17,9 @@ class Py3status:
     color = None
     format = ''
 
-    def static_string(self, i3s_output_list, i3s_config):
+    def static_string(self):
         response = {
-            'cached_until': time() + 60,
+            'cached_until': self.py3.CACHE_FOREVER,
             'color': self.color,
             'full_text': self.format,
         }
@@ -29,9 +27,11 @@ class Py3status:
 
 
 if __name__ == "__main__":
-    x = Py3status()
+    """
+    Run module in test mode.
+    """
     config = {
-        'color_good': '#00FF00',
-        'color_bad': '#FF0000',
+        'format': 'Hello World!'
     }
-    print(x.static_string([], config))
+    from py3status.module_test import module_test
+    module_test(Py3status, config=config)

--- a/py3status/modules/static_string.py
+++ b/py3status/modules/static_string.py
@@ -17,7 +17,7 @@ class Py3status:
     color = None
     format = ''
 
-    def static_string(self):
+    def static_string(self, i3s_output_list, i3s_config):
         response = {
             'cached_until': self.py3.CACHE_FOREVER,
             'color': self.color,

--- a/py3status/modules/timer.py
+++ b/py3status/modules/timer.py
@@ -51,7 +51,7 @@ class Py3status:
             self.alarm = True
         self.timer()
 
-    def timer(self, i3s_output_list, i3s_config):
+    def timer(self):
 
         def make_2_didget(value):
             value = str(value)
@@ -115,7 +115,7 @@ class Py3status:
         }
         return response
 
-    def on_click(self, i3s_output_list, i3s_config, event):
+    def on_click(self, event):
         deltas = {
             'hours': 3600,
             'mins': 60,
@@ -185,9 +185,8 @@ class Py3status:
 
 
 if __name__ == "__main__":
-    x = Py3status()
-    config = {
-        'color_good': '#00FF00',
-        'color_bad': '#FF0000',
-    }
-    print(x.timer([], config))
+    """
+    Run module in test mode.
+    """
+    from py3status.module_test import module_test
+    module_test(Py3status)

--- a/py3status/modules/timer.py
+++ b/py3status/modules/timer.py
@@ -51,7 +51,7 @@ class Py3status:
             self.alarm = True
         self.timer()
 
-    def timer(self):
+    def timer(self, i3s_output_list, i3s_config):
 
         def make_2_didget(value):
             value = str(value)
@@ -115,7 +115,7 @@ class Py3status:
         }
         return response
 
-    def on_click(self, event):
+    def on_click(self, i3s_output_list, i3s_config, event):
         deltas = {
             'hours': 3600,
             'mins': 60,

--- a/py3status/modules/twitch_streaming.py
+++ b/py3status/modules/twitch_streaming.py
@@ -23,8 +23,6 @@ Format of status string placeholders
 @license BSD
 """
 
-# import your useful libs here
-from time import time
 import requests
 
 
@@ -45,12 +43,15 @@ class Py3status:
         display_name_request = requests.get(url)
         self._display_name = display_name_request.json().get('display_name')
 
-    def is_streaming(self, i3s_output_list, i3s_config):
+    def is_streaming(self):
         if self.stream_name is None:
             return {
                 'full_text': 'stream_name missing',
                 'cached_until': self.py3.CACHE_FOREVER
             }
+
+        i3s_config = self.py3.i3s_config()
+
         r = requests.get('https://api.twitch.tv/kraken/streams/' + self.stream_name)
         if not self._display_name:
             self._get_display_name()
@@ -68,20 +69,18 @@ class Py3status:
             full_text = "An unknown error has occurred."
 
         response = {
-            'cached_until': time() + self.cache_timeout,
+            'cached_until': self.py3.time_in(self.cache_timeout),
             'full_text': full_text,
             'color': colour
         }
         return response
 
 if __name__ == "__main__":
-    from time import sleep
-    x = Py3status()
+    """
+    Run module in test mode.
+    """
     config = {
-        'color_bad': '#FF0000',
-        'color_degraded': '#FFFF00',
-        'color_good': '#00FF00'
+        'stream_name': 'moo'
     }
-    while True:
-        print(x.is_streaming([], config))
-        sleep(1)
+    from py3status.module_test import module_test
+    module_test(Py3status, config=config)

--- a/py3status/modules/twitch_streaming.py
+++ b/py3status/modules/twitch_streaming.py
@@ -43,14 +43,12 @@ class Py3status:
         display_name_request = requests.get(url)
         self._display_name = display_name_request.json().get('display_name')
 
-    def is_streaming(self):
+    def is_streaming(self, i3s_output_list, i3s_config):
         if self.stream_name is None:
             return {
                 'full_text': 'stream_name missing',
                 'cached_until': self.py3.CACHE_FOREVER
             }
-
-        i3s_config = self.py3.i3s_config()
 
         r = requests.get('https://api.twitch.tv/kraken/streams/' + self.stream_name)
         if not self._display_name:

--- a/py3status/modules/vpn_status.py
+++ b/py3status/modules/vpn_status.py
@@ -91,10 +91,9 @@ class Py3status:
         return path.isfile(self.pidfile)
 
     # Method run by py3status
-    def return_status(self):
+    def return_status(self, i3s_output_list, i3s_config):
         """Returns response dict"""
 
-        i3s_config = self.py3.i3s_config()
         # Start signal handler thread if it should be running
         if not self.check_pid and not self.thread_started:
             self._start_handler_thread()

--- a/py3status/modules/vpn_status.py
+++ b/py3status/modules/vpn_status.py
@@ -28,7 +28,7 @@ from pydbus import SystemBus
 from gi.repository import GObject
 from threading import Thread
 from os import path
-from time import time, sleep
+from time import sleep
 
 
 class Py3status:
@@ -91,8 +91,10 @@ class Py3status:
         return path.isfile(self.pidfile)
 
     # Method run by py3status
-    def return_status(self, i3s_outputs, i3s_config):
+    def return_status(self):
         """Returns response dict"""
+
+        i3s_config = self.py3.i3s_config()
         # Start signal handler thread if it should be running
         if not self.check_pid and not self.thread_started:
             self._start_handler_thread()
@@ -124,17 +126,12 @@ class Py3status:
 
         # Cache forever unless in check_pid mode
         if self.check_pid:
-            response["cached_until"] = time() + self.cache_timeout
+            response["cached_until"] = self.py3.time_in(self.cache_timeout)
         return response
 
-
 if __name__ == "__main__":
-    x = Py3status()
-    config = {
-        'color_bad': '#FF0000',
-        'color_degraded': '#FFFF00',
-        'color_good': '#00FF00'
-    }
-    while True:
-        print(x.return_status([], config))
-        sleep(1)
+    """
+    Run module in test mode.
+    """
+    from py3status.module_test import module_test
+    module_test(Py3status)

--- a/py3status/modules/window_title_async.py
+++ b/py3status/modules/window_title_async.py
@@ -109,7 +109,7 @@ class Py3status:
 
         conn.main()  # run the event loop
 
-    def window_title(self):
+    def window_title(self, i3s_output_list, i3s_config):
         resp = {
             'cached_until': self.py3.CACHE_FOREVER,
             'full_text': self.title,

--- a/py3status/modules/window_title_async.py
+++ b/py3status/modules/window_title_async.py
@@ -109,7 +109,7 @@ class Py3status:
 
         conn.main()  # run the event loop
 
-    def window_title(self, i3s_output_list, i3s_config):
+    def window_title(self):
         resp = {
             'cached_until': self.py3.CACHE_FOREVER,
             'full_text': self.title,
@@ -120,15 +120,10 @@ class Py3status:
 
 if __name__ == "__main__":
     """
-    Test this module by calling it directly.
+    Run module in test mode.
     """
-    from time import sleep
-    x = Py3status()
     config = {
-        'color_bad': '#FF0000',
-        'color_degraded': '#FFFF00',
-        'color_good': '#00FF00'
+        'always_show': True,
     }
-    while True:
-        print(x.window_title([], config))
-        sleep(1)
+    from py3status.module_test import module_test
+    module_test(Py3status, config=config)

--- a/py3status/py3.py
+++ b/py3status/py3.py
@@ -87,7 +87,8 @@ class Py3:
         request that the module is not refreshed after the event which is the
         default action.
         """
-        self._module.prevent_refresh = True
+        if self._module:
+            self._module.prevent_refresh = True
 
     def notify_user(self, msg, level='info'):
         """

--- a/py3status/py3.py
+++ b/py3status/py3.py
@@ -33,11 +33,14 @@ class Py3:
     def __init__(self, module=None, i3s_config=None):
         self._audio = None
         self._module = module
-        self._i3s_config = i3s_config
+        self._i3s_config = i3s_config or {}
         # we are running through the whole stack.
         # If testing then module is None.
         if module:
             self._output_modules = module._py3_wrapper.output_modules
+            if not i3s_config:
+                config = self._module.i3status_thread.config['general']
+                self._i3s_config = config
 
     def _get_module_info(self, module_name):
         """


### PR DESCRIPTION
Here is the new module_test to allow for Py3.

I have put it in it's own file for clarity.  I also dropped the MockPy3 from my first attempt as it seems better if the actual Py3 is used.

I've updated all the modules using `py3`.  I also updated `fedora_updates.py` as a demo that it will work for any module.

`Py3` now also has a `i3s_config()` to get the i3s_config.

The module tester can be given a simple config which I've used in a few places eg `static_string`

I also corrected a python2 unicode issue in `scratchpad_async.py`

`vpn_status.py` is a slight pain as the keyboard interrupt doesn't work as it gets caught in the gtk loop rather than the module_test (still for now it is good enough and I've tried too hard to sort it for one day)

A few random other changes as I was in the modules eg `self.py3.time_in()`