### PR TITLE
allow passing unicode to i3status

### DIFF
--- a/py3status/i3status.py
+++ b/py3status/i3status.py
@@ -230,6 +230,8 @@ class I3status(Thread):
             tmpfile.write(text)
         except TypeError:
             tmpfile.write(str.encode(text))
+        except UnicodeEncodeError:
+            tmpfile.write(text.encode('utf-8'))
 
     def write_tmp_i3status_config(self, tmpfile):
         """


### PR DESCRIPTION
This fixes the issue re i3status unicode and python2 #369