### PR TITLE
Improved formatter

### DIFF
--- a/py3status/formatter.py
+++ b/py3status/formatter.py
@@ -1,0 +1,632 @@
+# -*- coding: utf-8 -*-
+import re
+import sys
+
+try:
+    from urllib.parse import parse_qsl
+except ImportError:
+    from urlparse import parse_qsl
+
+
+class Composite:
+    """
+    Helper class to identify a composite
+    """
+
+    def __init__(self, name):
+        self.name = name
+
+    def __repr__(self):
+        return u'<Composite `{}`>'.format(self.name)
+
+
+class Block:
+    """
+    Represents a block of our format.  Block being contained inside [..]
+
+    A block may contain options split by a pipe | and the first 'valid' block
+    is the one that will be used.  blocks can contain other blocks and also
+    know about their parent block (if they have one)
+    """
+
+    def __init__(self, param_dict, composites, module, parent=None):
+        self.commands = {}
+        self.composites = composites
+        self.content = []
+        self.module = module
+        self.options = []
+        self.param_dict = param_dict
+        self.parent = parent
+        self.valid_blocks = set()
+
+    def __repr__(self):
+        return repr(self.options)
+
+    def add(self, item):
+        """
+        Add item to the block
+        """
+        self.content.append(item)
+
+    def switch(self):
+        """
+        New option has been started
+        """
+        self.options.append(self.content)
+        self.content = []
+
+    def mark_valid(self):
+        """
+        Mark the current block as valid. Propogate this to any parent blocks
+        """
+        self.valid_blocks.add(len(self.options))
+        if self.parent:
+            self.parent.mark_valid()
+
+    def set_commands(self, commands):
+        """
+        Process any commands into a dict and store
+        commands are url query string encoded
+        """
+        self.commands.update(parse_qsl(commands, keep_blank_values=True))
+
+    def is_valid_by_command(self):
+        """
+        Check if we have a command forcing the block to be valid or not
+        """
+        if 'if' in self.commands:
+            _if = self.commands['if']
+            if _if and _if.startswith('!'):
+                if not self.param_dict.get(_if[1:]):
+                    return True
+                else:
+                    return False
+            else:
+                if self.param_dict.get(_if):
+                    return True
+                else:
+                    return False
+        if 'show' in self.commands:
+            return True
+        # explicitly return None to aid code readability
+        return None
+
+    def set_valid_state(self):
+        """
+        Mark block valid if a command requests
+        """
+        if self.is_valid_by_command():
+            self.mark_valid()
+
+    def show(self, is_composite):
+        """
+        This is where we go output the content of a block and any valid child
+        block that it contains.
+
+        """
+        # Start by finalising the block.
+        # Any active content is added to self.options
+        if self.content:
+            self.options.append(self.content)
+
+        output = []
+
+        for index, option in enumerate(self.options):
+            if index in self.valid_blocks:
+                # A block may be valid but has a command that causes this to be
+                # disregarded.
+                if self.is_valid_by_command() is False:
+                    continue
+                # add the content of the block and any children
+                # to the output
+                for item in option:
+                    if isinstance(item, Block):
+                        output.extend(item.show(is_composite))
+                    else:
+                        output.append(item)
+                break
+
+        # if not building a composite then we can simply
+        # build our output and return it here
+        if not is_composite:
+            data = ''.join(output)
+            # apply our max length command
+            if 'max_length' in self.commands:
+                data = data[:int(self.commands['max_length'])]
+            return data
+
+        # Build up our output.  We join any text pieces togeather and if we
+        # have composites we keep them for final substitution in the main block
+        data = []
+        text = ''
+        for item in output:
+            if not isinstance(item, Composite):
+                text += item
+            else:
+                if text:
+                    if is_composite:
+                        data.append({'full_text': text})
+                    else:
+                        data.append(text)
+                text = ''
+                if self.parent is None:
+                    # This is the main block so we get the actual composites
+                    composite = self.composites.get(item.name)
+                    if isinstance(composite, list):
+                        data += composite
+                    else:
+                        data.append(composite)
+                else:
+                    data.append(item)
+        if text:
+            if is_composite:
+                data.append({'full_text': text})
+            else:
+                data.append(text)
+
+        return data
+
+
+class Formatter:
+    """
+    Formatter for processing format strings via the format method.
+    """
+
+    TOKENS = [
+        r'(?P<block_start>\[)'
+        r'|(?P<block_end>\])'
+        r'|(?P<switch>\|)'
+        r'|(\\\?(?P<command>\S*)\s)'
+        r'|(?P<escaped>(\\.|\{\{|\}\}))'
+        r'|(?P<placeholder>(\{(?P<key>([^}\\\:\!]|\\.)*)(([^}\\]|\\.)*)?\}))'
+        r'|(?P<literal>([^\[\]\\\{\}\|])+)'
+        r'|(?P<lost_brace>(\}))'
+    ]
+
+    python2 = sys.version_info < (3, 0)
+    reg_ex = re.compile(TOKENS[0], re.M | re.I)
+
+    def format(self, format_string, module=None, param_dict=None,
+               composites=None):
+        """
+        Format a string.
+        substituting place holders which can be found in
+        composites, param_dict or as attributes of the supplied module.
+        """
+
+        is_composite = composites is not None
+
+        def set_param(param, value, key):
+            """
+            Converts a placeholder to a string value.
+            We fix python 2 unicode issues and use string.format()
+            to ensure that formatting is applied correctly
+            """
+            if self.python2 and isinstance(param, str):
+                param = param.decode('utf-8')
+            if param:
+                value = value.format(**{key: param})
+                block.add(value)
+                block.mark_valid()
+
+        # fix python 2 unicode issues
+        if self.python2 and isinstance(format_string, str):
+            format_string = format_string.decode('utf-8')
+
+        if param_dict is None:
+            param_dict = {}
+
+        if composites is None:
+            composites = {}
+
+        block = Block(param_dict, composites, module)
+
+        # Tokenize the format string and process them
+        for token in re.finditer(self.reg_ex, format_string):
+            value = token.group(0)
+            if token.group('block_start'):
+                # Create new block
+                new_block = Block(param_dict, composites, module, block)
+                block.add(new_block)
+                block = new_block
+            elif token.group('block_end'):
+                # Close block setting any valid state as needed
+                # and return to parent block to continue
+                block.set_valid_state()
+                if not block.parent:
+                    raise Exception('Too many `]`')
+                block = block.parent
+            elif token.group('switch'):
+                # a new option has been created
+                block.set_valid_state()
+                block.switch()
+            elif token.group('placeholder'):
+                # Found a {placeholder}
+                key = token.group('key')
+                if key in composites:
+                    # Add the composite
+                    if composites[key]:
+                        block.add(Composite(key))
+                        block.mark_valid()
+                elif key in param_dict:
+                    # was a supplied parameter
+                    param = param_dict.get(key)
+                    set_param(param, value, key)
+                elif module and hasattr(module, key):
+                    # attribute of the module
+                    param = getattr(module, key)
+                    if not hasattr(param, '__call__'):
+                        set_param(param, value, key)
+                    else:
+                        block.add(value)
+                else:
+                    # substitution not found so add as a literal
+                    block.add(value)
+            elif token.group('literal'):
+                block.add(value)
+            elif token.group('lost_brace'):
+                # due to how parsing happens we can get a lonesome }
+                # eg in format_sting '{{something}' this fixes that issue
+                block.add(value)
+            elif token.group('command'):
+                # a block command has been found
+                block.set_commands(token.group('command'))
+            elif token.group('escaped'):
+                # escaped characters add unescaped values
+                if value[0] in ['\\', '{', '}']:
+                    value = value[1:]
+                block.add(value)
+
+        if block.parent:
+            raise Exception('Block not closed')
+
+        # This is the main block if none of the sections are valid use the last
+        # one for situations like '{placeholder}|Nothing'
+        if not block.valid_blocks:
+            block.mark_valid()
+        return block.show(is_composite)
+
+
+if __name__ == '__main__':
+
+    """
+    Run formatter tests
+    """
+
+    f = Formatter()
+
+    param_dict = {
+        'name': u'Björk',
+        'number': 42,
+        'pi': 3.14159265359,
+        'yes': True,
+        'no': False,
+        'empty': '',
+        'None': None,
+        '?bad name': 'evil',
+        u'☂ Very bad name ': u'☂ extremely evil',
+        'long_str': 'I am a long string though not too long',
+        'python2_unicode': u'Björk',
+        'python2_str': 'Björk',
+    }
+
+    composites = {
+        'complex': [{'full_text': 'LA 09:34'}, {'full_text': 'NY 12:34'}],
+        'simple': {'full_text': 'NY 12:34'},
+        'empty': [],
+    }
+
+    class Module:
+        module_param = 'something'
+
+        def module_method(self):
+            return 'method'
+
+        @ property
+        def module_property(self):
+            return 'property'
+
+    tests = [
+        {
+            'format': u'hello ☂',
+            'expected': u'hello ☂',
+        },
+        {
+            'format': 'hello ☂',
+            'expected': u'hello ☂',
+        },
+        {
+            'format': '[hello]',
+            'expected': '',
+        },
+        {
+            'format': r'\\ \[ \] \{ \}',
+            'expected': r'\ [ ] { }',
+        },
+        {
+            'format': '{{hello}}',
+            'expected': '{hello}',
+        },
+        {
+            'format': '{{hello}',
+            'expected': '{hello}',
+        },
+        {
+            'format': '{?bad name}',
+            'expected': 'evil',
+        },
+        {
+            'format': '{☂ Very bad name }',
+            'expected': '☂ extremely evil',
+        },
+        {
+            'format': '{missing} {name} {number}',
+            'expected': '{missing} Björk 42',
+        },
+        {
+            'format': '{missing}|{name}|{number}',
+            'expected': 'Björk',
+        },
+        {
+            'format': '{missing}|empty',
+            'expected': 'empty',
+        },
+        {
+            'format': '[{missing}|empty]',
+            'expected': '',
+        },
+        {
+            'format': 'pre [{missing}|empty] post',
+            'expected': 'pre  post',
+        },
+        {
+            'format': 'pre [{missing}|empty] post|After',
+            'expected': 'After',
+        },
+        {
+            'format': '{module_param}',
+            'expected': 'something',
+        },
+        {
+            'format': '{module_method}',
+            'expected': '{module_method}',
+        },
+        {
+            'format': '{module_property}',
+            'expected': 'property',
+        },
+        {
+            'format': 'Hello {name}!',
+            'expected': 'Hello Björk!',
+        },
+        {
+            'format': '[Hello {name}!]',
+            'expected': 'Hello Björk!',
+        },
+        {
+            'format': '[Hello {missing}|Anon!]',
+            'expected': '',
+        },
+        {
+            'format': 'zero [one [two [three [no]]]]|Numbers',
+            'expected': 'Numbers',
+        },
+        {
+            'format': 'zero [one [two [three [{yes}]]]]|Numbers',
+            'expected': 'zero one two three True',
+        },
+        {
+            'format': 'zero [one [two [three [{no}]]]]|Numbers',
+            'expected': 'Numbers',
+        },
+        # python 2 unicode
+        {
+            'format': 'Hello {python2_unicode}! ☂',
+            'expected': 'Hello Björk! ☂',
+        },
+        {
+            'format': u'Hello {python2_unicode}! ☂',
+            'expected': 'Hello Björk! ☂',
+        },
+        {
+            'format': 'Hello {python2_str}! ☂',
+            'expected': 'Hello Björk! ☂',
+        },
+        {
+            'format': u'Hello {python2_str}! ☂',
+            'expected': 'Hello Björk! ☂',
+        },
+        # formatting
+        {
+            'format': '{name}',
+            'expected': 'Björk',
+        },
+        {
+            'format': '{name!s}',
+            'expected': 'Björk',
+        },
+        {
+            'format': '{name!r}',
+            'expected': "'Björk'",
+            'py3only': True,
+        },
+        {
+            'format': '{name:7}',
+            'expected': 'Björk  ',
+        },
+        {
+            'format': '{name:<7}',
+            'expected': 'Björk  ',
+        },
+        {
+            'format': '{name:>7}',
+            'expected': '  Björk',
+        },
+        {
+            'format': '{name:*^9}',
+            'expected': '**Björk**',
+        },
+        {
+            'format': '{long_str}',
+            'expected': 'I am a long string though not too long',
+        },
+        {
+            'format': '{long_str:.6}',
+            'expected': 'I am a',
+        },
+        {
+            'format': '{number}',
+            'expected': '42',
+        },
+        {
+            'format': '{number:04d}',
+            'expected': '0042',
+        },
+        {
+            'format': '{pi}',
+            'expected': '3.14159265359',
+        },
+        {
+            'format': '{pi:05.2f}',
+            'expected': '03.14',
+        },
+        # commands
+        {
+            'format': '{missing}|\?show Anon',
+            'expected': 'Anon',
+        },
+        {
+            'format': 'Hello [{missing}|[\?show Anon]]!',
+            'expected': 'Hello Anon!',
+        },
+        {
+            'format': '[\?if=yes Hello]',
+            'expected': 'Hello',
+        },
+        {
+            'format': '[\?if=no Hello]',
+            'expected': '',
+        },
+        {
+            'format': '[\?if=missing Hello]',
+            'expected': '',
+        },
+        {
+            'format': '[\?if=!yes Hello]',
+            'expected': '',
+        },
+        {
+            'format': '[\?if=!no Hello]',
+            'expected': 'Hello',
+        },
+        {
+            'format': '[\?if=!missing Hello]',
+            'expected': 'Hello',
+        },
+        {
+            'format': '[\?if=yes Hello[ {name}]]',
+            'expected': 'Hello Björk',
+        },
+        {
+            'format': '[\?if=no Hello[ {name}]]',
+            'expected': '',
+        },
+        {
+            'format': '[\?max_length=10 Hello {name} {number}]',
+            'expected': 'Hello Björ',
+        },
+        {
+            'format': '\?max_length=9 Hello {name} {number}',
+            'expected': 'Hello Bjö',
+        },
+        # Errors
+        {
+            'format': 'hello]',
+            'exception': 'Too many `]`',
+        },
+        {
+            'format': '[hello',
+            'exception': 'Block not closed',
+        },
+        # Composites
+        {
+            'format': '{empty}',
+            'expected': [],
+            'composite': True,
+        },
+        {
+            'format': '{simple}',
+            'expected': [{'full_text': 'NY 12:34'}],
+            'composite': True,
+        },
+        {
+            'format': '{complex}',
+            'expected': [{'full_text': 'LA 09:34'}, {'full_text': 'NY 12:34'}],
+            'composite': True,
+        },
+        {
+            'format': 'TEST {simple}',
+            'expected': [{'full_text': u'TEST '}, {'full_text': 'NY 12:34'}],
+            'composite': True,
+        },
+        {
+            'format': '[{empty}]',
+            'expected': [],
+            'composite': True,
+        },
+        {
+            'format': '[{simple}]',
+            'expected': [{'full_text': 'NY 12:34'}],
+            'composite': True,
+        },
+        {
+            'format': '[{complex}]',
+            'expected': [{'full_text': 'LA 09:34'}, {'full_text': 'NY 12:34'}],
+            'composite': True,
+        },
+        {
+            'format': 'TEST [{simple}]',
+            'expected': [{'full_text': u'TEST '}, {'full_text': 'NY 12:34'}],
+            'composite': True,
+        },
+    ]
+
+    passed = 0
+    failed = 0
+    module = Module()
+
+    for test in tests:
+        if test.get('py3only') and f.python2:
+            continue
+        try:
+            if test.get('composite'):
+                result = f.format(
+                    test['format'],
+                    module,
+                    param_dict,
+                    composites,
+                )
+            else:
+                result = f.format(test['format'], module, param_dict)
+        except Exception as e:
+            if test.get('exception') == str(e):
+                passed += 1
+                continue
+            else:
+                print('Fail %r' % test['format'])
+                print('exception raised %r' % e)
+                print('')
+                failed += 1
+        expected = test.get('expected')
+        if f.python2 and isinstance(expected, str):
+            expected = expected.decode('utf-8')
+        if result == expected:
+            passed += 1
+        else:
+            print('Fail %r' % test['format'])
+            print('expected %r' % expected)
+            print('got      %r' % result)
+            print('')
+            failed += 1
+
+    print('Tests complete: %s passed %s failed' % (passed, failed))

