### PR TITLE
safe_format() get attributes from module

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -692,7 +692,7 @@ Returns the time a given number of seconds into the future.
 Helpful for creating the `cached_until` value for the module
 output.
 
-__safe_format(format_string, param_dict)__
+__safe_format(format_string, param_dict=None)__
 
 Parser for advanced formating.
 
@@ -706,7 +706,7 @@ A pipe (vertical bar) `|` can be used to divide sections the first
 valid section only will be shown in the output.
 
 A backslash `\` can be used to escape a character eg `\[` will show `[`
-in the output.
+in the output. Note: `\?` is reserved for future use and is removed.
 
 `{<placeholder>}` will be converted, or removed if it is None or empty.
 
@@ -719,6 +719,11 @@ Formating can also be applied to the placeholder eg
 This will show `artist - title` if artist is present,
 `title` if title but no artist,
 and `file` if file is present but not artist or title.
+
+
+param_dict is a dictionary of palceholders that will be substituted.
+If a placeholder is not in the dictionary then if the py3status module
+has an attribute with the same name then it will be used.
 
 __build_composite(format_string, param_dict=None, composites=None)__
 

--- a/py3status/module_test.py
+++ b/py3status/module_test.py
@@ -10,7 +10,7 @@ def module_test(module_class, config=None):
         'color_good': '#00FF00'
     }
     module = module_class()
-    setattr(module, 'py3', Py3(i3s_config=i3s_config))
+    setattr(module, 'py3', Py3(i3s_config=i3s_config, py3status=module))
     if config:
         for key, value in config.items():
             setattr(module, key, value)

--- a/py3status/modules/check_tcp.py
+++ b/py3status/modules/check_tcp.py
@@ -44,9 +44,7 @@ class Py3status:
             response['color'] = self.color_down or self.py3.COLOR_BAD
 
         response['full_text'] = self.py3.safe_format(self.format,
-                                                     {'host': self.host,
-                                                      'port': self.port,
-                                                      'state': state})
+                                                     {'state': state})
         return response
 
 


### PR DESCRIPTION
* `safe_format()` now can get placeholders straight from the py3status module (ignores any methods)

* `\?` special escape char added for the future

* Works with module stand alone test

* docs updated to reflect changes