### PR TITLE
kdeconnector: API fix

### DIFF
--- a/py3status/modules/kdeconnector.py
+++ b/py3status/modules/kdeconnector.py
@@ -127,7 +127,7 @@ class Py3status:
             device = {
                 'name': self._dev.name,
                 'isReachable': self._dev.isReachable,
-                'isPaired': self._dev.isPaired,
+                'isTrusted': self._dev.isTrusted,
             }
         except Exception:
             return None
@@ -203,7 +203,7 @@ class Py3status:
         if device is None:
             return (UNKNOWN_DEVICE, self.py3.COLOR_BAD)
 
-        if not device['isReachable'] or not device['isPaired']():
+        if not device['isReachable'] or not device['isTrusted']():
             return (self.py3.safe_format(self.format_disconnected,
                                          {'name': device['name']}),
                     self.py3.COLOR_BAD)

--- a/py3status/modules/kdeconnector.py
+++ b/py3status/modules/kdeconnector.py
@@ -120,15 +120,18 @@ class Py3status:
         return None
 
     def _get_isTrusted(self):
+        if self._dev is None:
+            return False
+
         try:
             # New method which replaced 'isPaired' in version 1.0
-            return self._dev.isTrusted
-        except Exception:
+            return self._dev.isTrusted()
+        except AttributeError:
             try:
-                # Deprecated
-                return self._dev.isPaired
-            except Exception:
-                return None
+                # Deprecated since version 1.0
+                return self._dev.isPaired()
+            except AttributeError:
+                return False
 
     def _get_device(self):
         """
@@ -138,7 +141,7 @@ class Py3status:
             device = {
                 'name': self._dev.name,
                 'isReachable': self._dev.isReachable,
-                'isTrusted': self._get_isTrusted,
+                'isTrusted': self._get_isTrusted(),
             }
         except Exception:
             return None
@@ -214,7 +217,7 @@ class Py3status:
         if device is None:
             return (UNKNOWN_DEVICE, self.py3.COLOR_BAD)
 
-        if not device['isReachable'] or not device['isTrusted']():
+        if not device['isReachable'] or not device['isTrusted']:
             return (self.py3.safe_format(self.format_disconnected,
                                          {'name': device['name']}),
                     self.py3.COLOR_BAD)

--- a/py3status/modules/kdeconnector.py
+++ b/py3status/modules/kdeconnector.py
@@ -119,6 +119,17 @@ class Py3status:
 
         return None
 
+    def _get_isTrusted(self):
+        try:
+            # New method which replaced 'isPaired' in version 1.0
+            return self._dev.isTrusted
+        except Exception:
+            try:
+                # Deprecated
+                return self._dev.isPaired
+            except Exception:
+                return None
+
     def _get_device(self):
         """
         Get the device
@@ -127,7 +138,7 @@ class Py3status:
             device = {
                 'name': self._dev.name,
                 'isReachable': self._dev.isReachable,
-                'isTrusted': self._dev.isTrusted,
+                'isTrusted': self._get_isTrusted,
             }
         except Exception:
             return None


### PR DESCRIPTION
`isPaired` is deprecated and module doesn't work anymore with the new kdeconnector version.