### PR TITLE
events: cleanup and bug fix

### DIFF
--- a/py3status/module.py
+++ b/py3status/module.py
@@ -40,6 +40,7 @@ class Module(Thread):
         self.module_name = module.split(' ')[0]
         self.new_update = False
         self.nagged = False
+        self.prevent_refresh = False
         self.sleeping = False
         self.timer = None
 
@@ -327,6 +328,10 @@ class Module(Thread):
         """
         Execute the 'on_click' method of this module with the given event.
         """
+        # we can prevent request that a refresh after the event has happened
+        # by setting this to True.  Modules should do this via
+        # py3.prevent_refresh()
+        self.prevent_refresh = False
         try:
             click_method = getattr(self.module_class, 'on_click')
             if self.click_events == self.PARAMS_NEW:

--- a/py3status/modules/github.py
+++ b/py3status/modules/github.py
@@ -212,3 +212,4 @@ class Py3status:
             # open github notifications page in default browser
             cmd = 'xdg-open {}'.format(GITHUB_NOTIFICATION_URL)
             call(split(cmd))
+            self.py3.prevent_refresh()

--- a/py3status/py3.py
+++ b/py3status/py3.py
@@ -67,6 +67,14 @@ class Py3:
             self._module._py3_wrapper.events_thread.process_event(
                 module_name, event)
 
+    def prevent_refresh(self):
+        """
+        Calling this function during the on_click() method of a module will
+        request that the module is not refreshed after the event which is the
+        default action.
+        """
+        self._module.prevent_refresh = True
+
     def notify_user(self, msg, level='info'):
         """
         Send notification to user.


### PR DESCRIPTION
This PR does 3 things:

* Fixes issue with i3status modules not being updated on middle click.

* Simplifies `events.py`

* Adds `Py3.prevent_refresh()` that allows modules to prevent their `on_click` events causing a refresh.

The prevent_refresh functionality is for modules that do not need to update after the click event and have slow or resource intensive updates.  I can remove this functionality if not wanted but I think it is useful. 