### PR TITLE
Anon modules: less module clashes in containers

### DIFF
--- a/py3status/constants.py
+++ b/py3status/constants.py
@@ -18,12 +18,14 @@ TZTIME_FORMAT = '%Y-%m-%d %H:%M:%S %Z'
 
 TIME_MODULES = ['time', 'tztime']
 
-I3STATUS_MODULES = [
+I3S_INSTANCE_MODULES = [
     'battery', 'cpu_temperature', 'disk', 'ethernet', 'path_exists',
     'run_watch', 'tztime', 'volume', 'wireless'
 ]
 
 I3S_SINGLE_NAMES = ['cpu_usage', 'ddate', 'ipv6', 'load', 'time']
+
+I3S_MODULE_NAMES = I3S_SINGLE_NAMES + I3S_INSTANCE_MODULES
 
 ERROR_CONFIG = '''
     general {colors = true interval = 60}

--- a/py3status/parse_config.py
+++ b/py3status/parse_config.py
@@ -10,7 +10,7 @@ from subprocess import check_output
 
 from py3status.constants import (
     I3S_SINGLE_NAMES,
-    I3STATUS_MODULES,
+    I3S_MODULE_NAMES,
     MAX_NESTING_LEVELS,
     ERROR_CONFIG,
     GENERAL_DEFAULTS,
@@ -119,6 +119,7 @@ class ConfigParser:
         self.line_start = 0
         self.raw = config.split('\n')
         self.container_modules = []
+        self.anon_count = 0
 
     class ParseEnd(Exception):
         '''
@@ -427,8 +428,19 @@ class ConfigParser:
                 if self.level == 1 and name == 'order':
                     self.check_module_name(value, offset=1)
                     dictionary.setdefault(name, []).append(value)
-                # assignment of value or module definition
-                elif t_value in ['=', '{']:
+                # assignment of  module definition
+                elif t_value == '{':
+                    # If this is an py3status module and in a container and has
+                    # no instance name then give it an anon one.  This allows
+                    # us to have multiple non-instance named modules defined
+                    # without them clashing.
+                    if (self.level > 1 and ' ' not in name and
+                            name not in I3S_MODULE_NAMES):
+                        name = '{} _anon_module_{}'.format(name, self.anon_count)
+                        self.anon_count += 1
+                    dictionary[name] = value
+                # assignment of value
+                elif t_value == '=':
                     dictionary[name] = value
                 # appending to existing values
                 elif t_value == '+=':
@@ -451,7 +463,7 @@ def process_config(config_path, py3_wrapper=None):
 
     def module_names():
         # get list of all module names
-        modules = I3S_SINGLE_NAMES + I3STATUS_MODULES
+        modules = I3S_MODULE_NAMES[:]
         root = os.path.dirname(os.path.realpath(__file__))
         module_path = os.path.join(root, 'modules', '*.py')
         for file in glob.glob(module_path):
@@ -528,7 +540,7 @@ def process_config(config_path, py3_wrapper=None):
         '''
         i3status or py3status?
         '''
-        if name.split()[0] in I3S_SINGLE_NAMES + I3STATUS_MODULES:
+        if name.split()[0] in I3S_MODULE_NAMES:
             return 'i3status'
         return 'py3status'
 


### PR DESCRIPTION
If we have the following i3status.conf.  

```
order += "static_string"
order += "group"

static_string {
    format = 'one'
}

group {
    static_string {
        format = 'two'
    }
    static_string {
        format = 'three'
    }
}
```
Then currently, only one static_string module is created even though three have been defined.  This PR instead treats this as three independent modules.  It does this by creating a unique name for modules defined inside a container.  This allow them to be distinguished between and so be initialised with the correct values.