### PR TITLE
Group module minor update

### DIFF
--- a/py3status/modules/group.py
+++ b/py3status/modules/group.py
@@ -178,15 +178,13 @@ class Py3status:
         """
 
         # hide if no contents
-        # FIXME the module shouldn't even run if no content
         if not self.items:
             return {
                 'cached_until': self.py3.CACHE_FOREVER,
                 'full_text': '',
             }
 
-        ready = self.initialized
-        if not ready:
+        if not self.initialized:
             self._init()
 
         if self.open:
@@ -217,12 +215,6 @@ class Py3status:
                             'index': 'button'}]
             else:
                 output += [{'full_text': part}]
-
-        # FIXME always start contained items after container so they trigger
-        # on the first run contained items may not be displayed so make sure we
-        # check them again to ensure all is correct
-        if not ready:
-            update_time = 0
 
         if update_time is not None:
             cached_until = time() + update_time


### PR DESCRIPTION
Due to how modules were started the group module had to be sure that all modules were initialised before it could produce the correct output.  Since PR #276 all modules are now initialised before any are run so we no longer need this behaviour.