### PR TITLE
logging: log to file, Py3.log() etc

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -105,13 +105,15 @@ You can see the help of py3status by issuing `py3status -h`:
 
     -h, --help            show this help message and exit
     -b, --dbus-notify     use notify-send to send user notifications rather than
-                        i3-nagbar, requires a notification daemon eg dunst
+                          i3-nagbar, requires a notification daemon eg dunst
     -c I3STATUS_CONF, --config I3STATUS_CONF
                           path to i3status config file
     -d, --debug           be verbose in syslog
     -i INCLUDE_PATHS, --include INCLUDE_PATHS
                           include user-written modules from those directories
                           (default ~/.i3/py3status)
+    -l LOG_FILE, --log-file LOG_FILE
+                          path to i3status log file
     -n INTERVAL, --interval INTERVAL
                           update interval in seconds (default 1 sec)
     -s, --standalone      standalone mode, do not use i3status

--- a/py3status/core.py
+++ b/py3status/core.py
@@ -3,17 +3,17 @@ from __future__ import print_function
 import argparse
 import os
 import sys
-from collections import deque
+import time
 
+from collections import deque
 from json import dumps
 from signal import signal
 from signal import SIGTERM, SIGUSR1, SIGUSR2, SIGCONT
 from subprocess import Popen
 from subprocess import call
 from threading import Event
-from time import sleep, time
 from syslog import syslog, LOG_ERR, LOG_INFO, LOG_WARNING
-from traceback import extract_tb
+from traceback import extract_tb, format_tb
 
 import py3status.docstrings as docstrings
 from py3status.events import Events
@@ -38,7 +38,7 @@ class Py3statusWrapper():
         """
         self.config = {}
         self.i3bar_running = True
-        self.last_refresh_ts = time()
+        self.last_refresh_ts = time.time()
         self.lock = Event()
         self.modules = {}
         self.output_modules = {}
@@ -126,6 +126,13 @@ class Py3statusWrapper():
                             dest="include_paths",
                             help="""include user-written modules from those
                             directories (default ~/.i3/py3status)""")
+        parser.add_argument('-l',
+                            '--log-file',
+                            action="store",
+                            dest="log_file",
+                            type=str,
+                            default=None,
+                            help="path to i3status log file")
         parser.add_argument('-n',
                             '--interval',
                             action="store",
@@ -170,6 +177,7 @@ class Py3statusWrapper():
         if options.include_paths:
             config['include_paths'] = options.include_paths
         config['interval'] = int(options.interval)
+        config['log_file'] = options.log_file
         config['standalone'] = options.standalone
         config['i3status_config_path'] = options.i3status_conf
 
@@ -235,9 +243,9 @@ class Py3statusWrapper():
                     my_m.start()
                     self.modules[module] = my_m
                 elif self.config['debug']:
-                    syslog(LOG_INFO,
-                           'ignoring module "{}" (no methods found)'.format(
-                               module))
+                    self.log(
+                        'ignoring module "{}" (no methods found)'.format(
+                            module))
             except Exception:
                 err = sys.exc_info()[1]
                 msg = 'Loading module "{}" failed ({}).'.format(module, err)
@@ -266,8 +274,8 @@ class Py3statusWrapper():
             sys.exit()
 
         if self.config['debug']:
-            syslog(LOG_INFO,
-                   'py3status started with config {}'.format(self.config))
+            self.log(
+                'py3status started with config {}'.format(self.config))
 
         # setup i3status thread
         self.i3status_thread = I3status(self)
@@ -290,17 +298,16 @@ class Py3statusWrapper():
                     self.i3status_thread.mock()
                     i3s_mode = 'mocked'
                     break
-                sleep(0.1)
+                time.sleep(0.1)
         if self.config['debug']:
-            syslog(LOG_INFO, 'i3status thread {} with config {}'.format(
-                i3s_mode,
-                self.i3status_thread.config))
+            self.log('i3status thread {} with config {}'.format(
+                i3s_mode, self.i3status_thread.config))
 
         # setup input events thread
         self.events_thread = Events(self)
         self.events_thread.start()
         if self.config['debug']:
-            syslog(LOG_INFO, 'events thread started')
+            self.log('events thread started')
 
         # suppress modules' ouput wrt issue #20
         if not self.config['debug']:
@@ -313,7 +320,7 @@ class Py3statusWrapper():
         # get a dict of all user provided modules
         user_modules = self.get_user_configured_modules()
         if self.config['debug']:
-            syslog(LOG_INFO, 'user_modules={}'.format(user_modules))
+            self.log('user_modules={}'.format(user_modules))
 
         if self.py3_modules:
             # load and spawn i3status.conf configured modules threads
@@ -333,8 +340,7 @@ class Py3statusWrapper():
             fix_msg = '{} Please try to fix this and reload i3wm (Mod+Shift+R)'
             msg = fix_msg.format(msg)
         try:
-            log_level = LOG_LEVELS.get(level, LOG_ERR)
-            syslog(log_level, msg)
+            self.log(msg, level)
             if dbus:
                 # fix any html entities
                 msg = msg.replace('&', '&amp;')
@@ -357,7 +363,7 @@ class Py3statusWrapper():
         try:
             self.lock.clear()
             if self.config['debug']:
-                syslog(LOG_INFO, 'lock cleared, exiting')
+                self.log('lock cleared, exiting')
             # run kill() method on all py3status modules
             for module in self.modules.values():
                 module.kill()
@@ -373,8 +379,8 @@ class Py3statusWrapper():
 
         To prevent abuse, we rate limit this function to 100ms.
         """
