### PR TITLE
Bug fix: parse_config for python 3.5

### DIFF
--- a/py3status/parse_config.py
+++ b/py3status/parse_config.py
@@ -541,7 +541,7 @@ def process_config(config_path, py3_wrapper=None):
                 module['.group'] = parent
 
         # check module content
-        for k, v in module.items():
+        for k, v in list(module.items()):
             if k.startswith('on_click'):
                 # on_click event
                 process_onclick(k, v, name)


### PR DESCRIPTION
Force modules.items() to a list so that we are not iterating it when it might change.

This was not needed for python 3.4/2.7 but was a problem in 3.5

