### PR TITLE
Allow password encodings in config

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -112,6 +112,24 @@ imap {
 }
 ```
 
+As well as disguising the value in your configuration py3status also tries to
+prevent the information leaking, eg into log files or i3bar output.  Due to the
+workings of python it is easy for an attacker to counter these efforts.  When
+requested in an inappropriate place `***` will be used.
+
+If you just want py3status to prevent leakage you can use `:hide` to do
+this whilst keeping your configuration in plain text.
+
+```
+# Example of private configuration
+imap {
+    imap_server = 'imap.myprovider.com'
+    password:hide = 'coconut'
+    user = 'mylogin'
+}
+```
+
+
 #### <a name="configuring_color"></a>Configuring colors
 
 Since version 3.1 py3status allows greater color configuration.

--- a/doc/README.md
+++ b/doc/README.md
@@ -95,11 +95,29 @@ imap {
 
 __New in version 3.1__
 
-In the previous example configuration the users password is in plain text.  Users may
-want to make it less easy to read. Py3status allows strings to be base64
-encoded.
+Py3status allows you to hide individual configuration parameters so that they
+do not leak into log files, user notifications or to the i3bar. Additionally
+they allow you to obfuscate configuration parameters using base64 encoding.
 
-__Base64 encoding is very simple and should not be considered secure in any way.__
+To do this you need to add an obfuscation option to the configuration
+parameter. Obfuscation options are added by adding `:hide` or `:base64` to the
+name of the parameters.
+__Obfuscation is only available for string parameters.__
+
+Example:
+
+```
+# normal_parameter will be shown in log files etc as 'some value'
+# obfuscated_parameter will be shown in log files etc as '***'
+module {
+    normal_parameter: 'some value'
+    obfuscated_parameter:hide 'some value'
+}
+```
+
+In the previous example configuration the users password is in plain text.
+Users may want to make it less easy to read. Py3status allows strings to be
+base64 encoded.
 
 To use an encoded string add `:base64` to the name of the parameter.
 
@@ -112,23 +130,7 @@ imap {
 }
 ```
 
-As well as disguising the value in your configuration py3status also tries to
-prevent the information leaking, eg into log files or i3bar output.  Due to the
-workings of python it is easy for an attacker to counter these efforts.  When
-requested in an inappropriate place `***` will be used.
-
-If you just want py3status to prevent leakage you can use `:hide` to do
-this whilst keeping your configuration in plain text.
-
-```
-# Example of private configuration
-imap {
-    imap_server = 'imap.myprovider.com'
-    password:hide = 'coconut'
-    user = 'mylogin'
-}
-```
-
+__Base64 encoding is very simple and should not be considered secure in any way.__
 
 #### <a name="configuring_color"></a>Configuring colors
 