-        if time() > (self.last_refresh_ts + 0.1):
-            syslog(LOG_INFO, 'received USR1, forcing refresh')
+        if time.time() > (self.last_refresh_ts + 0.1):
+            self.log('received USR1, forcing refresh')
 
             # send SIGUSR1 to i3status
             call(['killall', '-s', 'USR1', 'i3status'])
@@ -383,10 +389,9 @@ class Py3statusWrapper():
             self.clear_modules_cache()
 
             # reset the refresh timestamp
-            self.last_refresh_ts = time()
+            self.last_refresh_ts = time.time()
         else:
-            syslog(LOG_INFO,
-                   'received USR1 but rate limit is in effect, calm down')
+            self.log('received USR1 but rate limit is in effect, calm down')
 
     def clear_modules_cache(self):
         """
@@ -421,6 +426,19 @@ class Py3statusWrapper():
             if group_module:
                 group_module['module'].force_update()
 
+    def log(self, msg, level='info'):
+        """
+        log this information to syslog or user provided logfile.
+        """
+        if not self.config['log_file']:
+            # If level was given as a str then convert to actual level
+            level = LOG_LEVELS.get(level, level)
+            syslog(level, msg)
+        else:
+            with open(self.config['log_file'], 'a') as f:
+                log_time = time.strftime("%Y-%m-%d %H:%M:%S")
+                f.write('{}\t{}\t{}\n'.format(log_time, level.upper(), msg))
+
     def report_exception(self, msg, notify_user=True):
         """
         Report details of an exception to the user.
@@ -437,11 +455,14 @@ class Py3statusWrapper():
         py3_paths = [os.path.dirname(__file__)]
         user_paths = self.config['include_paths']
         py3_paths += [os.path.abspath(path) + '/' for path in user_paths]
+        traceback = None
 
         try:
             # We need to make sure to delete tb even if things go wrong.
             exc_type, exc_obj, tb = sys.exc_info()
             stack = extract_tb(tb)
+            error_str = '{}: {}\n'.format(exc_type.__name__, exc_obj)
+            traceback = [error_str] + format_tb(tb)
             # Find first relevant trace in the stack.
             # it should be in py3status or one of it's modules.
             found = False
@@ -466,7 +487,9 @@ class Py3statusWrapper():
             # delete tb!
             del tb
         # log the exception and notify user
-        syslog(LOG_WARNING, msg)
+        self.log(msg, 'warning')
+        if traceback and self.config['log_file']:
+            self.log(''.join(['Traceback\n'] + traceback))
         if notify_user:
             self.notify_user(msg, level='error')
 
@@ -562,9 +585,9 @@ class Py3statusWrapper():
         # main loop
         while True:
             while not self.i3bar_running:
-                sleep(0.1)
+                time.sleep(0.1)
 
-            sec = int(time())
+            sec = int(time.time())
 
             # only check everything is good each second
             if sec > last_sec:
@@ -606,7 +629,7 @@ class Py3statusWrapper():
                 print_line(',[{}]'.format(out))
 
             # sleep a bit before doing this again to avoid killing the CPU
