### PR TITLE
Bug Fix: ensure that last_output remains correct

### DIFF
--- a/py3status/i3status.py
+++ b/py3status/i3status.py
@@ -70,7 +70,7 @@ class I3statusModule:
         return '<I3statusModule {}>'.format(self.module_name)
 
     def get_latest(self):
-        return [self.item]
+        return [self.item.copy()]
 
     def update_from_item(self, item):
         """


### PR DESCRIPTION
There was an issue after the sleeping dogs branch was merged that affected the output from a group.  A time module in the group would not be updated regularly.

This was because i3status time modules do not always create a fresh response and therefore they corrupted the module updated checks in module.py (the time would be updated and this would end up updating the last_output - so it looked like the output hadn't changed)