### PR TITLE
pomodoro module: Set default time separator to ":"

### DIFF
--- a/py3status/modules/pomodoro.py
+++ b/py3status/modules/pomodoro.py
@@ -95,7 +95,7 @@ class Py3status:
     # available configuration parameters
     display_bar = False
     format = u'{ss}'
-    format_separator = u"-"
+    format_separator = u":"
     max_breaks = 4
     num_progress_bars = 5
     sound_break_end = None


### PR DESCRIPTION
as defined by ISO8601
following issue #332