### PR TITLE
Stop notify_user rate limiting notifications from modules

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -465,7 +465,7 @@ __trigger_event(module_name, event)__
 
 Trigger an event on a named module.
 
-__notify_user(msg, level='info')__
+__notify_user(msg, level='info', rate_limit=5)__
 
 Send a notification to the user.
 `level` must be `info`, `error` or `warning`.

--- a/doc/README.md
+++ b/doc/README.md
@@ -469,6 +469,8 @@ __notify_user(msg, level='info')__
 
 Send a notification to the user.
 `level` must be `info`, `error` or `warning`.
+`rate_limit` is the time period in seconds during which this message
+should not be repeated.
 
 __prevent_refresh()__
 

--- a/py3status/core.py
+++ b/py3status/core.py
@@ -333,7 +333,10 @@ class Py3statusWrapper():
         NOTE: Message should end with a '.' for consistency.
         """
         dbus = self.config.get('dbus_notify')
-        if not dbus:
+        if dbus:
+            # force msg to be a string
+            msg = '{}'.format(msg)
+        else:
             msg = 'py3status: {}'.format(msg)
         if level != 'info':
             fix_msg = '{} Please try to fix this and reload i3wm (Mod+Shift+R)'

--- a/py3status/core.py
+++ b/py3status/core.py
@@ -325,7 +325,7 @@ class Py3statusWrapper():
             # load and spawn i3status.conf configured modules threads
             self.load_modules(self.py3_modules, user_modules)
 
-    def notify_user(self, msg, level='error'):
+    def notify_user(self, msg, level='error', rate_limit=None):
         """
         Display notification to user via i3-nagbar or send-notify
         We also make sure to log anything to keep trace of it.
@@ -338,13 +338,28 @@ class Py3statusWrapper():
         if level != 'info':
             fix_msg = '{} Please try to fix this and reload i3wm (Mod+Shift+R)'
             msg = fix_msg.format(msg)
-        try:
-            if msg in self.notified_messages:
-                return
-            else:
-                self.log(msg, level)
-                self.notified_messages.add(msg)
+        # Rate limiting. If rate limiting then we need to calculate the time
+        # period for which the message should not be repeated.  We just use
+        # A simple chunked time model where a message cannot be repeated in a
+        # given time period. Messages can be repeated more frequently but must
+        # be in different time periods.
 
+        limit_key = ''
+        if rate_limit:
+            try:
+                limit_key = time.time()//rate_limit
+            except TypeError:
+                pass
+        # We use a hash to see if the message is being repeated.  This is crude
+        # and imperfect but should work for our needs.
+        msg_hash = hash('{}{}'.format(limit_key, msg))
+        if msg_hash in self.notified_messages:
+            return
+        else:
+            self.log(msg, level)
+            self.notified_messages.add(msg_hash)
+
+        try:
             if dbus:
                 # fix any html entities
                 msg = msg.replace('&', '&amp;')

--- a/py3status/core.py
+++ b/py3status/core.py
@@ -1,4 +1,5 @@
 from __future__ import print_function
+from __future__ import division
 
 import argparse
 import os

--- a/py3status/core.py
+++ b/py3status/core.py
@@ -325,7 +325,7 @@ class Py3statusWrapper():
             # load and spawn i3status.conf configured modules threads
             self.load_modules(self.py3_modules, user_modules)
 
-    def notify_user(self, msg, level='error', rate_limit=None):
+    def notify_user(self, msg, level='error', rate_limit=None, key=''):
         """
         Display notification to user via i3-nagbar or send-notify
         We also make sure to log anything to keep trace of it.
@@ -352,7 +352,7 @@ class Py3statusWrapper():
                 pass
         # We use a hash to see if the message is being repeated.  This is crude
         # and imperfect but should work for our needs.
-        msg_hash = hash('{}{}'.format(limit_key, msg))
+        msg_hash = hash('{}#{}#{}'.format(key, limit_key, msg))
         if msg_hash in self.notified_messages:
             return
         else:

--- a/py3status/py3.py
+++ b/py3status/py3.py
@@ -95,13 +95,16 @@ class Py3:
         """
         self._module.prevent_refresh = True
 
-    def notify_user(self, msg, level='info'):
+    def notify_user(self, msg, level='info', rate_limit=5):
         """
-        Send notification to user.
-        level must be 'info', 'error' or 'warning'
+        Send a notification to the user.
+        level must be 'info', 'error' or 'warning'.
+        rate_limit is the time period in seconds during which this message
+        should not be repeated.
         """
+        key = self._module.module_full_name
         self._module._py3_wrapper.notify_user(
-            msg, level=level, rate_limit=5)
+            msg, level=level, rate_limit=rate_limit, key=key)
 
     def time_in(self, seconds=0):
         """

--- a/py3status/py3.py
+++ b/py3status/py3.py
@@ -100,7 +100,8 @@ class Py3:
         Send notification to user.
         level must be 'info', 'error' or 'warning'
         """
-        self._module._py3_wrapper.notify_user(msg, level=level)
+        self._module._py3_wrapper.notify_user(
+            msg, level=level, rate_limit=5)
 
     def time_in(self, seconds=0):
         """


### PR DESCRIPTION
Now that `core.notify_user()` does rate limiting (suppresses duplicates) `py3.notify_user()` does not show output when called if a message is a duplicate.

This is unhelpful for debugging and also it is reasonable for a module to display the same information to the user multiple times.  eg. Pomodoro time is up

This commit adds a rate_limit variable to allow notifications to now be rate limited.  It is set automatically in `py3.notify_user()` at 5 seconds.

It does not strictly limit the rate of duplicate messages but does prevent more than one being shown for every time period, this greatly simplifies things.

I use the hash function to just reduce the weight of our duplicate set.

`rate_limit` could be made available to users via `py3.notify_user()` in the future, or I can add now if wanted.