### PR TITLE
Pass color to composite parts

### DIFF
--- a/py3status/module.py
+++ b/py3status/module.py
@@ -205,6 +205,7 @@ class Module(Thread):
             align = self.module_options['align']
 
         # update all components
+        color = response.get('color')
         for index, item in enumerate(response['composite']):
             # validate the response
             if 'full_text' not in item:
@@ -227,6 +228,10 @@ class Module(Thread):
             # set align
             if align:
                 item['align'] = align
+            # If a color was supplied for the composite and a composite
+            # part does not supply a color, use the composite color.
+            if color and 'color' not in item:
+                item['color'] = color
 
     def _params_type(self, method_name, instance):
         """


### PR DESCRIPTION
In PR #354 mpris module the output wants to be colored but currently there is no easy way to do this.

This PR allows composites to provide a color
```
{
    'cached_until': ...,
    'color': <color>,
    'composite': [
        {.....},
        {.....},
    ]
}
```

The color will be added to any of the parts of the composite that do not supply color themselves.
It needs documenting but since #393 adds composite documentation. I'll add it in either this PR or that one depending which gets merged first.

