### PR TITLE
pomodoro module: make clock more configurable

### DIFF
--- a/py3status/modules/pomodoro.py
+++ b/py3status/modules/pomodoro.py
@@ -5,6 +5,7 @@ Display and control a Pomodoro countdown.
 Configuration parameters:
     display_bar: display time in bars when True, otherwise in seconds
     format: define custom display format. See placeholders below
+    format_separator: separator between minutes:seconds
     max_breaks: maximum number of breaks
     num_progress_bars: number of progress bars
     sound_break_end: break end sound (file path) (requires pyglet
@@ -94,6 +95,7 @@ class Py3status:
     # available configuration parameters
     display_bar = False
     format = u'{ss}'
+    format_separator = u"-"
     max_breaks = 4
     num_progress_bars = 5
     sound_break_end = None
@@ -236,9 +238,15 @@ class Py3status:
             mins, seconds = divmod(rest, 60)
 
             if hours:
-                vals['mmss'] = u'%d-%02d-%02d' % (hours, mins, seconds)
+                vals['mmss'] = u'%d%s%02d%s%02d' % (hours,
+                                                    self.format_separator,
+                                                    mins,
+                                                    self.format_separator,
+                                                    seconds)
             else:
-                vals['mmss'] = u'%d-%02d' % (mins, seconds)
+                vals['mmss'] = u'%d%s%02d' % (mins,
+                                              self.format_separator,
+                                              seconds)
 
         if '{bar}' in self.format:
             vals['bar'] = self._setup_bar()


### PR DESCRIPTION
Added config parameter format_separator. By default it is '-' like 00-00.
Now you can set it to something like 00:00, 00x00.