### PR TITLE
Events: Better errors and fix for non-displayed modules

### DIFF
--- a/py3status/events.py
+++ b/py3status/events.py
@@ -148,6 +148,8 @@ class Events(Thread):
 
         # get the module that the event is for
         module_info = self.output_modules.get(module_name)
+        if not module_info:
+            return
         module = module_info['module']
         # if module is a py3status one and it has an on_click function then
         # call it.
@@ -229,6 +231,4 @@ class Events(Thread):
                 self.process_event(module_name, event)
 
             except Exception:
-                err = sys.exc_info()[1]
-                self.error = err
-                self.py3_wrapper.log('event failed ({})'.format(err), 'warning')
+                self.py3_wrapper.report_exception('Event failed')


### PR DESCRIPTION
When events fail currently we do not receive a full traceback in the logs etc - this commit adds this it should help fix any event related problems.  A user notification is also triggered by this change when an event error occurs.

It is also possible that a 'corrupt' config can cause events to be triggered when they should not.  Basically if a container is defined but not actually added via order etc and it contains a module that is used elsewhere then an event for the non-setup container module is triggered.  This is an unlikely thing to happen but this just stops it if it does.