### PR TITLE
kdeconnector: fix for notifications not available

### DIFF
--- a/py3status/modules/kdeconnector.py
+++ b/py3status/modules/kdeconnector.py
@@ -184,7 +184,10 @@ class Py3status:
         """
         Get the notifications status
         """
-        size = len(notifications['activeNotifications'])
+        if notifications:
+            size = len(notifications['activeNotifications'])
+        else:
+            size = 0
         status = self.status_notif if size > 0 else self.status_no_notif
 
         return (size, status)


### PR DESCRIPTION
If notifications are disabled via  `kcmshell5 kcm_kdeconnect` then we get the following error.

```
TypeError: 'NoneType' object is not subscriptable
  File "/home/toby/dev/py3status/py3status/module.py", line 419, in run
    response = method()
  File "/home/toby/dev/py3status/py3status/modules/kdeconnector.py", line 221, in kdeconnector
    (text, color) = self._get_text()
  File "/home/toby/dev/py3status/py3status/modules/kdeconnector.py", line 208, in _get_text
    (notif_size, notif_status) = self._get_notifications_status(notif)
  File "/home/toby/dev/py3status/py3status/modules/kdeconnector.py", line 187, in _get_notifications_status
    size = len(notifications['activeNotifications'])
```

This is a simple fix for that 