-            sleep(0.1)
+            time.sleep(0.1)
 
     def handle_cli_command(self, config):
         """Handle a command from the CLI.

--- a/py3status/i3status.py
+++ b/py3status/i3status.py
@@ -6,7 +6,6 @@ from json import loads
 from datetime import datetime, timedelta, tzinfo
 from subprocess import Popen
 from subprocess import PIPE
-from syslog import syslog, LOG_INFO
 from signal import SIGUSR2, SIGSTOP, SIG_IGN, signal
 from tempfile import NamedTemporaryFile
 from threading import Thread
@@ -541,9 +540,9 @@ class I3status(Thread):
         try:
             with NamedTemporaryFile(prefix='py3status_') as tmpfile:
                 self.write_tmp_i3status_config(tmpfile)
-                syslog(LOG_INFO,
-                       'i3status spawned using config file {}'.format(
-                           tmpfile.name))
+                self.py3_wrapper.log(
+                    'i3status spawned using config file {}'.format(
+                        tmpfile.name))
 
                 i3status_pipe = Popen(
                     ['i3status', '-c', tmpfile.name],
@@ -585,6 +584,7 @@ class I3status(Thread):
                 except IOError:
                     err = sys.exc_info()[1]
                     self.error = err
+                    self.py3_wrapper.log(err, 'error')
         except OSError:
             # we cleanup the tmpfile ourselves so when the delete will occur
             # it will usually raise an OSError: No such file or directory

--- a/py3status/module.py
+++ b/py3status/module.py
@@ -4,7 +4,6 @@ import inspect
 
 from threading import Thread, Timer
 from collections import OrderedDict
-from syslog import syslog, LOG_INFO
 from time import time
 
 from py3status.py3 import Py3, PY3_CACHE_FOREVER
@@ -89,7 +88,7 @@ class Module(Thread):
         for meth in self.methods:
             self.methods[meth]['cached_until'] = time()
             if self.config['debug']:
-                syslog(LOG_INFO, 'clearing cache for method {}'.format(meth))
+                self._py3_wrapper.log('clearing cache for method {}'.format(meth))
         # cancel any existing timer
         if self.timer:
             self.timer.cancel()
@@ -263,15 +262,15 @@ class Module(Thread):
         # user provided modules take precedence over py3status provided modules
         if self.module_name in user_modules:
             include_path, f_name = user_modules[self.module_name]
-            syslog(LOG_INFO,
-                   'loading module "{}" from {}{}'.format(module, include_path,
-                                                          f_name))
+            self._py3_wrapper.log(
+                'loading module "{}" from {}{}'.format(module, include_path,
+                                                       f_name))
             class_inst = self.load_from_file(include_path + f_name)
         # load from py3status provided modules
         else:
-            syslog(LOG_INFO,
-                   'loading module "{}" from py3status.modules.{}'.format(
-                       module, self.module_name))
+            self._py3_wrapper.log(
+                'loading module "{}" from py3status.modules.{}'.format(
+                    module, self.module_name))
             class_inst = self.load_from_namespace(self.module_name)
 
         if class_inst:
@@ -316,12 +315,12 @@ class Module(Thread):
                             }
                             self.methods[method] = method_obj
 
-        # done, syslog some debug info
+        # done, log some debug info
         if self.config['debug']:
-            syslog(LOG_INFO,
-                   'module "{}" click_events={} has_kill={} methods={}'.format(
-                       module, self.click_events, self.has_kill,
-                       self.methods.keys()))
+            self._py3_wrapper.log(
+                'module "{}" click_events={} has_kill={} methods={}'.format(
+                    module, self.click_events, self.has_kill,
+                    self.methods.keys()))
 
     def click_event(self, event):
         """
@@ -433,8 +432,8 @@ class Module(Thread):
 
                     # debug info
                     if self.config['debug']:
-                        syslog(LOG_INFO,
-                               'method {} returned {} '.format(meth, result))
+                        self._py3_wrapper.log(
+                            'method {} returned {} '.format(meth, result))
                 except Exception:
                     msg = 'Instance `{}`, user method `{}` failed'
                     msg = msg.format(self.module_full_name, meth)

--- a/py3status/modules/player_control.py
+++ b/py3status/modules/player_control.py
@@ -19,7 +19,6 @@ Configuration parameters:
 # Any contributor to this module should add his/her name to the @author
 # line, comma separated.
 
-from syslog import syslog, LOG_INFO
 from time import time, sleep
 import os
 import subprocess
@@ -29,10 +28,6 @@ try:
     dbus_available = True
 except:
     dbus_available = False
-
-
-def log(msg):
-    syslog(LOG_INFO, "player_control: %s" % msg[:100])
 
 
 class Py3status:
@@ -83,7 +78,7 @@ class Py3status:
 
     def _run(self, *args):
         if self.debug:
-            log('running %s' % repr(*args))
+            self.py3.log('running %s' % repr(*args))
 
         subprocess.check_output(*args, stderr=subprocess.STDOUT)
 
@@ -151,11 +146,11 @@ class Py3status:
         for player_name in supported_players:
             if player_name in running_players:
                 if self.debug:
-                    log('found player: %s' % player_name)
+                    self.py3.log('found player: %s' % player_name)
 
                 # those players need the dbus module
                 if player_name in ('vlc') and not dbus_available:
