### PR TITLE
Refactor events and module refresh

### DIFF
--- a/py3status/events.py
+++ b/py3status/events.py
@@ -2,8 +2,7 @@ import select
 import sys
 
 from threading import Thread
-from time import time
-from subprocess import Popen, call, PIPE
+from subprocess import Popen, PIPE
 from json import loads
 
 from py3status.profiling import profile
@@ -57,7 +56,6 @@ class Events(Thread):
         self.config = py3_wrapper.config
         self.error = None
         self.i3s_config = py3_wrapper.i3status_thread.config
-        self.last_refresh_ts = time()
         self.lock = py3_wrapper.lock
         self.modules = py3_wrapper.modules
         self.on_click = self.i3s_config['on_click']
@@ -65,56 +63,24 @@ class Events(Thread):
         self.poller_inp = IOPoller(sys.stdin)
         self.py3_wrapper = py3_wrapper
 
-    def refresh(self, module_name):
-        """
-        Force a cache expiration for all the methods of the given module.
-
-        We rate limit the i3status refresh to 100ms.
-        """
-        module = self.modules.get(module_name)
-        if module is not None:
-            if self.config['debug']:
-                self.py3_wrapper.log('refresh module {}'.format(module_name))
-            module.force_update()
-        else:
-            if time() > (self.last_refresh_ts + 0.1):
-                if self.config['debug']:
-                    self.py3_wrapper.log(
-                        'refresh i3status for module {}'.format(module_name))
-                call(['killall', '-s', 'USR1', 'i3status'])
-                self.last_refresh_ts = time()
-
-    def refresh_all(self, module_name):
-        """
-        Force a full refresh of py3status and i3status modules by sending
-        a SIGUSR1 signal to py3status.
-
-        We rate limit this command to 100ms for obvious abusive behavior.
-        """
-        if time() > (self.last_refresh_ts + 0.1):
-            call(['killall', '-s', 'USR1', 'py3status'])
-            self.last_refresh_ts = time()
-
     def on_click_dispatcher(self, module_name, command):
         """
         Dispatch on_click config parameters to either:
             - Our own methods for special py3status commands (listed below)
             - The i3-msg program which is part of i3wm
         """
-        py3_commands = ['refresh', 'refresh_all']
         if command is None:
             return
-        elif command in py3_commands:
-            # this is a py3status command handled by this class
-            method = getattr(self, command)
-            method(module_name)
+        elif command == 'refresh_all':
+            self.py3_wrapper.refresh_modules()
+        elif command == 'refresh':
+            self.py3_wrapper.refresh_modules(module_name)
         else:
             # this is a i3 message
             self.i3_msg(module_name, command)
-
             # to make the bar more responsive to users we ask for a refresh
             # of the module or of i3status if the module is an i3status one
-            self.refresh(module_name)
+            self.py3_wrapper.refresh_modules(module_name)
 
     def i3_msg(self, module_name, command):
         """
@@ -161,7 +127,7 @@ class Events(Thread):
             # to make the bar more responsive to users we refresh the module
             # unless the on_click event called py3.prevent_refresh()
             if not module.prevent_refresh:
-                self.refresh(module_name)
+                self.py3_wrapper.refresh_modules(module_name)
             default_event = False
 
         if default_event:
@@ -169,13 +135,47 @@ class Events(Thread):
             if self.config['debug']:
                 self.py3_wrapper.log(
                     'dispatching default event {}'.format(event))
-            self.refresh(module_name)
+            self.py3_wrapper.refresh_modules(module_name)
 
         # find container that holds the module and call its onclick
         module_groups = self.i3s_config['.module_groups']
         containers = module_groups.get(module_name, [])
         for container in containers:
             self.process_event(container, event, top_level=False)
+
+    def dispatch_event(self, event):
+        '''
+        Takes an event dict.  Logs the event if needed and cleans up the dict
+        such as setting the index needed for composits.
+        '''
+        if self.config['debug']:
+            self.py3_wrapper.log('received event {}'.format(event))
+        # usage variables
+        instance = event.get('instance', '')
+        name = event.get('name', '')
+
+        # composites have an index which is passed to i3bar with
+        # the instance.  We need to separate this out here and
+        # clean up the event.  If index
+        # is an integer type then cast it as such.
+        if ' ' in instance:
+            instance, index = instance.split(' ', 1)
+            try:
+                index = int(index)
+            except ValueError:
+                pass
+            event['index'] = index
+            event['instance'] = instance
+
+        if self.config['debug']:
+            self.py3_wrapper.log(
+                'trying to dispatch event to module "{}"'.format(
+                    '{} {}'.format(name, instance).strip()))
+
+        # guess the module config name
+        module_name = '{} {}'.format(name, instance).strip()
+        # do the work
+        self.process_event(module_name, event)
 
     @profile
     def run(self):
@@ -199,36 +199,6 @@ class Events(Thread):
                 if event_str[0] == ',':
                     event_str = event_str[1:]
                 event = loads(event_str)
-
-                if self.config['debug']:
-                    self.py3_wrapper.log('received event {}'.format(event))
-
-                # usage variables
-                instance = event.get('instance', '')
-                name = event.get('name', '')
-
-                # composites have an index which is passed to i3bar with
-                # the instance.  We need to separate this out here and
-                # clean up the event.  If index
-                # is an integer type then cast it as such.
-                if ' ' in instance:
-                    instance, index = instance.split(' ', 1)
-                    try:
-                        index = int(index)
-                    except ValueError:
-                        pass
-                    event['index'] = index
-                    event['instance'] = instance
-
-                if self.config['debug']:
-                    self.py3_wrapper.log(
-                        'trying to dispatch event to module "{}"'.format(
-                            '{} {}'.format(name, instance).strip()))
-
-                # guess the module config name
-                module_name = '{} {}'.format(name, instance).strip()
-                # do the work
-                self.process_event(module_name, event)
-
+                self.dispatch_event(event)
             except Exception:
                 self.py3_wrapper.report_exception('Event failed')


### PR DESCRIPTION
This PR does the following

* Moves refreshing i3status into i3status.py as `I3status.refresh_i3status()`. Rather than being implemented in both in events.py and core.py.

* `Py3statusWrapper.refresh_modules()` can refresh all or named modules.  With named modules either an exact name or starting_with can be used.  `refresh_all` events now happen without needing to send a USR1 signal to py3status.  Events code changed to use this rather than re-implementing.

* `Events.dispatch_event()` Now handles the dispatching of events rather being done in `Events.run()` This allows events to come from other sources as well as i3bar.

The reasons for this PR are.

1. Cleans up some of the code and reduces repetition.

2. Allows for some cool future functionality I've been playing with to be introduced more easily.

I can split it into 3 PRs if that helps with reviewing.