### PR TITLE
Better handling of init errors especially locale issues

### DIFF
--- a/py3status/__init__.py
+++ b/py3status/__init__.py
@@ -13,13 +13,24 @@ except ImportError:
 def main():
     try:
         locale.setlocale(locale.LC_ALL, '')
+    except locale.Error:
+        print('No locale available')
+        sys.exit(2)
+
+    py3 = None
+    try:
         py3 = Py3statusWrapper()
         py3.setup()
     except KeyboardInterrupt:
-        py3.notify_user('Setup interrupted (KeyboardInterrupt).')
+        if py3:
+            py3.notify_user('Setup interrupted (KeyboardInterrupt).')
         sys.exit(0)
-    except Exception:
-        py3.report_exception('Setup error')
+    except Exception as e:
+        if py3:
+            py3.report_exception('Setup error')
+        else:
+            # we cannot report this Exception
+            raise e
         sys.exit(2)
 
     try:


### PR DESCRIPTION
This would help for issue #373 

Basically check for the locale independently

Check we have `py3` available when reporting errors 