### PR TITLE
py3status docstrings: Allow checking docstring for specific modules

### DIFF
--- a/py3status/core.py
+++ b/py3status/core.py
@@ -761,7 +761,11 @@ class Py3statusWrapper():
         elif cmd[:2] in (['docstring', 'check'], ['docstring', 'update']):
             if cmd[1] == 'check':
                 show_diff = len(cmd) > 2 and cmd[2] == 'diff'
-                docstrings.check_docstrings(show_diff, config)
+                if show_diff:
+                    mods = cmd[3:]
+                else:
+                    mods = cmd[2:]
+                docstrings.check_docstrings(show_diff, config, mods)
             if cmd[1] == 'update':
                 if len(cmd) < 3:
                     print_stderr('Error: you must specify what to update')

--- a/py3status/docstrings.py
+++ b/py3status/docstrings.py
@@ -258,26 +258,37 @@ def update_docstrings():
     print_stderr('Modules updated from README.md')
 
 
-def check_docstrings(show_diff=False, config=None):
+def check_docstrings(show_diff=False, config=None, mods=None):
     '''
     Check docstrings in module match the README.md
     '''
 
     readme = parse_readme()
     modules_readme = core_module_docstrings(config=config)
+    warned = False
     if (create_readme(readme) != create_readme(modules_readme)):
-        print_stderr('Documentation does not match!\n')
-        for module in readme:
+        for module in sorted(readme):
+            if mods and module not in mods:
+                continue
+            err = None
             if module not in modules_readme:
-                print_stderr(
-                    '\tModule {} in README but not in /modules'.format(module))
+                err = '\tModule {} in README but not in /modules'.format(
+                    module
+                )
             elif ''.join(readme[module]).strip() != ''.join(modules_readme[
                     module]).strip():
-                print_stderr(
-                    '\tModule {} docstring does not match README'.format(
-                        module))
+                err = '\tModule {} docstring does not match README'.format(
+                    module
+                )
+            if err:
+                if not warned:
+                    print_stderr('Documentation does not match!\n')
+                    warned = True
+                print_stderr(err)
 
         for module in modules_readme:
+            if mods and module not in mods:
+                continue
             if module not in readme:
                 print_stderr(
                     '\tModule {} in /modules but not in README'.format(module))
@@ -286,8 +297,10 @@ def check_docstrings(show_diff=False, config=None):
                 create_readme(readme).split('\n'), create_readme(
                     modules_readme).split('\n'))))
         else:
-            print_stderr()
-            print_stderr('Use `py3status docstring check diff` to view diff.')
+            if warned:
+                print_stderr(
+                    '\nUse `py3status docstring check diff` to view diff.'
+                )
 
 
 def update_readme_for_modules(modules):


### PR DESCRIPTION
When using `py3status docstring check` allow modules to be specified eg  `py3status docstring check xrandr`

