### PR TITLE
Run all post config hooks before starting any modules

### DIFF
--- a/py3status/core.py
+++ b/py3status/core.py
@@ -667,20 +667,23 @@ class Py3statusWrapper():
         # initialize usage variables
         i3status_thread = self.i3status_thread
         config = i3status_thread.config
-        self.create_output_modules()
 
         # prepare the color mappings
         self.create_mappings(config)
 
-        # start modules
         # self.output_modules needs to have been created before modules are
         # started.  This is so that modules can do things like register their
-        # content_functionn.
+        # content_function.
+        self.create_output_modules()
+
+        # Some modules need to be prepared before they can run
+        # eg run their post_config_hook
+        for module in self.modules.values():
+            module.prepare_module()
+
+        # start modules
         for module in self.modules.values():
             module.start_module()
-
-        # update queue populate with all py3modules
-        self.queue.extend(self.modules)
 
         # this will be our output set to the correct length for the number of
         # items in the bar

--- a/py3status/module.py
+++ b/py3status/module.py
@@ -82,9 +82,9 @@ class Module(Thread):
         class_inst = py_mod.Py3status()
         return class_inst
 
-    def start_module(self):
+    def prepare_module(self):
         """
-        Start the module running.
+        Ready the module to get it ready to start.
         """
         # Modules can define a post_config_hook() method which will be run
         # after the module has had it config settings applied and before it has
@@ -92,6 +92,11 @@ class Module(Thread):
         # perform any necessary setup.
         if self.has_post_config_hook:
             self.module_class.post_config_hook()
+
+    def start_module(self):
+        """
+        Start the module running.
+        """
         # Start the module and call its output method(s)
         self.start()
 

--- a/py3status/modules/group.py
+++ b/py3status/modules/group.py
@@ -101,16 +101,14 @@ class Py3status:
     class Meta:
         container = True
 
-    def __init__(self):
-        self.items = []
-        self.active = 0
-        self.initialized = False
-
-    def _init(self):
+    def post_config_hook(self):
         # if no items don't cycle
         if not self.items:
             self.cycle = 0
+
+        self.active = 0
         self._cycle_time = time() + self.cycle
+
         self.open = bool(self.open)
         # set default format etc based on click_mode
         if self.format is None:
@@ -182,9 +180,6 @@ class Py3status:
                 'cached_until': self.py3.CACHE_FOREVER,
                 'full_text': '',
             }
-
-        if not self.initialized:
-            self._init()
 
         if self.open:
             if self.cycle and time() >= self._cycle_time:


### PR DESCRIPTION
Because the `post_config_hook()` was run when a module started, it was possible for content of groups to be updated and trigger an update of the group before the group had its `post_config_hook()` run.

This PR ensures that all modules have their `post_config_hook()` run before any modules are started.

This also updates group module to use post_config_hook()