### PR TITLE
Restart i3status should it die

### DIFF
--- a/py3status/core.py
+++ b/py3status/core.py
@@ -576,7 +576,6 @@ class Py3statusWrapper():
                     if not err:
                         err = 'I3status died horribly.'
                     self.notify_user(err)
-                    break
 
                 # check events thread
                 if not self.events_thread.is_alive():


### PR DESCRIPTION
Back to issue #302

It looks as though i3status dying kills py3status due to the main thread being killed when the i3status_thread stops.

This patch just restarts i3status if it is killed for whatever reason.  We only do this is i3status has actual worked correctly initially so faulty configs etc would still cause it to stop.