### PR TITLE
Py3 improvements: safe_format() and build_composite()

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -484,7 +484,7 @@ Returns the time a given number of seconds into the future.
 Helpful for creating the `cached_until` value for the module
 output.
 
-__safe_format(format_string, data)__
+__safe_format(format_string, param_dict)__
 
 Parser for advanced formating.
 
@@ -512,7 +512,7 @@ This will show `artist - title` if artist is present,
 `title` if title but no artist,
 and `file` if file is present but not artist or title.
 
-__build_composite(format_string, data=None, composites=None)__
+__build_composite(format_string, param_dict=None, composites=None)__
 
 Build a composite output using a format string.
 

--- a/doc/README.md
+++ b/doc/README.md
@@ -484,13 +484,40 @@ Returns the time a given number of seconds into the future.
 Helpful for creating the `cached_until` value for the module
 output.
 
-__safe_format(format_string, param_dict)__
+__parse_format(format_string, data)__
+
+Parser for advanced formating.
+
+Square brackets `[]` can be used. The content of them will be removed
+from the output if there is no valid placeholder contained within.
+They can also be nested.
+
+A pipe (vertical bar) `|` can be used to divide sections the first
+valid section only will be shown in the output.
+
+A backslash `\` can be used to escape a character eg `\[` will show `[`
+in the output.
+
+`{<placeholder>}` will be converted, or removed if it is None or
+missing.  formating can also be applied to the placeholder eg
+`{number:03.2f}`.
+
+*example format_string:*
+
+`"[[{artist} - ]{title}]|{file}"`
+This will show `artist - title` if artist is present,
+`title` if title but no artist,
+and `file` if file is present but not artist or title.
+
+__safe_format(format_string, param_dict, advanced_format=False)__
 
 Perform a safe formatting of a string. Using format fails if the
 format string contains placeholders which are missing. Since these can
 be set by the user it is possible that they add unsupported items.
 This function will show missing placeholders so that modules do not
 crash hard.
+If `advanced_format` is `True` then `parse_format()` will be used.
+
 
 __check_commands(cmd_list)__
 

--- a/doc/README.md
+++ b/doc/README.md
@@ -512,6 +512,15 @@ This will show `artist - title` if artist is present,
 `title` if title but no artist,
 and `file` if file is present but not artist or title.
 
+__build_composite(format_string, data=None, composites=None)__
+
+Build a composite output using a format string.
+
+Takes a format_string and treats it the same way as `safe_format` but
+also takes a composites dict where each key/value is the name of the
+placeholderand either an output eg `{'full_text': 'something'}` or a
+list of outputs.
+
 __check_commands(cmd_list)__
 
 Checks to see if the shell commands in list are available using `which`.

--- a/doc/README.md
+++ b/doc/README.md
@@ -484,9 +484,11 @@ Returns the time a given number of seconds into the future.
 Helpful for creating the `cached_until` value for the module
 output.
 
-__parse_format(format_string, data)__
+__safe_format(format_string, data)__
 
 Parser for advanced formating.
+
+Unknown placeholders will be shown in the output eg `{foo}`
 
 Square brackets `[]` can be used. The content of them will be removed
 from the output if there is no valid placeholder contained within.
@@ -498,8 +500,9 @@ valid section only will be shown in the output.
 A backslash `\` can be used to escape a character eg `\[` will show `[`
 in the output.
 
-`{<placeholder>}` will be converted, or removed if it is None or
-missing.  formating can also be applied to the placeholder eg
+`{<placeholder>}` will be converted, or removed if it is None or empty.
+
+Formating can also be applied to the placeholder eg
 `{number:03.2f}`.
 
 *example format_string:*
@@ -508,16 +511,6 @@ missing.  formating can also be applied to the placeholder eg
 This will show `artist - title` if artist is present,
 `title` if title but no artist,
 and `file` if file is present but not artist or title.
-
-__safe_format(format_string, param_dict, advanced_format=False)__
-
-Perform a safe formatting of a string. Using format fails if the
-format string contains placeholders which are missing. Since these can
-be set by the user it is possible that they add unsupported items.
-This function will show missing placeholders so that modules do not
-crash hard.
-If `advanced_format` is `True` then `parse_format()` will be used.
-
 
 __check_commands(cmd_list)__
 

--- a/py3status/modules/group.py
+++ b/py3status/modules/group.py
@@ -198,17 +198,12 @@ class Py3status:
             format_control = self.format_button_closed
             format = self.format_closed
 
-        parts = findall('({[^}]*}|[^{]+)', format)
-
-        output = []
-        for part in parts:
-            if part == '{output}':
-                output += current_output
-            elif part == '{button}':
-                output += [{'full_text': format_control,
-                            'index': 'button'}]
-            else:
-                output += [{'full_text': part}]
+        button = {'full_text': format_control, 'index': 'button'}
+        composites = {
+            'output': current_output,
+            'button': button,
+        }
+        output = self.py3.build_composite(format, composites=composites)
 
         # FIXME always start contained items after container so they trigger
         # on the first run contained items may not be displayed so make sure we

--- a/py3status/modules/group.py
+++ b/py3status/modules/group.py
@@ -80,7 +80,6 @@ group disks {
 @author tobes
 """
 
-from re import findall
 from time import time
 
 

--- a/py3status/py3.py
+++ b/py3status/py3.py
@@ -133,7 +133,7 @@ class Py3:
         """
         return time() + seconds
 
-    def _safe_format(self, format_string, data):
+    def _safe_format(self, format_string, param_dict):
         '''
         '''
 
@@ -177,7 +177,7 @@ class Py3:
                     Info.char = None
                     param = parsed[Info.part][1]
                     Info.part += 1
-                    if data.get(param) is not None:
+                    if param_dict.get(param) is not None:
                         # valid placeholder so return it along with any extras
                         conversion = parsed[Info.part - 1][3]
                         if conversion:
@@ -186,7 +186,7 @@ class Py3:
                         if field_format:
                             param += ':%s' % field_format
                         return '{%s}' % param, True
-                    elif param not in data:
+                    elif param not in param_dict:
                         # Missing placeholder
                         return '{{%s}}' % param, True
                     else:
@@ -254,7 +254,7 @@ class Py3:
 
         return ''.join([p[0] for p in parts if p[1]])
 
-    def safe_format(self, format_string, data):
+    def safe_format(self, format_string, param_dict):
         """
         Parser for advanced formating.
 
@@ -278,9 +278,9 @@ class Py3:
         and `file` if file is present but not artist or title.
         """
         # Output our format string with the placeholders substituted.
-        return self._safe_format(format_string, data).format(**data)
+        return self._safe_format(format_string, param_dict).format(**param_dict)
 
-    def build_composite(self, format_string, data=None, composites=None):
+    def build_composite(self, format_string, param_dict=None, composites=None):
         """
         Build a composite output using a format string.
 
@@ -289,14 +289,14 @@ class Py3:
         placeholderand either an output eg `{'full_text': 'something'}` or a
         list of outputs.
         """
-        if data is None:
-            data = {}
+        if param_dict is None:
+            param_dict = {}
         if composites is None:
             composites = {}
 
         # Make sure that placeholders for our composites are kept by adding
-        # entries if not in data
-        my_data = data.copy()
+        # entries if not in param_dict
+        my_data = param_dict.copy()
         for composite in composites:
             if composite not in my_data:
                 my_data[composite] = True
@@ -309,8 +309,8 @@ class Py3:
         for item in parsed:
             text += item[0]
             if item[1]:
-                if item[1] in data:
-                    text = '{}{}'.format(text, data[item[1]])
+                if item[1] in param_dict:
+                    text = '{}{}'.format(text, param_dict[item[1]])
                 else:
                     if text:
                         output.append({'full_text': text})

--- a/py3status/py3.py
+++ b/py3status/py3.py
@@ -224,7 +224,7 @@ class Py3:
                     n += m
             return n, found
 
-        parts = [['', True]]
+        parts = [['', True, 0]]
         level = 0
         block_level = None
         # We will go through the parsed format string one character/placeholder
@@ -237,12 +237,24 @@ class Py3:
             if found:
                 # A placeholder exists so this section is valid
                 parts[len(parts) - 1][1] = True
+                # We need to work out which other sections depend on this one
+                # so that we can make sure they are shown.
+                # [ [ ] | [ ] ] [show [{placeholder}] | [ ] ]
+                fix_level = level
+                for i in range(len(parts) - 2, 0, -1):
+                    part_level = parts[i][2]
+                    if part_level >= fix_level:
+                        continue
+                    parts[i][1] = True
+                    if part_level == 0:
+                        break
+                    fix_level = part_level
             if n == '':
                 continue
             if n == '[':
                 # Start a new section
-                parts.append(['', False])
                 level += 1
+                parts.append(['', False, level])
                 continue
             if n == ']':
                 # Section finished remove if no placeholders found

--- a/py3status/py3.py
+++ b/py3status/py3.py
@@ -134,8 +134,11 @@ class Py3:
         return time() + seconds
 
     def _safe_format(self, format_string, param_dict):
-        '''
-        '''
+        """
+        Parse a format string. we make sure that no undefined parameters are
+        included in the format and if they do we escape them.  We also apply
+        rules around [ | ] etc.
+        """
 
         # we need to treat \{ and \} specially for the formatter
         # change them to {{ and }}
@@ -159,10 +162,10 @@ class Py3:
             return 'Invalid Format'
 
         def next_item(ignore_slash=False):
-            '''
+            """
             Get the next item from the pared info.  This will be a single
             character or placeholder and may be preceded by a backslash.
-            '''
+            """
             if Info.part >= len(parsed):
                 # We got to the end of the format string.
                 return None, None

--- a/py3status/py3.py
+++ b/py3status/py3.py
@@ -282,11 +282,11 @@ class Py3:
 
     def build_composite(self, format_string, data=None, composites=None):
         """
-        Build composite output.
+        Build a composite output using a format string.
 
-        Takes a format_string and treats it the same way as safe_format but
+        Takes a format_string and treats it the same way as `safe_format` but
         also takes a composites dict where each key/value is the name of the
-        placeholderand either some output eg {'full_text': 'something} or a
+        placeholderand either an output eg `{'full_text': 'something'}` or a
         list of outputs.
         """
         if data is None:


### PR DESCRIPTION
Allow substituted formatings like mpd has eg `[[{artist} - ]{title}]|{file}`