--- a/py3status/py3.py
+++ b/py3status/py3.py
@@ -1,10 +1,10 @@
 import sys
 import os
-import re
 import shlex
 from time import time
 from subprocess import Popen, call
-from string import Formatter
+
+from py3status.formatter import Formatter
 
 
 PY3_CACHE_FOREVER = -1
@@ -32,6 +32,9 @@ class Py3:
     LOG_ERROR = PY3_LOG_ERROR
     LOG_INFO = PY3_LOG_INFO
     LOG_WARNING = PY3_LOG_WARNING
+
+    # All Py3 Instances can share a formatter
+    _formatter = Formatter()
 
     def __init__(self, module=None, i3s_config=None, py3status=None):
         self._audio = None
@@ -186,168 +189,6 @@ class Py3:
         """
         return time() + seconds
 
-    def _fix_unicode_dict(self, a_dict):
-        """
-        Takes a dict and replaces any str values with their unicode equivalent.
-        Only works for python2
-        """
-        for key, value in a_dict.items():
-            if isinstance(value, str):
-                a_dict[key] = value.decode('utf-8')
-
-    def _safe_format(self, format_string, param_dict):
-        """
-        Parse a format string. we make sure that no undefined parameters are
-        included in the format and if they do we escape them.  We also apply
-        rules around [ | ] etc.
-        """
-
-        # we need to treat \{ and \} specially for the formatter
-        # change them to {{ and }}
-        def my_replace(match):
-            match = match.group()
-            if match == '\\{':
-                return '{{'
-            if match == '\\}':
-                return '}}'
-            return match
-        format_string = re.sub('\\\\.', my_replace, format_string)
-
-        # this class helps us maintain state in the next_item function
-        class Info:
-            part = 0
-            char = None
-
-        try:
-            parsed = list(Formatter().parse(format_string))
-        except ValueError:
-            return 'Invalid Format'
-
-        def next_item(ignore_slash=False):
-            """
-            Get the next item from the pared info.  This will be a single
-            character or placeholder and may be preceded by a backslash.
-            """
-            if Info.part >= len(parsed):
-                # We got to the end of the format string.
-                return None, None
-            # Find the next character location
-            if Info.char is None:
-                Info.char = 0
-            else:
-                Info.char += 1
-            if Info.char >= len(parsed[Info.part][0]):
-                # We have gone of the end of the string is there a placeholder?
-                if parsed[Info.part][1]:
-                    Info.char = None
-                    param = parsed[Info.part][1]
-                    Info.part += 1
-                    if param_dict.get(param) is not None:
-                        # valid placeholder so return it along with any extras
-                        conversion = parsed[Info.part - 1][3]
-                        if conversion:
-                            param += '!%s' % conversion
-                        field_format = parsed[Info.part - 1][2]
-                        if field_format:
-                            param += ':%s' % field_format
-                        return '{%s}' % param, True
-                    elif param not in param_dict:
-                        # Missing placeholder
-                        return '{{%s}}' % param, True
-                    else:
-                        # Empty placeholder
-                        return '', False
-                # Move to next part of the format string
-                Info.char = 0
-                Info.part += 1
-                if Info.part >= len(parsed):
-                    return None, None
-            found = None
-            n = parsed[Info.part][0][Info.char]
-            if n == '\\' and not ignore_slash:
-                # the next item is escaped
-                m, found = next_item(ignore_slash=True)
-                if m:
-                    n += m
-            return n, found
-
-        parts = [['', True, 0]]
-        level = 0
-        block_level = None
-        # We will go through the parsed format string one character/placeholder
-        # at a time.
-        while True:
-            n, found = next_item()
-            if n is None:
-                # Finished
-                break
-            if found:
-                # A placeholder exists so this section is valid
-                parts[len(parts) - 1][1] = True
-                # We need to work out which other sections depend on this one
-                # so that we can make sure they are shown.
-                # [ [ ] | [ ] ] [show [{placeholder}] | [ ] ]
-                fix_level = level
-                for i in range(len(parts) - 2, 0, -1):
-                    part_level = parts[i][2]
-                    if part_level >= fix_level:
-                        continue
-                    parts[i][1] = True
-                    if part_level == 0:
-                        break
-                    fix_level = part_level
-            if n == '':
-                continue
-            if n == '[':
-                # Start a new section
-                level += 1
-                parts.append(['', False, level])
-                continue
-            if n == ']':
-                # Section finished remove if no placeholders found
-                if not parts[len(parts) - 1][1]:
-                    parts = parts[:-1]
-                level -= 1
-                if block_level is not None and level < block_level:
-                    block_level = None
-                continue
-            if n == '|':
-                # Alternative section if we already have output then prevent
-                # any more at this depth.
-                if parts[len(parts) - 1][1]:
-                    if block_level is None:
-                        block_level = level
-                continue
-            if n == '\?':
-                # this is for future functionality
-                n = ''
-            if n and n[0] == '\\':
-                # The item was escaped remove the escape character
-                n = n[1:]
-            if n == '{':
-                n = '{{'
-            if n == '}':
-                n = '}}'
-            if block_level is None:
-                # Add the item if we are not blocking
-                parts[len(parts) - 1][0] += n
-
-        return ''.join([p[0] for p in parts if p[1]])
-
-    def _get_missing_placeholder(self, format_string, param_dict):
-        """
-        Look for missing placeholders in the module.
-        """
-        parsed = [x[1] for x in Formatter().parse(format_string) if x[1]]
-        for item in parsed:
-            if (item not in param_dict and
-                    hasattr(self._py3status_module, item)):
-                attribute = getattr(self._py3status_module, item)
-                if hasattr(attribute, '__call__'):
-                    # ignore if a function
-                    continue
-                param_dict[item] = attribute
-
     def safe_format(self, format_string, param_dict=None):
         """
         Parser for advanced formating.
