### PR TITLE
fix log exception when message contains special characters, by @Lujeni

### DIFF
--- a/py3status/core.py
+++ b/py3status/core.py
@@ -482,7 +482,7 @@ class Py3statusWrapper():
         if not self.config['log_file']:
             # If level was given as a str then convert to actual level
             level = LOG_LEVELS.get(level, level)
-            syslog(level, msg)
+            syslog(level, u'{}'.format(msg))
         else:
             with open(self.config['log_file'], 'a') as f:
                 log_time = time.strftime("%Y-%m-%d %H:%M:%S")


### PR DESCRIPTION
reported on IRC

@Lujeni was affected also and found the problem and this patch.

I'm doing the PR since he's busy and I'd like 3.1 out.