### PR TITLE
battery_level.py recommended changes

### DIFF
--- a/py3status/core.py
+++ b/py3status/core.py
@@ -488,13 +488,16 @@ class Py3statusWrapper():
             level = LOG_LEVELS.get(level, level)
             syslog(level, u'{}'.format(msg))
         else:
-            with open(self.config['log_file'], 'a') as f:
+            # Binary mode so fs encoding setting is not an issue
+            with open(self.config['log_file'], 'ab') as f:
                 log_time = time.strftime("%Y-%m-%d %H:%M:%S")
                 out = u'{} {} {}\n'.format(log_time, level.upper(), msg)
                 try:
-                    f.write(out)
-                except UnicodeEncodeError:
+                    # Encode unicode strings to bytes
                     f.write(out.encode('utf-8'))
+                except (AttributeError, UnicodeDecodeError):
+                    # Write any byte strings straight to log
+                    f.write(out)
 
     def report_exception(self, msg, notify_user=True, level='error'):
         """

--- a/py3status/modules/battery_level.py
+++ b/py3status/modules/battery_level.py
@@ -115,10 +115,12 @@ class Py3status:
     threshold_bad = 10
     threshold_degraded = 30
     threshold_full = 100
-    last_known_status = 'good'
     # obsolete configuration parameters
     mode = None
     show_percent_with_blocks = None
+    # internal status variable
+    last_known_status = ''
+
 
     def battery_level(self):
 

--- a/py3status/modules/battery_level.py
+++ b/py3status/modules/battery_level.py
@@ -118,8 +118,6 @@ class Py3status:
     # obsolete configuration parameters
     mode = None
     show_percent_with_blocks = None
-    # internal status variable
-    last_known_status = ''
 
 
     def battery_level(self):
@@ -336,6 +334,8 @@ class Py3status:
             self.percent_charged >= self.threshold_full else self.full_text
 
     def _set_bar_color(self):
+        # Prevent AttributeError when starting below threshold.
+        last_status = getattr(self, 'last_known_status', '')
         if self.charging:
             self.response['color'] = self.py3.COLOR_CHARGING or "#FCE94F"
             battery_status = 'charging'
@@ -343,14 +343,14 @@ class Py3status:
             self.response['color'] = self.py3.COLOR_BAD
             battery_status = 'bad'
             if (self.notify_low_level and
-                    self.last_known_status != battery_status):
+                    last_status != battery_status):
                 self.py3.notify_user('Battery level is critically low ({}%)'
                             .format(self.percent_charged), 'error')
         elif self.percent_charged < self.threshold_degraded:
             self.response['color'] = self.py3.COLOR_DEGRADED
             battery_status = 'degraded'
             if (self.notify_low_level and
-                    self.last_known_status != battery_status):
+                    last_status != battery_status):
                 self.py3.notify_user('Battery level is running low ({}%)'
                             .format(self.percent_charged), 'warning')
         elif self.percent_charged >= self.threshold_full:

--- a/py3status/modules/battery_level.py
+++ b/py3status/modules/battery_level.py
@@ -115,6 +115,7 @@ class Py3status:
     threshold_bad = 10
     threshold_degraded = 30
     threshold_full = 100
+    last_known_status = ''
     # obsolete configuration parameters
     mode = None
     show_percent_with_blocks = None
@@ -149,7 +150,7 @@ class Py3status:
                                             time_remaining=self.time_remaining))
 
         if message:
-            self._desktop_notification(message)
+            self.py3.notify_user(message, 'info')
 
     def _desktop_notification(self, message):
         """
@@ -341,14 +342,15 @@ class Py3status:
             battery_status = 'bad'
             if (self.notify_low_level and
                     self.last_known_status != battery_status):
-                self._notify('Battery level is critically low ({}%)',
-                             'critical')
+                self.py3.notify_user('Battery level is critically low ({}%)'
+                            .format(self.percent_charged), 'error')
         elif self.percent_charged < self.threshold_degraded:
             self.response['color'] = self.py3.COLOR_DEGRADED
             battery_status = 'degraded'
             if (self.notify_low_level and
                     self.last_known_status != battery_status):
-                self._notify('Battery level is running low ({}%)', 'normal')
+                self.py3.notify_user('Battery level is running low ({}%)'
+                            .format(self.percent_charged), 'warning')
         elif self.percent_charged >= self.threshold_full:
             self.response['color'] = self.py3.COLOR_GOOD
             battery_status = 'full'

--- a/py3status/modules/battery_level.py
+++ b/py3status/modules/battery_level.py
@@ -361,12 +361,6 @@ class Py3status:
     def _set_cache_timeout(self):
         self.response['cached_until'] = time() + self.cache_timeout
 
