### PR TITLE
Groups switch to urgent items

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -832,6 +832,33 @@ offset is used to alter the base time used. A timer that started at a
 certain time could set that as the offset and any syncronisation would
 then be relative to that time.
 
+__register_function(function_name, function)__
+
+Register a function for the module.
+
+The following functions can be registered
+
+> __content_function()__
+>
+> Called to discover what modules a container is displaying.  This is
+> used to determine when updates need passing on to the container and
+> also when modules can be put to sleep.
+>
+> the function must return a set of module names that are being
+> displayed.
+>
+> Note: This function should only be used by containers.
+>
+> __urgent_function(module_names)__
+>
+> This function will be called when one of the contents of a container
+> has changed from a non-urgent to an urgent state.  It is used by the
+> group module to switch to displaying the urgent module.
+>
+> `module_names` is a list of modules that have become urgent
+>
+> Note: This function should only be used by containers.
+
 __safe_format(format_string, param_dict=None)__
 
 Parser for advanced formating.

--- a/py3status/core.py
+++ b/py3status/core.py
@@ -446,7 +446,7 @@ class Py3statusWrapper():
         """
         raise KeyboardInterrupt()
 
-    def notify_update(self, update):
+    def notify_update(self, update, urgent=False):
         """
         Name or list of names of modules that have updated.
         """
@@ -464,6 +464,10 @@ class Py3statusWrapper():
         for container in containers_to_update:
             container_module = self.output_modules.get(container)
             if container_module:
+                # If the container registered a urgent_function then call it
+                # if this update is urgent.
+                if urgent and container_module.get('urgent_function'):
+                    container_module['urgent_function'](update)
                 # If a container has registered a content_function we use that
                 # to see if the container needs to be updated.
                 # We only need to update containers if their active content has

--- a/py3status/module.py
+++ b/py3status/module.py
@@ -43,6 +43,7 @@ class Module(Thread):
         self.prevent_refresh = False
         self.sleeping = False
         self.timer = None
+        self.urgent = False
 
         # py3wrapper this is private and any modules accessing their instance
         # should only use it on the understanding that it is not supported.
@@ -145,8 +146,16 @@ class Module(Thread):
                 output.append(data)
         # if changed store and force display update.
         if output != self.last_output:
+            # has the modules output become urgent?
+            # we only care the update that this happens
+            # not any after then.
+            urgent = True in [x.get('urgent') for x in output]
+            if urgent != self.urgent:
+                self.urgent = urgent
+            else:
+                urgent = False
             self.last_output = output
-            self._py3_wrapper.notify_update(self.module_full_name)
+            self._py3_wrapper.notify_update(self.module_full_name, urgent)
 
     def get_latest(self):
         """

--- a/py3status/modules/group.py
+++ b/py3status/modules/group.py
@@ -121,8 +121,8 @@ class Py3status:
         # if no button then force open
         if '{button}' not in self.format:
                 self.open = True
-        self.py3.register_content_function(self._content_function)
-        self.initialized = True
+        self.py3.register_function('content_function', self._content_function)
+        self.py3.register_function('urgent_function', self._urgent_function)
 
     def _content_function(self):
         '''
@@ -130,6 +130,14 @@ class Py3status:
         only get update events triggered for these modules.
         '''
         return set([self.items[self.active]])
+
+    def _urgent_function(self, module_list):
+        '''
+        A contained module has become urgent.  We want to display it to the user
+        '''
+        for module in module_list:
+            if module in self.items:
+                self.active = self.items.index(module)
 
     def _get_output(self):
         if not self.fixed_width:

--- a/py3status/py3.py
+++ b/py3status/py3.py
@@ -184,20 +184,36 @@ class Py3:
             self._module._py3_wrapper.notify_user(
                 msg, level=level, rate_limit=rate_limit, module_name=module_name)
 
-    def register_content_function(self, content_function):
+    def register_function(self, function_name, function):
         """
-        Register a function that can be called to discover what modules a
-        container is displaying.  This is used to determine when updates need
-        passing on to the container and also when modules can be put to sleep.
+        Register a function for the module.
 
-        the function must return a set of module names that are being
-        displayed.
+        The following functions can be registered
 
-        Note: This function should only be used by containers.
+        > __content_function()__
+        >
+        > Called to discover what modules a container is displaying.  This is
+        > used to determine when updates need passing on to the container and
+        > also when modules can be put to sleep.
+        >
+        > the function must return a set of module names that are being
+        > displayed.
+        >
+        > Note: This function should only be used by containers.
+        >
+        > __urgent_function(module_names)__
+        >
+        > This function will be called when one of the contents of a container
+        > has changed from a non-urgent to an urgent state.  It is used by the
+        > group module to switch to displaying the urgent module.
+        >
+        > `module_names` is a list of modules that have become urgent
+        >
+        > Note: This function should only be used by containers.
         """
         if self._module:
             my_info = self._get_module_info(self._module.module_full_name)
-            my_info['content_function'] = content_function
+            my_info[function_name] = function
 
     def time_in(self, seconds=None, sync_to=None, offset=0):
         """


### PR DESCRIPTION
This implements #469

`Py3.register_content_function()` has now been replaced with a more general `Py3.register_function()` and it is now documented.

