### PR TITLE
Fix for occassional timezone bug

### DIFF
--- a/py3status/i3status.py
+++ b/py3status/i3status.py
@@ -140,7 +140,11 @@ class I3statusModule:
         # get datetime and time zone info
         parts = i3s_time.split()
         i3s_datetime = ' '.join(parts[:2])
-        i3s_time_tz = parts[2]
+        # occassionally we do not get the timezone name
+        if len(parts) < 3:
+            return
+        else:
+            i3s_time_tz = parts[2]
 
         date = datetime.strptime(i3s_datetime, TIME_FORMAT)
         # calculate the time delta


### PR DESCRIPTION
On rare occasions I've had this error.  I'm not sure quite what causes it but this patch will stop the error.

```
IndexError: list index out of range
  File "/home/toby/dev/py3status/py3status/i3status.py", line 349, in spawn_i3status
    self.set_responses(json_list)
  File "/home/toby/dev/py3status/py3status/i3status.py", line 227, in set_responses
    if self.i3modules[conf_name].update_from_item(item):
  File "/home/toby/dev/py3status/py3status/i3status.py", line 105, in update_from_item
    self.set_time_zone()
  File "/home/toby/dev/py3status/py3status/i3status.py", line 143, in set_time_zone
    i3s_time_tz = parts[2]
```