### PR TITLE
Move sleep to start of main loop in core.py

### DIFF
--- a/py3status/core.py
+++ b/py3status/core.py
@@ -700,6 +700,11 @@ class Py3statusWrapper():
 
         # main loop
         while True:
+            # sleep a bit to avoid killing the CPU
+            # by doing this at the begining rather than the end
+            # of the loop we ensure a smoother first render of the i3bar
+            time.sleep(0.1)
+
             while not self.i3bar_running:
                 time.sleep(0.1)
 
@@ -742,9 +747,6 @@ class Py3statusWrapper():
                 out = ','.join([x for x in output if x])
                 # dump the line to stdout
                 print_line(',[{}]'.format(out))
-
-            # sleep a bit before doing this again to avoid killing the CPU
-            time.sleep(0.1)
 
     def handle_cli_command(self, config):
         """Handle a command from the CLI.


### PR DESCRIPTION
By moving the sleep from the end of the main loop to the beginning we allow more modules to have provided output when we first display.  This makes the initial display when we Mod+Shift+R etc much smoother.
