### PR TITLE
Fix exchange_rate module when single currency is used

### DIFF
--- a/py3status/modules/exchange_rate.py
+++ b/py3status/modules/exchange_rate.py
@@ -64,8 +64,12 @@ class Py3status:
             except KeyError:
                 pass
         output = {}
-        for rate in rates:
-            output[rate['id'][3:]] = rate['Rate']
+        # Single currency is not passed as a 1 element list
+        if isinstance(rates, list):
+            for rate in rates:
+                output[rate['id'][3:]] = rate['Rate']
+        else:
+            output[rates['id'][3:]] = rates['Rate']
         for currency in self.currencies:
             if currency not in output:
                 output[currency] = '?'


### PR DESCRIPTION
When a single currency is used in the format string, this module failed on line
68 since Yahooapis does not return single currency as a one element list, but
the element (dictionary) itself.

Solution: check if the expected element is a list or not.