--- a/doc/README.md
+++ b/doc/README.md
@@ -7,6 +7,7 @@ py3status documentation
 * [Available modules](#available_modules)
 * [Ordering modules](#ordering_modules)
 * [Configuring modules](#configuring_modules)
+* [Configuration obfuscation](#obfuscation)
 * [Configuring colors](#configuring_color)
 * [Grouping modules](#group_modules)
 
@@ -83,11 +84,31 @@ imap {
     cache_timeout = 60
     imap_server = 'imap.myprovider.com'
     mailbox = 'INBOX'
-    name = 'Mail'
     password = 'coconut'
     port = '993'
     user = 'mylogin'
     on_click 1 = "exec thunderbird"
+}
+```
+
+#### <a name="obfuscation"></a>Configuration obfuscation
+
+__New in version 3.1__
+
+In the previous example configuration the users password is in plain text.  Users may
+want to make it less easy to read. Py3status allows strings to be base64
+encoded.
+
+__Base64 encoding is very simple and should not be considered secure in any way.__
+
+To use an encoded string add `:base64` to the name of the parameter.
+
+```
+# Example of obfuscated configuration
+imap {
+    imap_server = 'imap.myprovider.com'
+    password:base64 = 'Y29jb251dA=='
+    user = 'mylogin'
 }
 ```
 

--- a/py3status/parse_config.py
+++ b/py3status/parse_config.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-import base64
 import codecs
 import glob
 import imp
@@ -20,6 +19,8 @@ from py3status.constants import (
     TIME_FORMAT,
     TZTIME_FORMAT,
 )
+
+from py3status.private import PrivateHide, PrivateBase64
 
 
 class ParseException(Exception):
@@ -398,11 +399,9 @@ class ConfigParser:
         if ':' in name:
             (name, scheme) = name.split(':')
             if scheme == 'base64':
-                new_value = base64.b64decode(value)
-                try:
-                    value = new_value.decode('utf-8')
-                except UnicodeDecodeError:
-                    pass
+                value = PrivateBase64(value, self.current_module[-1])
+            if scheme == 'hide':
+                value = PrivateHide(value, self.current_module[-1])
 
         return name, value
 

--- a/py3status/parse_config.py
+++ b/py3status/parse_config.py
@@ -398,7 +398,12 @@ class ConfigParser:
         if ':' in name:
             (name, scheme) = name.split(':')
             if scheme == 'base64':
-                value = base64.b64decode(value)
+                new_value = base64.b64decode(value)
+                try:
+                    value = new_value.decode('utf-8')
+                except UnicodeDecodeError:
+                    pass
+
         return name, value
 
     def parse(self, dictionary=None, end_token=None):

--- a/py3status/private.py
+++ b/py3status/private.py
@@ -1,0 +1,154 @@
+import base64
+import inspect
+
+
+class Private(object):
+    """
+    This class attempts to keep private information.
+
+    Clearly this is python so we cannot actually achieve that aim.
+    Any attacker could easily monkey patch out any of this code rendering it
+    useless.
+
+    The point of this is to make the code less likely to leak sensitive
+    information for example via the logs, user notifications, displaying in
+    i3bar.
+
+    THIS IS NOT SECURE!
+    """
+
+    def __init__(self, encoded, module_name):
+        self._decoded = False
+        self._encoded = encoded
+        self._module_name = module_name.split(' ')[0]
+        self._private = u'***'  # this is used when the user is untrusted
+        self._value = u'encrypted'
+
+        # Try to decrypt data if possible
+        self._decrypt()
+
+    def _decrypt(self, key=None):
+        """
+        method called to decrypt the value
+        """
+        if not self._decoded:
+            self._decode(key)
+
+    def __getattribute__(self, name):
+        """
+        Check if user can acces this attribute.
+        """
+        # allowed by all users
+        if name in ['_decrypt', '_decode']:
+            return object.__getattribute__(self, name)
+
+        # allow internal calls
+        stack = inspect.stack()
+        state = ((not name.startswith('_')) or (
+                 inspect.getmodule(stack[1][0]).__name__ == __name__ and
+                 stack[1][3] in ['_catch', '_decode']))
+        if state:
+            return object.__getattribute__(self, name)
+        return None
+
+
+def catch_factory(attr):
+    """
+    Factory returning a catch function
+    """
+    def _catch(s, *args, **kw):
+        """
+        This is used to catch and process all calls.
+        """
+        def process(value):
+            """
+            return the actual value after processing
+            """
+            if attr.startswith('__'):
+                # __repr__, __str__ etc
+                return getattr(value, attr)(*args, **kw)
+            else:
+                # upper, lower etc
+                return getattr(u''.__class__, attr)(value, *args, **kw)
+
+        stack = inspect.stack()
+        mod = inspect.getmodule(stack[1][0])
+        # We are called from the owning module so allow
+        if mod.__name__.split('.')[-1] == s._module_name:
+            return process(s._value)
+        # very shallow calling no stack
+        if len(stack) < 3:
+            return process(s._private)
+        # Check if this is an internal or external module.  We need to allow
+        # calls to modules like requests etc
+        remote = not inspect.getmodule(stack[2][0]).__name__.startswith('py3status')
+        valid = False
+        # go through the stack to see how we came through the code
+        for frame in stack[2:]:
+            mod = inspect.getmodule(frame[0])
+            if remote and mod.__name__.split('.')[-1] == s._module_name:
+                # the call to an external module started in the correct module
+                # so allow this usage
+                valid = True
+                break
+            if mod.__name__.startswith('py3status'):
+                # We were somewhere else in py3status than the module, maybe we
+                # are doing some logging.  Prevent usage
+                return process(s._private)
+        if valid:
+            return process(s._value)
+        return process(s._private)
+    return _catch
+
+
+# We need to populate our base class with all the methods that unicode
+# has.  We will implement them using the _catch function created by out
+# factory.  We want to exclude a few select methods
+EXCLUDE = ['__init__', '__getattribute__', '__new__', '__setattr__']
+for attr in dir(u''):
+    if attr.startswith('__') and attr in EXCLUDE:
+        continue
+    if '__call__' in dir(getattr(u'', attr)):
+        setattr(Private, attr, catch_factory(attr))
+
+
+class PrivateBase64(Private):
+    """
+    Simple base64 encoder
+    """
+
+    def _decode(self, key):
+        if self._encoded is None:
+            return
+        try:
+            new_value = base64.b64decode(self._encoded)
+            self._value = new_value.decode('utf-8')
+        except Exception:
+            self._value = 'Error'
+        self._decoded = True
+
+
+class PrivateHide(Private):
+    """
+    This does not encode the data in any way but it does keep it from being
+    shown in the log files, i3bar etc
+    """
+
+    def _decode(self, key):
+        if self._encoded is None:
+            return
+        self._value = self._encoded
+        self._decoded = True
+
+
+if __name__ == '__main__':
+    # This module can read this
+    x = PrivateHide('test', '__main__')
+    print(x)
+    print(x.upper())
+    print(x.split('e'))
+    # This module cannot read this
+    x = PrivateHide('test', 'xxx')
+    print(x)
+    print(x.upper())
+    print(x.split('e'))

--- a/py3status/private.py
+++ b/py3status/private.py
@@ -34,9 +34,18 @@ class Private(object):
         if not self._decoded:
             self._decode(key)
 
+    def __setattr__(self, name, value):
+        """
+        Do not allow this object to be updated outside of this module
+        """
+        stack = inspect.stack()
+        if inspect.getmodule(stack[1][0]).__name__ != __name__:
+            return
+        return object.__setattr__(self, name, value)
+
     def __getattribute__(self, name):
         """
-        Check if user can acces this attribute.
+        Check if user can access this attribute.
         """
         # allowed by all users
         if name in ['_decrypt', '_decode']:


### PR DESCRIPTION
From #415 this adds universal base64 encoding via
```
module {
   value:base64 = '<encoded>'
}
```

@ultrabug if you are happy with this concept I'll update this PR with some documentation