### PR TITLE
Ignore ? as battery time_remaining value, because it might exist on b…

### DIFF
--- a/py3status/modules/battery_level.py
+++ b/py3status/modules/battery_level.py
@@ -273,7 +273,7 @@ class Py3status:
             active_battery = None
             inactive_battery = battery_list[:]
             for battery_id in range(0, len(battery_list)):
-                if battery_list[battery_id]["time_remaining"]:
+                if battery_list[battery_id]["time_remaining"] and battery_list[battery_id]["time_remaining"] != '?':
                     active_battery = battery_list[battery_id]
                     del inactive_battery[battery_id]
 

--- a/py3status/modules/battery_level.py
+++ b/py3status/modules/battery_level.py
@@ -273,7 +273,8 @@ class Py3status:
             active_battery = None
             inactive_battery = battery_list[:]
             for battery_id in range(0, len(battery_list)):
-                if battery_list[battery_id]["time_remaining"] and battery_list[battery_id]["time_remaining"] != '?':
+                if (battery_list[battery_id]["time_remaining"]
+                        and battery_list[battery_id]["time_remaining"] != '?'):
                     active_battery = battery_list[battery_id]
                     del inactive_battery[battery_id]
 


### PR DESCRIPTION
…oth batteries.

It seems that the row currently assumes that only the active battery has time_remaining defined, but in fact it is always defined, with value '?' if not known. This patch fixes that to only consider the battery active if the value is also not ?.