@@ -378,15 +219,14 @@ class Py3:
         If a placeholder is not in the dictionary then if the py3status module
         has an attribute with the same name then it will be used.
         """
-        if param_dict is None:
-            param_dict = {}
-
-        self._get_missing_placeholder(format_string, param_dict)
-
-        if self._is_python_2:
-            self._fix_unicode_dict(param_dict)
-        # Output our format string with the placeholders substituted.
-        return self._safe_format(format_string, param_dict).format(**param_dict)
+        try:
+            return self._formatter.format(
+                format_string,
+                self._module,
+                param_dict
+            )
+        except Exception:
+            return 'invalid format'
 
     def build_composite(self, format_string, param_dict=None, composites=None):
         """
@@ -397,45 +237,15 @@ class Py3:
         placeholder and either an output eg `{'full_text': 'something'}` or a
         list of outputs.
         """
-        if param_dict is None:
-            param_dict = {}
-        if composites is None:
-            composites = {}
-
-        self._get_missing_placeholder(format_string, param_dict)
-
-        if self._is_python_2:
-            self._fix_unicode_dict(param_dict)
-
-        # Make sure that placeholders for our composites are kept by adding
-        # entries if not in param_dict
-        my_data = param_dict.copy()
-        for composite in composites:
-            if composite not in my_data:
-                my_data[composite] = True
-
-        output_format = self._safe_format(format_string, my_data)
-        parsed = list(Formatter().parse(output_format))
-
-        output = []
-        text = u''
-        for item in parsed:
-            text += item[0]
-            if item[1]:
-                if item[1] in param_dict:
-                    text = u'{}{}'.format(text, param_dict[item[1]])
-                else:
-                    if text:
-                        output.append({'full_text': text})
-                        text = u''
-                    composite = composites[item[1]]
-                    if isinstance(composite, list):
-                        output += composite
-                    else:
-                        output.append(composite)
-        if text:
-            output.append({'full_text': text})
-        return output
+        try:
+            return self._formatter.format(
+                format_string,
+                self._module,
+                param_dict,
+                composites,
+            )
+        except Exception:
+            return [{'full_text': 'invalid format'}]
 
     def check_commands(self, cmd_list):
         """


### PR DESCRIPTION
So `_safe_format()` had a few issues where it didn't behave as i would have liked.

eg `'{empty}|nothing here'` would return `''` rather than `'nothing here'`

Additionally the code was starting to become quite hard to read, possibly buggy, and prevented expansion of new ideas eg block commands things like `[\?max_length=10 {file-name}]` `[\?if=param Hello]`

Anyhow I have written a formatter it uses a simple parser similar to the config parser.  It also makes py3.py much shorter and easier to read.

Plus it has tests `python formatter.py`

I think seeing as we are going to shift modules to safe_format() that having a solid implementation is an improvement. 

