### PR TITLE
Tests: module docstrings

### DIFF
--- a/py3status/modules/backlight.py
+++ b/py3status/modules/backlight.py
@@ -4,9 +4,14 @@ Display the current screen backlight level.
 
 Configuration parameters:
     cache_timeout: How often we refresh this module in seconds (default 10)
-    device:        The backlight device
-                   If not specified the plugin will detect it automatically
-    format:        Display brightness, see placeholders below
+    device: The backlight device
+        If not specified the plugin will detect it automatically
+        (default None)
+    device_path: path to backlight eg /sys/class/backlight/acpi_video0
+        if None then use first device found.
+        (default None)
+    format: Display brightness, see placeholders below
+        (default '☼: {level}%')
 
 Format status string parameters:
     {level} brightness

--- a/py3status/modules/process_status.py
+++ b/py3status/modules/process_status.py
@@ -7,7 +7,8 @@ Configuration parameters:
     format_not_running: what to display when process is not running
         (default '■')
     format_running: what to display when process running (default '●')
-    full: if True, match against the full command line and not just the process name
+    full: if True, match against the full command line and not just the
+        process name (default False)
     process: the process name to check if it is running (default None)
 
 Color options:

--- a/py3status/modules/scratchpad_async.py
+++ b/py3status/modules/scratchpad_async.py
@@ -5,8 +5,6 @@ Display the amount of windows and indicate urgency hints on scratchpad (async).
 Configuration parameters:
     always_show: whether the indicator should be shown if there are no
         scratchpad windows (default False)
-    color_urgent: color to use if a scratchpad window is urgent
-        (default "#900000")
     format: string to format the output (default "{} ⌫")
 
 Requires:

--- a/tests/test_module_doc.py
+++ b/tests/test_module_doc.py
@@ -1,0 +1,196 @@
+"""
+This tests module docstrings to ensure
+
+* all the config options are documented
+
+* correct default values are given
+
+* config parameters listed in alphabetical order
+
+Specific modules/config parameters are excluded but this should be discouraged.
+"""
+
+import re
+from collections import OrderedDict
+
+from py3status.docstrings import core_module_docstrings
+
+IGNORE_MODULE = [
+    # Cannot be imported due to missing libs
+    'aws_bill',
+    'glpi',
+    'mpd_status',
+    'ns_checker',
+    'rt',
+    'scratchpad_counter',
+]
+
+IGNORE_ITEM = [
+    ('screenshot', 'save_path'),  # home dir issue
+    ('rate_counter', 'config_file'),  # home dir issue
+    ('group', 'format'),  # dynamic depending on click_mode
+    ('github', 'format'),  # dynamic
+]
+
+RE_PARAM = re.compile(
+    '^  - `(?P<name>[^`]*)`.*?('
+    '\*\(default (?P<value>('
+    '("[^"]*")'  # double quote strings
+    '|'
+    "('[^']*')"  # quote strings
+    '|'
+    '([^)]*)'  # anything else
+    '))\)\*)?$'
+)
+
+
+def docstring_params(docstring):
+    """
+    Crudely parse the docstring and get parameters and their defaults
+    """
+
+    def find_line(text):
+        for index, line in enumerate(docstring):
+            if line == text:
+                return index + 1
+
+    def find_params(start):
+        """
+        find documented parameters and add them to params dict
+        """
+        params = OrderedDict()
+        if start is None:
+            return params
+        lines = []
+        for part in docstring[start:]:
+            if part == '\n':
+                break
+            if part.startswith('  - '):
+                lines.append(part[:-1])
+                continue
+            lines[-1] += part[:-1]
+
+        for line in lines:
+            match = RE_PARAM.match(line)
+            if match:
+                if match.group('value'):
+                    try:
+                        value = eval(match.group('value'))
+                        if isinstance(value, str):
+                            try:
+                                value = value.decode('utf-8')
+                            except AttributeError:
+                                # python3
+                                pass
+                        try:
+                            value = value.replace('&amp;', '&')
+                            value = value.replace('&lt;', '<')
+                            value = value.replace('&gt;', '>')
+                        except AttributeError:
+                            pass
+                        # wrap in tuple to distinguish None from missing
+                        value = (value, )
+                    except (SyntaxError, NameError):
+                        value = '?Unknown?'
+                else:
+                    value = None
+                params[match.group('name')] = value
+        return params
+
+    params = find_params(find_line('Configuration parameters:\n'))
+    obsolete = find_params(find_line('Obsolete configuration parameters:\n'))
+    return params, obsolete
+
+
+def check_docstrings():
+    all_errors = []
+    docstrings = core_module_docstrings()
+    for module_name in sorted(docstrings.keys()):
+        errors = []
+        if module_name in IGNORE_MODULE:
+            continue
+        name = 'py3status.modules.{}'.format(module_name)
+        try:
+            py_mod = __import__(name)
+            pass
+        except ImportError as e:
+            msg = 'Cannot import module `{}` {}'
+            errors.append(msg.format(module_name, e))
+            continue
+        except Exception as e:
+            msg = 'Cannot import module `{}` {}'
+            errors.append(msg.format(module_name, e))
+            continue
+
+        try:
+            py_mod = __import__(name)
+            py3_mod = getattr(py_mod.modules, module_name).Py3status
+        except AttributeError as e:
+            msg = 'Module `{}` pas no Py3status class'
+            errors.append(msg.format(module_name))
+            continue
+        mod_config = OrderedDict()
+        for attribute_name in sorted(dir(py3_mod)):
+            if attribute_name.startswith('_'):
+                continue
+            attribute = getattr(py3_mod, attribute_name)
+            if repr(attribute).startswith('<'):
+                continue
+            if isinstance(attribute, str):
+                try:
+                    attribute = attribute.decode('utf-8')
+                except AttributeError:
+                    # python3
+                    pass
+            mod_config[attribute_name] = attribute
+        params, obsolete = docstring_params(docstrings[module_name])
+
+        if list(params.keys()) != list(sorted(params.keys())):
+            keys = list(sorted(params.keys()))
+            msg = 'config params not in alphabetical order should be\n{keys}'
+            errors.append(msg.format(keys=keys))
+        if list(obsolete.keys()) != list(sorted(obsolete.keys())):
+            keys = list(sorted(obsolete.keys()))
+            msg = 'obsolete params not in alphabetical order should be\n{keys}'
+            errors.append(msg.format(keys=keys))
+
+        # combine docstring parameters
+        params.update(obsolete)
+
+        for param in sorted(mod_config.keys()):
+            if (module_name, param) in IGNORE_ITEM:
+                continue
+            default = mod_config[param]
+            if param not in params:
+                msg = '{}: (default {!r}) not in module docstring'
+                errors.append(msg.format(param, default))
+                continue
+            default_doc = params[param]
+            if default_doc is None:
+                msg = '`{}` (default {!r}) not in module docstring'
+                errors.append(msg.format(param, default))
+                del params[param]
+                continue
+            if default_doc[0] != default:
+                msg = '`{}` (default {!r}) does not match docstring {!r}'
+                errors.append(msg.format(param, default, default_doc[0]))
+                del params[param]
+                continue
+            del params[param]
+
+        for param in params:
+            if (module_name, param) in IGNORE_ITEM:
+                continue
+            errors.append('{} in module docstring but not module'.format(param))
+        if errors:
+            all_errors += ['=' * 30, module_name, '=' * 30] + errors + ['\n']
+    return all_errors
+
+
+def test_docstrings():
+    errors = check_docstrings()
+    if errors:
+        print('Docstring error(s) detected!\n\n')
+        for error in errors:
+            print(error)
+        assert(False)


### PR DESCRIPTION
This PR adds testing of docstrings.

We check that 

* docstring contains all the config options the module provides.

* correct default values are given

* config parameters listed in alphabetical order

Some modules have odd defaults eg `save_path` in `screenshot` module these are excluded from the tests.

Some modules cannot be imported due to missing dependencies eg `aws_bill` these are currently excluded but if we agree the proposal in #482 then we could also test these modules.

As well as ensuring more accurate docstrings this PR will help ensure new modules are correctly documented.

Also included are some fixes for existing modules to pass the tests