-    def _notify(self, text, urgency):
-        subprocess.call(
-            ['notify-send', text.format(self.percent_charged), '-u', urgency],
-            stdout=open('/dev/null', 'w'),
-            stderr=open('/dev/null', 'w'))
-
 
 if __name__ == "__main__":
     """

--- a/py3status/modules/battery_level.py
+++ b/py3status/modules/battery_level.py
@@ -115,7 +115,7 @@ class Py3status:
     threshold_bad = 10
     threshold_degraded = 30
     threshold_full = 100
-    last_known_status = ''
+    last_known_status = 'good'
     # obsolete configuration parameters
     mode = None
     show_percent_with_blocks = None

--- a/py3status/modules/battery_level.py
+++ b/py3status/modules/battery_level.py
@@ -119,7 +119,6 @@ class Py3status:
     mode = None
     show_percent_with_blocks = None
 
-
     def battery_level(self):
 
         self._refresh_battery_info()
@@ -342,17 +341,15 @@ class Py3status:
         elif self.percent_charged < self.threshold_bad:
             self.response['color'] = self.py3.COLOR_BAD
             battery_status = 'bad'
-            if (self.notify_low_level and
-                    last_status != battery_status):
+            if (self.notify_low_level and last_status != battery_status):
                 self.py3.notify_user('Battery level is critically low ({}%)'
-                            .format(self.percent_charged), 'error')
+                                    .format(self.percent_charged), 'error')
         elif self.percent_charged < self.threshold_degraded:
             self.response['color'] = self.py3.COLOR_DEGRADED
             battery_status = 'degraded'
-            if (self.notify_low_level and
-                    last_status != battery_status):
+            if (self.notify_low_level and last_status != battery_status):
                 self.py3.notify_user('Battery level is running low ({}%)'
-                            .format(self.percent_charged), 'warning')
+                                    .format(self.percent_charged), 'warning')
         elif self.percent_charged >= self.threshold_full:
             self.response['color'] = self.py3.COLOR_GOOD
             battery_status = 'full'

--- a/py3status/modules/battery_level.py
+++ b/py3status/modules/battery_level.py
@@ -343,13 +343,13 @@ class Py3status:
             battery_status = 'bad'
             if (self.notify_low_level and last_status != battery_status):
                 self.py3.notify_user('Battery level is critically low ({}%)'
-                                    .format(self.percent_charged), 'error')
+                    .format(self.percent_charged), 'error')
         elif self.percent_charged < self.threshold_degraded:
             self.response['color'] = self.py3.COLOR_DEGRADED
             battery_status = 'degraded'
             if (self.notify_low_level and last_status != battery_status):
                 self.py3.notify_user('Battery level is running low ({}%)'
-                                    .format(self.percent_charged), 'warning')
+                    .format(self.percent_charged), 'warning')
         elif self.percent_charged >= self.threshold_full:
             self.response['color'] = self.py3.COLOR_GOOD
             battery_status = 'full'

--- a/py3status/modules/battery_level.py
+++ b/py3status/modules/battery_level.py
@@ -119,6 +119,9 @@ class Py3status:
     mode = None
     show_percent_with_blocks = None
 
+    def __init__(self):
+        self.last_known_status = ''
+
     def battery_level(self):
 
         self._refresh_battery_info()
@@ -333,23 +336,23 @@ class Py3status:
             self.percent_charged >= self.threshold_full else self.full_text
 
     def _set_bar_color(self):
-        # Prevent AttributeError when starting below threshold.
-        last_status = getattr(self, 'last_known_status', '')
         if self.charging:
             self.response['color'] = self.py3.COLOR_CHARGING or "#FCE94F"
             battery_status = 'charging'
         elif self.percent_charged < self.threshold_bad:
             self.response['color'] = self.py3.COLOR_BAD
             battery_status = 'bad'
-            if (self.notify_low_level and last_status != battery_status):
+            if (self.notify_low_level and
+                    self.last_known_status != battery_status):
                 self.py3.notify_user('Battery level is critically low ({}%)'
-                    .format(self.percent_charged), 'error')
+                                     .format(self.percent_charged), 'error')
         elif self.percent_charged < self.threshold_degraded:
             self.response['color'] = self.py3.COLOR_DEGRADED
             battery_status = 'degraded'
-            if (self.notify_low_level and last_status != battery_status):
+            if (self.notify_low_level and
+                    self.last_known_status != battery_status):
                 self.py3.notify_user('Battery level is running low ({}%)'
-                    .format(self.percent_charged), 'warning')
+                                     .format(self.percent_charged), 'warning')
         elif self.percent_charged >= self.threshold_full:
             self.response['color'] = self.py3.COLOR_GOOD
             battery_status = 'full'


### PR DESCRIPTION
Module battery_level.py lines 343 and 350 raise an AttributeError when the Py3status class is instantiated and the battery is below either threshold. 
The self.last_known_status variable isn't declared yet so the threshold conditionals fail. Otherwise if the battery starts above the threshold and drops below it, the error is avoided.
Declaring last_known_status = '' at the top of Py3status fixes the problem.

A subprocess.call() to notify-send on lines 159 and 364 of battery_level.py raises a FileNotFoundError (python3.5) when libnotify is not installed. Neither libnotify nor dunst is listed in the module requirements.
The module should probably use the py3status notify_user() method so people can utilize the -b flag.
