### PR TITLE
Add format_charging and format_full to battery_level

### DIFF
--- a/py3status/modules/battery_level.py
+++ b/py3status/modules/battery_level.py
@@ -16,6 +16,10 @@ Configuration parameters:
         default is "⚡"
     format: string that formats the output. See placeholders below.
         default is "{icon}"
+    format_charging: string that formats the output when charging. Defaults to
+        the value of format. See placeholders below.
+    format_full: string that formats the output when the battery is full.
+        Defaults to the value of format. See placeholders below.
     format_notify_charging: format of the notification received when you click
         on the module while your computer is plugged
         default is "Charging ({percent}%)"
@@ -106,6 +110,8 @@ class Py3status:
     cache_timeout = 30
     charging_character = CHARGING_CHARACTER
     format = FORMAT
+    format_charging = None
+    format_full = None
     format_notify_charging = FORMAT_NOTIFY_CHARGING
     format_notify_discharging = FORMAT_NOTIFY_DISCHARGING
     hide_when_full = False
@@ -118,6 +124,9 @@ class Py3status:
     # obsolete configuration parameters
     mode = None
     show_percent_with_blocks = None
+
+    def __init__(self):
+        self.last_known_status = None
 
     def battery_level(self):
 
@@ -309,10 +318,27 @@ class Py3status:
                                                   (len(self.blocks) - 1)))]
 
     def _update_full_text(self):
-        self.full_text = self.format.format(ascii_bar=self.ascii_bar,
-                                            icon=self.icon,
-                                            percent=self.percent_charged,
-                                            time_remaining=self.time_remaining)
+        if self.charging and self.format_charging:
+            self.full_text = self.py3.safe_format(self.format_charging,
+                                                  {'ascii_bar': self.ascii_bar,
+                                                   'icon': self.icon,
+                                                   'percent': self.percent_charged,
+                                                   'time_remaining': self.time_remaining,
+                                                   })
+        elif self.last_known_status == 'full' and self.format_full:
+            self.full_text = self.py3.safe_format(self.format_full,
+                                                  {'ascii_bar': self.ascii_bar,
+                                                   'icon': self.icon,
+                                                   'percent': self.percent_charged,
+                                                   'time_remaining': self.time_remaining,
+                                                   })
+        else:
+            self.full_text = self.py3.safe_format(self.format,
+                                                  {'ascii_bar': self.ascii_bar,
+                                                   'icon': self.icon,
+                                                   'percent': self.percent_charged,
+                                                   'time_remaining': self.time_remaining,
+                                                   })
 
     def _build_response(self):
         self.response = {}

--- a/py3status/modules/battery_level.py
+++ b/py3status/modules/battery_level.py
@@ -85,7 +85,6 @@ Requires:
 """
 
 from __future__ import division  # python2 compatibility
-from time import time
 from re import findall
 
 import math

--- a/py3status/modules/battery_level.py
+++ b/py3status/modules/battery_level.py
@@ -378,7 +378,7 @@ class Py3status:
         self.last_known_status = battery_status
 
     def _set_cache_timeout(self):
-        self.response['cached_until'] = time() + self.cache_timeout
+        self.response['cached_until'] = self.py3.time_in(seconds=self.cache_timeout)
 
     def _notify(self, text, urgency):
         subprocess.call(


### PR DESCRIPTION
This allows for changing the displayed string based on the status of the battery.

Also switched to `self.py3.safe_format` and `self.py3.time_in`