### PR TITLE
Fix safe format refactoring regressions

### DIFF
--- a/py3status/modules/xrandr_rotate.py
+++ b/py3status/modules/xrandr_rotate.py
@@ -126,7 +126,7 @@ class Py3status:
                 screen = self.screen or all_outputs[0]
             else:
                 screen = 'ALL'
-            full_text = self.py3.safe_format(self.format.format,
+            full_text = self.py3.safe_format(self.format,
                                              dict(icon=self.displayed or '?',
                                                   screen=screen))
 

--- a/py3status/modules/yandexdisk_status.py
+++ b/py3status/modules/yandexdisk_status.py
@@ -57,7 +57,7 @@ class Py3status:
             status = 'Busy'
             response['color'] = self.py3.COLOR_DEGRADED
 
-        full_text = self.py3.safe_format(self.format.format, {'status': status})
+        full_text = self.py3.safe_format(self.format, {'status': status})
         response['full_text'] = full_text
         return response
 


### PR DESCRIPTION
`self.format` is a string that needs to be passed into `safe_format()`, not `self.format.format`, which is a function.