### PR TITLE
Remove additional separator at the end of frames

### DIFF
--- a/py3status/modules/frame.py
+++ b/py3status/modules/frame.py
@@ -103,6 +103,10 @@ class Py3status:
                         out += [{'full_text': self.format_separator}]
                 output += out
 
+            # Remove last separator
+            if self.format_separator:
+                output = output[:-1]
+
         if '{button}' in self.format:
             if self.open:
                 format_control = self.format_button_open


### PR DESCRIPTION
This PR removes the additional separator that were added at the end of frames. This is only if "separator" is set. If this was an expected behaviour, I'll add an option to remove it.