### PR TITLE
warn user on empty config

### DIFF
--- a/py3status/parse_config.py
+++ b/py3status/parse_config.py
@@ -595,7 +595,7 @@ def process_config(config_path, py3_wrapper=None):
     allowed_modules = module_names()
 
     # create config for modules in order
-    for name in config_info['order']:
+    for name in config_info.get('order', []):
         module = modules.get(name, {})
         module_type = get_module_type(name)
         if allowed_modules and name.split()[0] not in allowed_modules:
@@ -626,6 +626,8 @@ def process_config(config_path, py3_wrapper=None):
             else:
                 config[name]['format'] = TZTIME_FORMAT
 
+    if not config['order']:
+        notify_user('There are no modules in your py3status config')
     return config
 
 

--- a/py3status/parse_config.py
+++ b/py3status/parse_config.py
@@ -627,7 +627,8 @@ def process_config(config_path, py3_wrapper=None):
                 config[name]['format'] = TZTIME_FORMAT
 
     if not config['order']:
-        notify_user('There are no modules in your py3status config')
+        notify_user('Your configuration file does not list any module'
+                    ' to be loaded with the "order" directive.')
     return config
 
 


### PR DESCRIPTION
#387 includes a report of an issue with an empty config.  This prevents that error and notifies the user that no modules are present.  I'm not sure if the notification is the best.  really we are sayingthat there are none defined in `order +=...`