### PR TITLE
volume_status: color_bad for muted channel

### DIFF
--- a/py3status/modules/volume_status.py
+++ b/py3status/modules/volume_status.py
@@ -146,7 +146,7 @@ class Py3status:
         muted = self._get_muted(output)
 
         # determine the color based on the current volume level
-        color = self._perc_to_color(i3s_config, perc)
+        color = self._perc_to_color(i3s_config, perc if not muted else '0')
 
         # format the output
         text = self._format_output(self.format_muted


### PR DESCRIPTION
Muted channel now will display with "bad color" (with default thresholds)

Reason: muted state must be equal to zero-volume.