### PR TITLE
Improved reporting of module import errors

### DIFF
--- a/py3status/core.py
+++ b/py3status/core.py
@@ -243,7 +243,7 @@ class Py3statusWrapper():
             except Exception:
                 err = sys.exc_info()[1]
                 msg = 'Loading module "{}" failed ({}).'.format(module, err)
-                self.notify_user(msg, level='warning')
+                self.report_exception(msg, level='warning')
 
     def setup(self):
         """
@@ -478,7 +478,7 @@ class Py3statusWrapper():
                 log_time = time.strftime("%Y-%m-%d %H:%M:%S")
                 f.write('{} {} {}\n'.format(log_time, level.upper(), msg))
 
-    def report_exception(self, msg, notify_user=True):
+    def report_exception(self, msg, notify_user=True, level='error'):
         """
         Report details of an exception to the user.
         This should only be called within an except: block Details of the
@@ -530,7 +530,7 @@ class Py3statusWrapper():
         if traceback and self.config['log_file']:
             self.log(''.join(['Traceback\n'] + traceback))
         if notify_user:
-            self.notify_user(msg, level='error')
+            self.notify_user(msg, level=level)
 
     def create_output_modules(self):
         """


### PR DESCRIPTION
Module import errors were not very informative.

This PR adds better logging of exceptions.

It also adds `level` parameter to `report_exception()` to allow error level to be passed.