### PR TITLE
Fixed exception if config-file is a symlink

### DIFF
--- a/py3status/parse_config.py
+++ b/py3status/parse_config.py
@@ -490,7 +490,7 @@ def process_config(config_path, py3_wrapper=None):
     config = {}
 
     # get the file encoding this is important with multi-byte unicode chars
-    encoding = check_output(['file', '-b', '--mime-encoding', config_path])
+    encoding = check_output(['file', '-b', '--mime-encoding', '--dereference', config_path])
     encoding = encoding.strip().decode('utf-8')
     with codecs.open(config_path, 'r', encoding) as f:
         try:


### PR DESCRIPTION
Fixed the unknown encoding "binary" exception that occurred, if the config-file happened to be a symbolic link on linux.