### PR TITLE
Bug Fix: py3 python2 unicode fixes for notify_user() and log()

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -464,6 +464,11 @@ __update(module_name=None)__
 Update a module. If `module_name` is supplied the module of that
 name is updated. Otherwise the module calling is updated.
 
+__is_python_2()__
+
+True if the version of python being used is 2.x
+Can be helpful for fixing python 2 compatability issues
+
 __get_output(module_name)__
 
 Return the output of the named module. This will be a list.

--- a/py3status/core.py
+++ b/py3status/core.py
@@ -334,11 +334,11 @@ class Py3statusWrapper():
         dbus = self.config.get('dbus_notify')
         if dbus:
             # force msg to be a string
-            msg = '{}'.format(msg)
+            msg = u'{}'.format(msg)
         else:
-            msg = 'py3status: {}'.format(msg)
+            msg = u'py3status: {}'.format(msg)
         if level != 'info' and module_name == '':
-            fix_msg = '{} Please try to fix this and reload i3wm (Mod+Shift+R)'
+            fix_msg = u'{} Please try to fix this and reload i3wm (Mod+Shift+R)'
             msg = fix_msg.format(msg)
         # Rate limiting. If rate limiting then we need to calculate the time
         # period for which the message should not be repeated.  We just use
@@ -354,7 +354,7 @@ class Py3statusWrapper():
                 pass
         # We use a hash to see if the message is being repeated.  This is crude
         # and imperfect but should work for our needs.
-        msg_hash = hash('{}#{}#{}'.format(module_name, limit_key, msg))
+        msg_hash = hash(u'{}#{}#{}'.format(module_name, limit_key, msg))
         if msg_hash in self.notified_messages:
             return
         else:
@@ -476,7 +476,11 @@ class Py3statusWrapper():
         else:
             with open(self.config['log_file'], 'a') as f:
                 log_time = time.strftime("%Y-%m-%d %H:%M:%S")
-                f.write('{} {} {}\n'.format(log_time, level.upper(), msg))
+                out = u'{} {} {}\n'.format(log_time, level.upper(), msg)
+                try:
+                    f.write(out)
+                except UnicodeEncodeError:
+                    f.write(out.encode('utf-8'))
 
     def report_exception(self, msg, notify_user=True):
         """

--- a/py3status/py3.py
+++ b/py3status/py3.py
@@ -1,3 +1,4 @@
+import sys
 import os
 import shlex
 from time import time
@@ -34,6 +35,7 @@ class Py3:
         self._audio = None
         self._module = module
         self._i3s_config = i3s_config or {}
+        self.is_python_2 = sys.version_info < (3, 0)
         # we are running through the whole stack.
         # If testing then module is None.
         if module:
@@ -121,6 +123,9 @@ class Py3:
         should not be repeated.
         """
         if self._module:
+            # force unicode for python2 str
+            if self.is_python_2 and isinstance(msg, str):
+                msg = msg.decode('utf-8')
             module_name = self._module.module_full_name
             self._module._py3_wrapper.notify_user(
                 msg, level=level, rate_limit=rate_limit, module_name=module_name)

--- a/py3status/py3.py
+++ b/py3status/py3.py
@@ -36,7 +36,7 @@ class Py3:
         self._audio = None
         self._module = module
         self._i3s_config = i3s_config or {}
-        self.is_python_2 = sys.version_info < (3, 0)
+        self._is_python_2 = sys.version_info < (3, 0)
         # we are running through the whole stack.
         # If testing then module is None.
         if module:
@@ -62,6 +62,13 @@ class Py3:
         returns the i3s_config dict.
         """
         return self._i3s_config
+
+    def is_python_2(self):
+        """
+        True if the version of python being used is 2.x
+        Can be helpful for fixing python 2 compatability issues
+        """
+        return self._is_python_2
 
     def log(self, message, level=LOG_INFO):
         """
@@ -125,7 +132,7 @@ class Py3:
         """
         if self._module:
             # force unicode for python2 str
-            if self.is_python_2 and isinstance(msg, str):
+            if self._is_python_2 and isinstance(msg, str):
                 msg = msg.decode('utf-8')
             module_name = self._module.module_full_name
             self._module._py3_wrapper.notify_user(
@@ -321,7 +328,7 @@ class Py3:
         `title` if title but no artist,
         and `file` if file is present but not artist or title.
         """
-        if self.is_python_2:
+        if self._is_python_2:
             self._fix_unicode_dict(param_dict)
         # Output our format string with the placeholders substituted.
         return self._safe_format(format_string, param_dict).format(**param_dict)
@@ -340,7 +347,7 @@ class Py3:
         if composites is None:
             composites = {}
 
-        if self.is_python_2:
+        if self._is_python_2:
             self._fix_unicode_dict(param_dict)
 
         # Make sure that placeholders for our composites are kept by adding


### PR DESCRIPTION
Both `py3.notify_user()` and `py3.log()` suffered issues when being sent a unicode string under python2.

This PR fixes the issue so that they are both much more forgiving about the strings they will accept.