### PR TITLE
Bugfix: weather_yahoo TypeError

### DIFF
--- a/py3status/modules/weather_yahoo.py
+++ b/py3status/modules/weather_yahoo.py
@@ -90,8 +90,11 @@ class Py3status:
             return None, None
         q.raise_for_status()
         r = q.json()
-        today = r['query']['results']['channel']['item']['condition']
-        forecasts = r['query']['results']['channel']['item']['forecast']
+        try:
+            today = r['query']['results']['channel']['item']['condition']
+            forecasts = r['query']['results']['channel']['item']['forecast']
+        except TypeError:
+            return None, None
         if not self.forecast_include_today:
             # Do not include today in forecasts
             forecasts.pop(0)


### PR DESCRIPTION
I get errors like this periodically with weather_yahoo module
```
2016-08-29 02:00:22 WARNING Instance `weather_yahoo _anon_module_2`, user method `weather_yahoo` failed (TypeError) weather_yahoo.py line 93.
2016-08-29 02:00:22 INFO Traceback
TypeError: 'NoneType' object has no attribute '__getitem__'
  File "/home/toby/dev/py3status/py3status/module.py", line 419, in run
    response = method()
  File "/home/toby/dev/py3status/py3status/modules/weather_yahoo.py", line 153, in weather_yahoo
    today, forecasts = self._get_forecast()
  File "/home/toby/dev/py3status/py3status/modules/weather_yahoo.py", line 93, in _get_forecast
    today = r['query']['results']['channel']['item']['condition']
```

This just catches that and behaves as if there was a connection or other error