### PR TITLE
Add module frame

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -123,6 +123,48 @@ group tz {
 }
 ```
 
+The [frame](
+https://github.com/ultrabug/py3status/blob/master/py3status/modules/README.md#frame
+)
+module also allows you to group several modules together, however in a frame all the modules are shown.  This allows you to have more than one module shown in a group.
+Example usage:
+```
+order += "group frames"
+
+# group showing disk space or times using button to change what is shown.
+group frames {
+    click_mode = "button"
+
+    frame time {
+        tztime la {
+            format = "LA %H:%M"
+            timezone = "America/Los_Angeles"
+        }
+
+        tztime ny {
+            format = "NY %H:%M"
+            timezone = "America/New_York"
+        }
+
+        tztime du {
+            format = "DU %H:%M"
+            timezone = "Asia/Dubai"
+        }
+    }
+
+    frame disks {
+        disk "/" {
+            format = "/ %avail"
+        }
+
+        disk "/home" {
+            format = "/home %avail"
+        }
+    }
+}
+```
+
+
 ## <a name="on_click"></a>Custom click events
 
 py3status allows you to easily add click events to modules in your i3bar.

--- a/doc/README.md
+++ b/doc/README.md
@@ -164,7 +164,9 @@ group tz {
 The [frame](
 https://github.com/ultrabug/py3status/blob/master/py3status/modules/README.md#frame
 )
-module also allows you to group several modules together, however in a frame all the modules are shown.  This allows you to have more than one module shown in a group.
+module also allows you to group several modules together, however in a frame
+all the modules are shown.  This allows you to have more than one module shown
+in a group.
 Example usage:
 ```
 order += "group frames"
@@ -202,6 +204,33 @@ group frames {
 }
 ```
 
+Frames can also have a toggle button to hide/show the content
+
+Example:
+```
+# A frame showing times in different cities.
+# We also have a button to hide/show the content
+
+frame time {
+    format = '{output}{button}'
+    format_separator = ' '  # have space instead of usual i3bar separator
+
+    tztime la {
+        format = "LA %H:%M"
+        timezone = "America/Los_Angeles"
+    }
+
+    tztime ny {
+        format = "NY %H:%M"
+        timezone = "America/New_York"
+    }
+
+    tztime du {
+        format = "DU %H:%M"
+        timezone = "Asia/Dubai"
+    }
+}
+```
 
 ## <a name="on_click"></a>Custom click events
 
@@ -706,6 +735,15 @@ __is_python_2()__
 
 True if the version of python being used is 2.x
 Can be helpful for fixing python 2 compatability issues
+
+__is_my_event(event)__
+
+Checks if an event triggered belongs to the module recieving it.  This
+is mainly for containers who will also recieve events from any children
+they have.
+
+Returns True if the event name and instance match that of the module
+checking.
 
 __get_output(module_name)__
 

--- a/py3status/core.py
+++ b/py3status/core.py
@@ -233,9 +233,8 @@ class Py3statusWrapper():
                 continue
             try:
                 my_m = Module(module, user_modules, self)
-                # only start and handle modules with available methods
+                # only handle modules with available methods
                 if my_m.methods:
-                    my_m.start()
                     self.modules[module] = my_m
                 elif self.config['debug']:
                     self.log(
@@ -593,6 +592,13 @@ class Py3statusWrapper():
         i3status_thread = self.i3status_thread
         config = i3status_thread.config
         self.create_output_modules()
+
+        # start all py3status modules.  We need self.output_modules to have
+        # been initiated before some modules can work correctly.
+        for module in self.output_modules.values():
+            self.log(module)
+            if module['type'] == 'py3status':
+                module['module'].start()
 
         # update queue populate with all py3modules
         self.queue.extend(self.modules)

--- a/py3status/core.py
+++ b/py3status/core.py
@@ -596,7 +596,6 @@ class Py3statusWrapper():
         # start all py3status modules.  We need self.output_modules to have
         # been initiated before some modules can work correctly.
         for module in self.output_modules.values():
-            self.log(module)
             if module['type'] == 'py3status':
                 module['module'].start()
 

--- a/py3status/modules/frame.py
+++ b/py3status/modules/frame.py
@@ -1,21 +1,64 @@
 # -*- coding: utf-8 -*-
 """
-Group two or more modules as a single one.
+Group modules and treat them as a single one.
 
 This can be useful for example when adding modules to a group and you wish two
 modules to be shown at the same time.
 
+By adding the `{button}` placeholder in the format you can enable a toggle
+button to hide or show the content.
+
+Configuration parameters:
+    button_toggle: Button used to toggle if one in format.
+        Setting to None disables (default 1)
+    format: Display format to use (default '{output}')
+    format_button_open: Format for the button when frame closed (default '-')
+    format_button_closed: Format for the button when frame open (default '+')
+    format_separator: Specify separator between contents.
+        If this is None then the default i3bar separator will be used
+        (default None)
+    open: If button then the frame can be set to be open or close
+        (default True)
+
+Format of status string parameters:
+    {button} If used a button will be used that can be clicked to hide/show
+        the contents of the frame.
+    {output} The output of the modules in the frame
+
 Example config:
 
 ```
