### PR TITLE
Tweak battery_level

### DIFF
--- a/py3status/modules/battery_level.py
+++ b/py3status/modules/battery_level.py
@@ -77,7 +77,7 @@ Obsolete configuration parameters:
         - if 'format' is "{icon}" and 'mode' is "ascii_bar" or "text", this
           parameter is completely ignored
         - if the value is True, the `format` is set to "{icon} {percent}%"
-        default is False
+        default is None
 
 Requires:
     - the `acpi` command line
@@ -127,7 +127,7 @@ class Py3status:
     threshold_full = 100
     # obsolete configuration parameters
     mode = None
-    show_percent_with_blocks = False
+    show_percent_with_blocks = None
 
     def battery_level(self, i3s_output_list, i3s_config):
         self.i3s_config = i3s_config

--- a/py3status/modules/battery_level.py
+++ b/py3status/modules/battery_level.py
@@ -34,14 +34,25 @@ Configuration parameters:
     format_notify_discharging: format of the notification received when you
         click on the module while your comupter is not plugged
         default is "{time_remaining}"
-    hide_when_full: hide any information when battery is fully charged
+    hide_when_full: hide any information when battery is fully charged (when
+        the battery level is greater than or equal to 'threshold_full')
         default is False
     hide_seconds: hide seconds in remaining time
         default is False
     notification: show current battery state as notification on click
         default is False
-    notify_low_level: display notification when battery is running low.
+    notify_low_level: display notification when battery is running low (when
+        the battery level is less than 'threshold_degraded')
         default is False
+    threshold_bad: a percentage below which the battery level should be
+        considered bad
+        default is 10
+    threshold_degraded: a percentage below which the battery level should be
+        considered degraded
+        default is 30
+    threshold_full: a percentage at or above which the battery level should
+        should be considered full
+        default is 100
 
 Format of status string placeholders:
     {ascii_bar} - a string of ascii characters representing the battery level,
@@ -111,6 +122,9 @@ class Py3status:
     hide_seconds = False
     notification = False
     notify_low_level = False
+    threshold_bad = 10
+    threshold_degraded = 30
+    threshold_full = 100
     # obsolete configuration parameters
     mode = None
     show_percent_with_blocks = False
@@ -321,16 +335,14 @@ class Py3status:
         return self.response
 
     def _set_bar_text(self):
-        if self.percent_charged == 100 and self.hide_when_full:
-            self.response['full_text'] = ''
-        else:
-            self.response['full_text'] = self.full_text
+        self.response['full_text'] = '' if self.hide_when_full and \
+            self.percent_charged >= self.threshold_full else self.full_text
 
     def _set_bar_color(self):
         if self.charging:
             self.response['color'] = self.color_charging
             battery_status = 'charging'
-        elif self.percent_charged < 10:
+        elif self.percent_charged < self.threshold_bad:
             self.response['color'] = self.color_bad or self.i3s_config[
                 'color_bad']
             battery_status = 'bad'
@@ -338,14 +350,14 @@ class Py3status:
                     self.last_known_status != battery_status):
                 self._notify('Battery level is critically low ({}%)',
                              'critical')
-        elif self.percent_charged < 30:
+        elif self.percent_charged < self.threshold_degraded:
             self.response['color'] = self.color_degraded or self.i3s_config[
                 'color_degraded']
             battery_status = 'degraded'
             if (self.notify_low_level and
                     self.last_known_status != battery_status):
                 self._notify('Battery level is running low ({}%)', 'normal')
-        elif self.percent_charged == 100:
+        elif self.percent_charged >= self.threshold_full:
             self.response['color'] = self.color_good or self.i3s_config[
                 'color_good']
             battery_status = 'full'

--- a/py3status/modules/battery_level.py
+++ b/py3status/modules/battery_level.py
@@ -53,15 +53,20 @@ Format of status string placeholders:
 
 Obsolete configuration parameters:
     mode: an old way to define `format` parameter. The current behavior is:
-        if 'format' is specified, this parameter is completely ignored
-        if the value is `ascii_bar`, the `format` is set to `"{ascii_bar}"`
-        if the value is `text`, the `format` is set to `"Battery: {percent}"`
-        all other values are ignored
-        there is no default value for this parameter
-    show_percent_with_blocks: an old way to define `format` parameter:
-        if `format` is specified, this parameter is completely ignored
-        if the value is True, the `format` is set to `"{icon} {percent}%"`
-        there is no default value for this parameter
+        - if 'format' is not "{icon}", this parameter is completely ignored
+        - if 'format' is "{icon}" and 'mode' is "ascii_bar", the `format` is
+          set to "{ascii_bar}"
+        - if 'format' is "{icon}" and 'mode' is "text", the `format` is set to
+          "Battery: {percent}"
+        - all other values are ignored
+        default is None
+    show_percent_with_blocks: an old way to define `format` parameter. The
+      current behavior is:
+        - if 'format' is not "{icon}", this parameter is completely ignored
+        - if 'format' is "{icon}" and 'mode' is "ascii_bar" or "text", this
+          parameter is completely ignored
+        - if the value is True, the `format` is set to "{icon} {percent}%"
+        default is False
 
 Requires:
     - the `acpi` command line
@@ -108,7 +113,7 @@ class Py3status:
     notify_low_level = False
     # obsolete configuration parameters
     mode = None
-    show_percent_with_blocks = None
+    show_percent_with_blocks = False
 
     def battery_level(self, i3s_output_list, i3s_config):
         self.i3s_config = i3s_config
@@ -153,18 +158,18 @@ class Py3status:
             stderr=open('/dev/null', 'w'))
 
     def _provide_backwards_compatibility(self):