-                    log('%s requires the dbus python module' % player_name)
+                    self.py3.log('%s requires the dbus python module' % player_name)
                     return None
 
                 return player_name

--- a/py3status/modules/pomodoro.py
+++ b/py3status/modules/pomodoro.py
@@ -35,7 +35,6 @@ pomodoro {
 
 from math import ceil
 from threading import Timer
-from syslog import syslog, LOG_INFO
 from time import time
 import os
 
@@ -276,8 +275,8 @@ class Py3status:
             return
 
         if not self._player.available:
-            syslog(LOG_INFO, "pomodoro module: the pyglet or pygame "
-                   "library are required to play sounds")
+            self.py3.log("pomodoro module: the pyglet or pygame "
+                         "library are required to play sounds")
             return
 
         try:

--- a/py3status/modules/xrandr.py
+++ b/py3status/modules/xrandr.py
@@ -70,7 +70,6 @@ from collections import deque
 from collections import OrderedDict
 from itertools import combinations
 from subprocess import call, Popen, PIPE
-from syslog import syslog, LOG_INFO
 from time import sleep, time
 
 
@@ -132,7 +131,7 @@ class Py3status:
                 else:
                     continue
             except Exception as err:
-                syslog(LOG_INFO, 'xrandr error="{}"'.format(err))
+                self.py3.log('xrandr error="{}"'.format(err))
             else:
                 layout[state][output] = {
                     'infos': infos,
@@ -211,8 +210,8 @@ class Py3status:
             if force_refresh:
                 self.displayed = self.available_combinations[0]
             else:
-                syslog(LOG_INFO,
-                       'xrandr error="displayed combination is not available"')
+                self.py3.log(
+                    'xrandr error="displayed combination is not available"')
 
     def _center(self, s):
         """
@@ -262,7 +261,7 @@ class Py3status:
             self.active_comb = combination
             self.active_layout = self.displayed
             self.active_mode = mode
-        syslog(LOG_INFO, 'command "{}" exit code {}'.format(cmd, code))
+        self.py3.log('command "{}" exit code {}'.format(cmd, code))
 
         # move workspaces to outputs as configured
         self._apply_workspaces(combination, mode)
@@ -290,9 +289,9 @@ class Py3status:
                     cmd = 'i3-msg move workspace to output "{}"'.format(output)
                     call(shlex.split(cmd), stdout=PIPE, stderr=PIPE)
                     # log this
-                    syslog(LOG_INFO,
-                           'moved workspace {} to output {}'.format(workspace,
-                                                                    output))
+                    self.py3.log(
+                        'moved workspace {} to output {}'.format(workspace,
+                                                                 output))
 
     def _refresh_py3status(self):
         """

--- a/py3status/py3.py
+++ b/py3status/py3.py
@@ -6,6 +6,9 @@ from subprocess import Popen, call
 
 
 PY3_CACHE_FOREVER = -1
+PY3_LOG_ERROR = 'error'
+PY3_LOG_INFO = 'info'
+PY3_LOG_WARNING = 'warning'
 
 
 class Py3:
@@ -20,6 +23,9 @@ class Py3:
     """
 
     CACHE_FOREVER = PY3_CACHE_FOREVER
+    LOG_ERROR = PY3_LOG_ERROR
+    LOG_INFO = PY3_LOG_INFO
+    LOG_WARNING = PY3_LOG_WARNING
 
     def __init__(self, module):
         self._audio = None
@@ -36,6 +42,20 @@ class Py3:
         'type': module type py3status/i3status
         """
         return self._output_modules.get(module_name)
+
+    def log(self, message, level=LOG_INFO):
+        """
+        Log the message.
+        The level must be one of LOG_ERROR, LOG_INFO or LOG_WARNING
+        """
+        assert level in [
+            self.LOG_ERROR, self.LOG_INFO, self.LOG_WARNING
+        ], 'level must be LOG_ERROR, LOG_INFO or LOG_WARNING'
+
+        if self._module:
+            message = 'Module `{}`: {}'.format(
+                self._module.module_full_name, message)
+            self._module._py3_wrapper.log(message, level)
 
     def update(self, module_name=None):
         """


### PR DESCRIPTION
This is a first draft for some logging changes.  Hopefully this will make it easier to find and fix issue.

* `py3status --log-file /path/to/logfile` option to use that instead of syslog

* `Py3.log(message, level)` helper function, message can be str, list etc for debugging

* `Py3statusWrapper.report_exception()` adds extra traceback info if using custom logfile.

In the future I'd like to add some `LOG_WARNING` constants for py3status internal use but I'd like to do that after the config_parser branch is merged/scrapped. `Py3` supplies and uses constants.

It might also be nice if debug extra logging used `DEBUG` rather than `INFO` in logging