### PR TITLE
Bugfix formatter composites error

### DIFF
--- a/py3status/formatter.py
+++ b/py3status/formatter.py
@@ -144,7 +144,7 @@ class Block:
                 text += item
             else:
                 if text:
-                    if is_composite:
+                    if is_composite and self.parent is None:
                         data.append({'full_text': text})
                     else:
                         data.append(text)
@@ -159,7 +159,7 @@ class Block:
                 else:
                     data.append(item)
         if text:
-            if is_composite:
+            if is_composite and self.parent is None:
                 data.append({'full_text': text})
             else:
                 data.append(text)
@@ -649,6 +649,11 @@ if __name__ == '__main__':
         {
             'format': 'TEST [{simple}]',
             'expected': [{'full_text': u'TEST '}, {'full_text': 'NY 12:34'}],
+            'composite': True,
+        },
+        {
+            'format': '{simple} TEST [{name}[ {number}]]',
+            'expected':  [{'full_text': 'NY 12:34'}, {'full_text': u' TEST Björk 42'}],
             'composite': True,
         },
     ]


### PR DESCRIPTION
This is for a bug in the formatter.  When we had a format like `'{composite}  [{placeholder}]'` the placeholder would end up being converted into a `{'full_text':...}` item too early in the processing, it should only be converted to this form in the final block (the one with no parent).

I've added a test for this case.