### PR TITLE
formatter updates

### DIFF
--- a/py3status/module.py
+++ b/py3status/module.py
@@ -439,8 +439,13 @@ class Module(Thread):
                     else:
                         # validate the response
                         if 'full_text' not in result:
-                            err = 'missing "full_text" key in response'
-                            raise KeyError(err)
+                            try:
+                                # try to set the full_text automatically
+                                full_text = self.module_class.py3.safe_format()
+                                result['full_text'] = full_text
+                            except:
+                                err = 'missing "full_text" key in response'
+                                raise KeyError(err)
                         # set universal module options in result
                         result.update(self.module_options)
 


### PR DESCRIPTION
So this does the following

* ~~Bug fix: we were passing `self._module` (Module) not `self._py3status_module` (Py3status) to the formatter.~~ 

* Auto select `self.format` for format_string if not passed by a module

* Change calling parameters so that we can deal with `()`, `(format, dict)`, `(dict)` etc

* auto-magically grab the `full_text` if missing from the response dict

If this is ok then I'll update the docs etc in this PR