### PR TITLE
Module init() method

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -608,21 +608,20 @@ If `True` the output will be shown as urgent in i3bar.
 
 Some special method are also defined.
 
-__init()__
+__kill()__
 
-Called once an instance of a module has been created and the configuration
-parameters have been set.  This is useful for any work a module must do before
-its output methods are run for the first time. `init()` introduced in version
-3.1
+Called just before a module is destroyed.
 
 __on_click(event)__
 
 Called when an event is recieved by a module.
 
-__kill()__
+__post_config_hook()__
 
-Called just before a module is destroyed.
-
+Called once an instance of a module has been created and the configuration
+parameters have been set.  This is useful for any work a module must do before
+its output methods are run for the first time. `post_config_hook()`
+introduced in version 3.1
 
 ***
 

--- a/doc/README.md
+++ b/doc/README.md
@@ -20,6 +20,7 @@ py3status documentation
 * [Example 2: Configuration parameters](#example_2)
 * [Example 3: Events](#example_3)
 * [Example 4: Status string placeholders](#example_4)
+* [Module methods](#module_methods)
 * [Py3 module helper](#py3)
 * [Module documentation](#docstring)
 * [Module testing](#testing)
@@ -266,6 +267,7 @@ show up in the status bar.
 The `Py3status` class tells py3status that this is a module. The module gets
 loaded. py3status then calls any public methods that the class contains to get
 a response. In our example there is a single method `hello_world()`.
+Read more here: [module methods](#module_methods).
 
 ####The response
 
@@ -432,6 +434,86 @@ click_info {
     format_clicked = "Vous avez appuyé sur le bouton {button}"
 }
 ```
+
+***
+
+
+## <a name="module_methods"></a>Module methods
+
+Py3status will call a method in a module to provide output to the i3bar.
+Methods that have names starting with an underscore will not be used in this
+way.  Any methods defined as static methods will also not be used.
+
+### Outputs
+
+Output methods should provide a response dict.
+
+Example response:
+
+```
+{
+    'full_text': "This text will be displayed",
+    'cached_until': 1470922537,  # Time in seconds since the epoch
+}
+```
+
+The response can include the folowing keys
+
+__cached_until__
+
+The time (in seconds since the epoch) that the output will be classed as no longer valid and the output
+function will be called again.  If no `cached_until` value is provided the the
+output will be cached for `cache_timeout` seconds by default this is
+`60` and can be set using the `-t` or `--timeout` option when running
+py3status.  To never expire the `self.py3.CACHE_FOREVER` constant should be
+used.
+
+__color__
+
+The color that the module output will be displayed in.
+
+__composite__
+
+Used to output more than one item to i3bar from a single output method.  If this is provided then `full_text` should not be.
+
+__full_text__
+
+This is the text output that will be sent to i3bar.
+
+__index__
+
+The index of the output.  Allows composite output to identify which component
+of their output had an event triggered.
+
+__separator__
+
+If `False` no separator will be shown after the output block (requires i3bar
+4.12).
+
+__urgent__
+
+If `True` the output will be shown as urgent in i3bar.
+
+
+### Special methods
+
+Some special method are also defined.
+
+__init()__
+
+Called once an instance of a module has been created and the configuration
+parameters have been set.  This is useful for any work a module must do before
+its output methods are run for the first time. `init()` introduced in version
+3.1
+
+__on_click(event)__
+
+Called when an event is recieved by a module.
+
+__kill()__
+
+Called just before a module is destroyed.
+
 
 ***
 

--- a/py3status/core.py
+++ b/py3status/core.py
@@ -607,7 +607,7 @@ class Py3statusWrapper():
         # started.  This is so that modules can do things like register their
         # content_functionn.
         for module in self.modules.values():
-            module.start()
+            module.start_module()
 
         # update queue populate with all py3modules
         self.queue.extend(self.modules)

--- a/py3status/module.py
+++ b/py3status/module.py
@@ -28,6 +28,7 @@ class Module(Thread):
         self.cache_time = None
         self.click_events = False
         self.config = py3_wrapper.config
+        self.has_init = False
         self.has_kill = False
         self.i3status_thread = py3_wrapper.i3status_thread
         self.last_output = []
@@ -80,6 +81,15 @@ class Module(Thread):
             py_mod = getattr(py_mod, comp)
         class_inst = py_mod.Py3status()
         return class_inst
+
+    def start_module(self):
+        """
+        Start the module running.
+        """
+        # Call modules init() method if it has one
+        if self.has_init:
+            self.module_class.init()
+        self.start()
 
     def force_update(self):
         """
@@ -285,6 +295,14 @@ class Module(Thread):
 
         if class_inst:
             self.module_class = class_inst
+            try:
+                # containers have items attribute set to a list of contained
+                # module instance names.  If there are no contained items then
+                # ensure that we have a empty list.
+                if class_inst.Meta.container:
+                    class_inst.items = []
+            except AttributeError:
+                pass
 
             # apply module configuration from i3status config
             mod_config = self.i3status_thread.config.get(module, {})
@@ -309,6 +327,8 @@ class Module(Thread):
                             self.click_events = params_type
                         elif method == 'kill':
                             self.has_kill = params_type
+                        elif method == 'init':
+                            self.has_init = True
                         else:
                             # the method_obj stores infos about each method
                             # of this module.

--- a/py3status/module.py
+++ b/py3status/module.py
@@ -28,7 +28,7 @@ class Module(Thread):
         self.cache_time = None
         self.click_events = False
         self.config = py3_wrapper.config
-        self.has_init = False
+        self.has_post_config_hook = False
         self.has_kill = False
         self.i3status_thread = py3_wrapper.i3status_thread
         self.last_output = []
@@ -87,8 +87,8 @@ class Module(Thread):
         Start the module running.
         """
         # Call modules init() method if it has one
-        if self.has_init:
-            self.module_class.init()
+        if self.has_post_config_hook:
+            self.module_class.post_config_hook()
         self.start()
 
     def force_update(self):
@@ -332,8 +332,8 @@ class Module(Thread):
                             self.click_events = params_type
                         elif method == 'kill':
                             self.has_kill = params_type
-                        elif method == 'init':
-                            self.has_init = True
+                        elif method == 'post_config_hook':
+                            self.has_post_config_hook = True
                         else:
                             # the method_obj stores infos about each method
                             # of this module.


### PR DESCRIPTION
* Add `init()` support for modules.

* Fixes containers so that `self.items` is always available.  This makes things easier for initialising containers as we do not need to check if self.items is defined for the module it will just be an empty list.

* Adds documentation on module methods/responses (think of this as a bribe)

Due to how py3status modules are loaded their `__init__()` is called before any configuration parameters have been set.  It is often useful to run code just once when the module has been configured.

To achieve this I have often written code like this 
```
def __init__(self):
    self._initialized = False

def _init(self):
    ... run initialization code here ...
    self._initialized = True

def module_method(self):
    if not self._initialized:
        self._init()
    ... run module code here ...
```

Other modules just run code every time in their main method which only needed to be run once.

I think it would be nice if we allowed an `init()` function to be defined in a module that would be run when the config parameters had been initialised.  Similar to how `kill()` is called in a module when it is destroyed.

So a module would look like this
```
def init(self):
    ... run initialization code here ...

def module_method(self):
    ... run module code here ...
```

Adding this functionality will only effect existing modules if they used `init` as the name of one of their methods.