+# A frame showing times in different cities.
+# We also have a button to hide/show the content
+
+frame time {
+    format = '{output}{button}'
+    format_separator = ' '  # have space instead of usual i3bar separator
+
+    tztime la {
+        format = "LA %H:%M"
+        timezone = "America/Los_Angeles"
+    }
+
+    tztime ny {
+        format = "NY %H:%M"
+        timezone = "America/New_York"
+    }
+
+    tztime du {
+        format = "DU %H:%M"
+        timezone = "Asia/Dubai"
+    }
+}
+
 # Define a group which shows volume and battery info
 # or the current time.
 # The frame, volume_status and battery_level modules are named
 # to prevent them clashing with any other defined modules of the same type.
 group {
-    frame volume_battery {
-        volume_status frame_volume {}
-        battery_level frame_battery {}
+    frame {
+        volume_status {}
+        battery_level {}
     }
 
     time {}
@@ -28,8 +71,19 @@ group {
 
 class Py3status:
 
+    button_toggle = 1
+    format = '{output}'
+    format_button_open = u'-'
+    format_button_closed = u'+'
+    format_separator = None
+    open = True
+
     class Meta:
         container = True
+
+    def post_config_hook(self):
+        if '{button}' not in self.format:
+            self.open = True
 
     def frame(self):
 
@@ -38,16 +92,45 @@ class Py3status:
 
         # get the child modules output.
         output = []
-        for item in self.items:
-            out = self.py3.get_output(item)
-            if out and 'separator' not in out[-1]:
-                out[-1]['separator'] = True
-            output += out
+        if self.open:
+            for item in self.items:
+                out = self.py3.get_output(item).copy()
+                if self.format_separator is None:
+                    if out and 'separator' not in out[-1]:
+                        out[-1]['separator'] = True
+                else:
+                    if self.format_separator:
+                        out += [{'full_text': self.format_separator}]
+                output += out
 
+        if '{button}' in self.format:
+            if self.open:
+                format_control = self.format_button_open
+            else:
+                format_control = self.format_button_closed
+
+            button = {'full_text': format_control, 'index': 'button'}
+        else:
+            button = None
+
+        composites = {
+            'output': output,
+            'button': button,
+        }
+        output = self.py3.build_composite(self.format, composites=composites)
         return {
             'cached_until': self.py3.CACHE_FOREVER,
             'composite': output,
         }
+
+    def on_click(self, event):
+        """
+        Switch the displayed module or pass the event on to the active module
+        """
+        if event['button'] == self.button_toggle:
+            # we only toggle if button was used
+            if event.get('index') == 'button' and self.py3.is_my_event(event):
+                self.open = not self.open
 
 
 if __name__ == "__main__":

--- a/py3status/modules/frame.py
+++ b/py3status/modules/frame.py
@@ -1,0 +1,58 @@
+# -*- coding: utf-8 -*-
+"""
+Group two or more modules as a single one.
+
+This can be useful for example when adding modules to a group and you wish two
+modules to be shown at the same time.
+
+Example config:
+
+```
+# Define a group which shows volume and battery info
+# or the current time.
+# The frame, volume_status and battery_level modules are named
+# to prevent them clashing with any other defined modules of the same type.
+group {
+    frame volume_battery {
+        volume_status frame_volume {}
+        battery_level frame_battery {}
+    }
+
+    time {}
+}
+```
+
+@author tobes
+"""
+
+
+class Py3status:
+
+    class Meta:
+        container = True
+
+    def frame(self):
+
+        if not self.items:
+            return {'full_text': '', 'cached_until': self.py3.CACHE_FOREVER}
+
+        # get the child modules output.
+        output = []
+        for item in self.items:
+            out = self.py3.get_output(item)
+            if out and 'separator' not in out[-1]:
+                out[-1]['separator'] = True
+            output += out
+
+        return {
+            'cached_until': self.py3.CACHE_FOREVER,
+            'composite': output,
+        }
+
+
+if __name__ == "__main__":
+    """
+    Run module in test mode.
+    """
+    from py3status.module_test import module_test
+    module_test(Py3status)

--- a/py3status/modules/group.py
+++ b/py3status/modules/group.py
@@ -231,7 +231,8 @@ class Py3status:
         # if click_mode is button then we only action clicks that are
         # directly on the group not its contents.
         if self.click_mode == 'button':
-            if event['name'] != 'group' or event.get('index') != 'button':
+            if (not self.py3.is_my_event(event) or
+                    event.get('index') != 'button'):
                 return
 
         # reset cycle time

--- a/py3status/py3.py
+++ b/py3status/py3.py
@@ -96,6 +96,23 @@ class Py3:
         """
         return self._is_python_2
 
+    def is_my_event(self, event):
+        """
+        Checks if an event triggered belongs to the module recieving it.  This
+        is mainly for containers who will also recieve events from any children
+        they have.
+
+        Returns True if the event name and instance match that of the module
+        checking.
+        """
+        if not self._module:
+            return False
+
+        return (
+            event.get('name') == self._module.module_name and
+            event.get('instance') == self._module.module_inst
+        )
+
     def log(self, message, level=LOG_INFO):
         """
         Log the message.


### PR DESCRIPTION
The frame module.  This allow modules to be grouped.  This is useful if you wish to add more than one module to a 'slot' in a group.

```
group {
    frame {
        volume_status {}
        battery_level {}
    }

    time {}
}
```