### PR TITLE
Better logging/reporting of i3status errors

### DIFF
--- a/py3status/i3status.py
+++ b/py3status/i3status.py
@@ -586,9 +586,7 @@ class I3status(Thread):
                     self.error = err
                     self.py3_wrapper.log(err, 'error')
         except Exception:
-            err = sys.exc_info()[1]
-            self.error = err
-            self.py3_wrapper.log(err, 'error')
+            self.py3_wrapper.report_exception('', notify_user=True)
         self.i3status_pipe = None
 
     def cleanup_tmpfile(self):


### PR DESCRIPTION
This makes issues like #362 much easier to debug as we now report the line number and provide traceback in the logs.