-        # Backwards compatibility for 'mode' parameter
-        if self.format == FORMAT and self.mode == 'ascii_bar':
-            self.format = "{ascii_bar}"
-        if self.format == FORMAT and self.mode == 'text':
-            self.format = "Battery: {percent}"
-
-        # Backwards compatibility for 'show_percent_with_blocks' parameter
-        if self.format == FORMAT and self.show_percent_with_blocks:
-            self.format = "{icon} {percent}%"
-
-        # Backwards compatibility for '{}' option in format string
-        self.format = self.format.replace('{}', '{percent}')
+        if self.format == FORMAT:
+            # Backwards compatibility for 'mode' parameter
+            if self.mode == 'ascii_bar':
+                self.format = "{ascii_bar}"
+            elif self.mode == 'text':
+                self.format = "Battery: {percent}"
+            # Backwards compatibility for 'show_percent_with_blocks' parameter
+            elif self.show_percent_with_blocks:
+                self.format = "{icon} {percent}%"
+        else:
+            # Backwards compatibility for '{}' option in format string
+            self.format = self.format.replace('{}', '{percent}')
 
     def _extract_battery_information_from_acpi(self, acpi_battery_lines):
         """

--- a/py3status/modules/battery_level.py
+++ b/py3status/modules/battery_level.py
@@ -64,19 +64,19 @@ Format of status string placeholders:
 
 Obsolete configuration parameters:
     mode: an old way to define `format` parameter. The current behavior is:
-        - if 'format' is not "{icon}", this parameter is completely ignored
-        - if 'format' is "{icon}" and 'mode' is "ascii_bar", the `format` is
-          set to "{ascii_bar}"
-        - if 'format' is "{icon}" and 'mode' is "text", the `format` is set to
-          "Battery: {percent}"
-        - all other values are ignored
+        if 'format' is not "{icon}", this parameter is completely ignored
+        if 'format' is "{icon}" and 'mode' is "ascii_bar", the `format` is
+            set to "{ascii_bar}"
+        if 'format' is "{icon}" and 'mode' is "text", the `format` is set to
+            "Battery: {percent}"
+        all other values are ignored
         default is None
     show_percent_with_blocks: an old way to define `format` parameter. The
       current behavior is:
-        - if 'format' is not "{icon}", this parameter is completely ignored
-        - if 'format' is "{icon}" and 'mode' is "ascii_bar" or "text", this
-          parameter is completely ignored
-        - if the value is True, the `format` is set to "{icon} {percent}%"
+        if 'format' is not "{icon}", this parameter is completely ignored
+        if 'format' is "{icon}" and 'mode' is "ascii_bar" or "text", this
+            parameter is completely ignored
+        if the value is True, the `format` is set to "{icon} {percent}%"
         default is None
 
 Requires:

--- a/py3status/modules/pomodoro.py
+++ b/py3status/modules/pomodoro.py
@@ -5,7 +5,6 @@ Display and control a Pomodoro countdown.
 Configuration parameters:
     display_bar: display time in bars when True, otherwise in seconds
     format: define custom display format. See placeholders below
-    format_separator: separator between minutes:seconds
     max_breaks: maximum number of breaks
     num_progress_bars: number of progress bars
     sound_break_end: break end sound (file path) (requires pyglet
@@ -95,7 +94,6 @@ class Py3status:
     # available configuration parameters
     display_bar = False
     format = u'{ss}'
-    format_separator = u"-"
     max_breaks = 4
     num_progress_bars = 5
     sound_break_end = None
@@ -238,15 +236,9 @@ class Py3status:
             mins, seconds = divmod(rest, 60)
 
             if hours:
-                vals['mmss'] = u'%d%s%02d%s%02d' % (hours,
-                                                    self.format_separator,
-                                                    mins,
-                                                    self.format_separator,
-                                                    seconds)
+                vals['mmss'] = u'%d-%02d-%02d' % (hours, mins, seconds)
             else:
-                vals['mmss'] = u'%d%s%02d' % (mins,
-                                              self.format_separator,
-                                              seconds)
+                vals['mmss'] = u'%d-%02d' % (mins, seconds)
 
         if '{bar}' in self.format:
             vals['bar'] = self._setup_bar()

--- a/py3status/modules/pomodoro.py
+++ b/py3status/modules/pomodoro.py
@@ -5,6 +5,7 @@ Display and control a Pomodoro countdown.
 Configuration parameters:
     display_bar: display time in bars when True, otherwise in seconds
     format: define custom display format. See placeholders below
+    format_separator: separator between minutes:seconds
     max_breaks: maximum number of breaks
     num_progress_bars: number of progress bars
     sound_break_end: break end sound (file path) (requires pyglet
@@ -94,6 +95,7 @@ class Py3status:
     # available configuration parameters
     display_bar = False
     format = u'{ss}'
+    format_separator = u"-"
     max_breaks = 4
     num_progress_bars = 5
     sound_break_end = None
@@ -236,9 +238,15 @@ class Py3status:
             mins, seconds = divmod(rest, 60)
 
             if hours:
-                vals['mmss'] = u'%d-%02d-%02d' % (hours, mins, seconds)
+                vals['mmss'] = u'%d%s%02d%s%02d' % (hours,
+                                                    self.format_separator,
+                                                    mins,
+                                                    self.format_separator,
+                                                    seconds)
             else:
-                vals['mmss'] = u'%d-%02d' % (mins, seconds)
+                vals['mmss'] = u'%d%s%02d' % (mins,
+                                              self.format_separator,
+                                              seconds)
 
         if '{bar}' in self.format:
             vals['bar'] = self._setup_bar()


### PR DESCRIPTION
Improve documentation for obsolete `mode` and `show_percent_with_blocks` parameters. Add new parameters for controlling how the battery level is decided to be bad, degraded, or good.