### PR TITLE
Add pulseaudio support to volume_status

### DIFF
--- a/py3status/modules/volume_status.py
+++ b/py3status/modules/volume_status.py
@@ -72,30 +72,23 @@ import re
 
 from subprocess import check_output, call, DEVNULL
 
-from abc import ABCMeta, abstractmethod
-from six import with_metaclass
 
-
-class AudioBackend(with_metaclass(ABCMeta)):
+class AudioBackend():
     def __init__(self, device, channel):
         self.device = device
         self.channel = channel
 
-    @abstractmethod
     def get_volume(self):
-        pass
+        raise NotImplemented
 
-    @abstractmethod
     def volume_up(self, delta):
-        pass
+        raise NotImplemented
 
-    @abstractmethod
     def volume_down(self, delta):
-        pass
+        raise NotImplemented
 
-    @abstractmethod
     def toggle_mute(self):
-        pass
+        raise NotImplemented
 
 
 class AlsaBackend(AudioBackend):

--- a/py3status/modules/volume_status.py
+++ b/py3status/modules/volume_status.py
@@ -78,6 +78,7 @@ class AudioBackend():
     def __init__(self, device, channel):
         self.device = device
         self.channel = channel
+        self.devnull = open(devnull, 'wb')
 
     def get_volume(self):
         raise NotImplemented
@@ -143,18 +144,15 @@ class AlsaBackend(AudioBackend):
 
     def volume_up(self, delta):
         # volume up
-        DEVNULL = open(devnull, 'wb')
-        call(self.cmd + ['{}%+'.format(delta)], stdout=DEVNULL, stderr=DEVNULL)
+        call(self.cmd + ['{}%+'.format(delta)], stdout=self.devnull, stderr=self.devnull)
 
     def volume_down(self, delta):
         # volume down
-        DEVNULL = open(devnull, 'wb')
-        call(self.cmd + ['{}%-'.format(delta)], stdout=DEVNULL, stderr=DEVNULL)
+        call(self.cmd + ['{}%-'.format(delta)], stdout=self.devnull, stderr=self.devnull)
 
     def toggle_mute(self):
         # toggle mute
-        DEVNULL = open(devnull, 'wb')
-        call(self.cmd + ['toggle'], stdout=DEVNULL, stderr=DEVNULL)
+        call(self.cmd + ['toggle'], stdout=self.devnull, stderr=self.devnull)
 
 
 class PulseaudioBackend(AudioBackend):
@@ -165,25 +163,21 @@ class PulseaudioBackend(AudioBackend):
         self.cmd = ["pamixer", "--sink", self.device]
 
     def get_volume(self):
-        DEVNULL = open(devnull, 'wb')
         perc = check_output(self.cmd + ["--get-volume"]).decode('utf-8').strip()
-        muted = (call(self.cmd + ["--get-mute"], stdout=DEVNULL, stderr=DEVNULL) == 0)
+        muted = (call(self.cmd + ["--get-mute"], stdout=self.devnull, stderr=self.devnull) == 0)
         return perc, muted
 
     def volume_up(self, delta):
         # volume up
-        DEVNULL = open(devnull, 'wb')
-        call(self.cmd + ["-i", str(delta)], stdout=DEVNULL, stderr=DEVNULL)
+        call(self.cmd + ["-i", str(delta)], stdout=self.devnull, stderr=self.devnull)
 
     def volume_down(self, delta):
         # volume down
-        DEVNULL = open(devnull, 'wb')
-        call(self.cmd + ["-d", str(delta)], stdout=DEVNULL, stderr=DEVNULL)
+        call(self.cmd + ["-d", str(delta)], stdout=self.devnull, stderr=self.devnull)
 
     def toggle_mute(self):
         # toggle mute
-        DEVNULL = open(devnull, 'wb')
-        call(self.cmd + ["-t"], stdout=DEVNULL, stderr=DEVNULL)
+        call(self.cmd + ["-t"], stdout=self.devnull, stderr=self.devnull)
 
 
 class Py3status:

--- a/py3status/modules/volume_status.py
+++ b/py3status/modules/volume_status.py
@@ -78,7 +78,10 @@ class AudioBackend():
     def __init__(self, device, channel):
         self.device = device
         self.channel = channel
-        self.devnull = open(devnull, 'wb')
+
+    def run_cmd(self, cmd):
+        with open(devnull, 'wb') as dn:
+            call(cmd, stdout=dn, stderr=dn)
 
     def get_volume(self):
         raise NotImplemented
@@ -144,15 +147,15 @@ class AlsaBackend(AudioBackend):
 
     def volume_up(self, delta):
         # volume up
-        call(self.cmd + ['{}%+'.format(delta)], stdout=self.devnull, stderr=self.devnull)
+        self.run_cmd(self.cmd + ['{}%+'.format(delta)])
 
     def volume_down(self, delta):
         # volume down
-        call(self.cmd + ['{}%-'.format(delta)], stdout=self.devnull, stderr=self.devnull)
+        self.run_cmd(self.cmd + ['{}%-'.format(delta)])
 
     def toggle_mute(self):
         # toggle mute
-        call(self.cmd + ['toggle'], stdout=self.devnull, stderr=self.devnull)
+        self.run_cmd(self.cmd + ['toggle'])
 
 
 class PulseaudioBackend(AudioBackend):
@@ -164,20 +167,20 @@ class PulseaudioBackend(AudioBackend):
 
     def get_volume(self):
         perc = check_output(self.cmd + ["--get-volume"]).decode('utf-8').strip()
-        muted = (call(self.cmd + ["--get-mute"], stdout=self.devnull, stderr=self.devnull) == 0)
+        muted = (self.run_cmd(self.cmd + ["--get-mute"]) == 0)
         return perc, muted
 
     def volume_up(self, delta):
         # volume up
-        call(self.cmd + ["-i", str(delta)], stdout=self.devnull, stderr=self.devnull)
+        self.run_cmd(self.cmd + ["-i", str(delta)])
 
     def volume_down(self, delta):
         # volume down
-        call(self.cmd + ["-d", str(delta)], stdout=self.devnull, stderr=self.devnull)
+        self.run_cmd(self.cmd + ["-d", str(delta)])
 
     def toggle_mute(self):
         # toggle mute
-        call(self.cmd + ["-t"], stdout=self.devnull, stderr=self.devnull)
+        self.run_cmd(self.cmd + ["-t"])
 
 
 class Py3status:

--- a/py3status/modules/volume_status.py
+++ b/py3status/modules/volume_status.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 """
-Display current sound volume using amixer.
+Display current sound volume.
 
 Expands on the standard i3status volume module by adding color
 and percentage threshold settings.

--- a/py3status/modules/volume_status.py
+++ b/py3status/modules/volume_status.py
@@ -69,8 +69,9 @@ NOTE:
 """
 
 import re
+from os import devnull
 
-from subprocess import check_output, call, DEVNULL
+from subprocess import check_output, call
 
 
 class AudioBackend():
@@ -142,14 +143,17 @@ class AlsaBackend(AudioBackend):
 
     def volume_up(self, delta):
         # volume up
+        DEVNULL = open(devnull, 'wb')
         call(self.cmd + ['{}%+'.format(delta)], stdout=DEVNULL, stderr=DEVNULL)
 
     def volume_down(self, delta):
         # volume down
+        DEVNULL = open(devnull, 'wb')
         call(self.cmd + ['{}%-'.format(delta)], stdout=DEVNULL, stderr=DEVNULL)
 
     def toggle_mute(self):
         # toggle mute
+        DEVNULL = open(devnull, 'wb')
         call(self.cmd + ['toggle'], stdout=DEVNULL, stderr=DEVNULL)
 
 
@@ -161,20 +165,24 @@ class PulseaudioBackend(AudioBackend):
         self.cmd = ["pamixer", "--sink", self.device]
 
     def get_volume(self):
+        DEVNULL = open(devnull, 'wb')
         perc = check_output(self.cmd + ["--get-volume"]).decode('utf-8').strip()
         muted = (call(self.cmd + ["--get-mute"], stdout=DEVNULL, stderr=DEVNULL) == 0)
         return perc, muted
 
     def volume_up(self, delta):
         # volume up
+        DEVNULL = open(devnull, 'wb')
         call(self.cmd + ["-i", str(delta)], stdout=DEVNULL, stderr=DEVNULL)
 
     def volume_down(self, delta):
         # volume down
+        DEVNULL = open(devnull, 'wb')
         call(self.cmd + ["-d", str(delta)], stdout=DEVNULL, stderr=DEVNULL)
 
     def toggle_mute(self):
         # toggle mute
+        DEVNULL = open(devnull, 'wb')
         call(self.cmd + ["-t"], stdout=DEVNULL, stderr=DEVNULL)
 
 

--- a/py3status/modules/volume_status.py
+++ b/py3status/modules/volume_status.py
@@ -71,7 +71,6 @@ NOTE:
 
 import re
 from os import devnull
-
 from subprocess import check_output, call
 
 

--- a/py3status/modules/volume_status.py
+++ b/py3status/modules/volume_status.py
@@ -16,13 +16,13 @@ Configuration parameters:
         (default 0)
     cache_timeout: how often we refresh this module in seconds.
         (default 10)
-    channel: Alsamixer channel to track (ignored by pulseaudio)
-        (default 'Master')
+    channel: channel to track. Default value is backend dependent.
+        (default None)
     command: Choose between "amixer" and "pamixer". If None, try to guess based
         on available commands.
         (default None)
-    device: Device to use.
-        (default 'default')
+    device: Device to use. Defaults value is backend dependent
+        (default None)
     format: Format of the output.
         (default '♪: {percentage}%')
     format_muted: Format of the output when the volume is muted.
@@ -87,6 +87,10 @@ class AudioBackend():
 
 class AlsaBackend(AudioBackend):
     def setup(self, parent):
+        if self.device is None:
+            self.device = 'default'
+        if self.channel is None:
+            self.channel = 'Master'
         self.cmd = ['amixer', '-q', '-D', self.device, 'sset', self.channel]
 
     def get_volume(self):
@@ -116,8 +120,10 @@ class AlsaBackend(AudioBackend):
 
 class PulseaudioBackend(AudioBackend):
     def setup(self, parent):
-        if self.device == 'default':
+        if self.device is None:
             self.device = "0"
+        # Ignore channel
+        self.channel = None
         self.cmd = ["pamixer", "--sink", self.device]
 
     def get_volume(self):
@@ -143,9 +149,9 @@ class Py3status:
     button_mute = 0
     button_up = 0
     cache_timeout = 10
-    channel = 'Master'
+    channel = None
     command = None
-    device = 'default'
+    device = None
     format = u'♪: {percentage}%'
     format_muted = u'♪: muted'
     threshold_bad = 20

--- a/py3status/modules/volume_status.py
+++ b/py3status/modules/volume_status.py
@@ -18,8 +18,9 @@ Configuration parameters:
         (default 10)
     channel: Alsamixer channel to track (ignored by pulseaudio)
         (default 'Master')
-    command: Choose between "amixer" and "pamixer"
-        (default auto-guessed)
+    command: Choose between "amixer" and "pamixer". If None, try to guess based
+        on available commands.
+        (default None)
     device: Device to use.
         (default 'default')
     format: Format of the output.
@@ -154,7 +155,7 @@ class Py3status:
 
     def post_config_hook(self):
         # Guess command if not set
-        if self.command == None:
+        if self.command is None:
             self.command = self.py3.check_commands(['amixer', 'pamixer'])
 
         if self.command == 'amixer':

--- a/py3status/modules/volume_status.py
+++ b/py3status/modules/volume_status.py
@@ -84,21 +84,6 @@ class AudioBackend():
         with open(devnull, 'wb') as dn:
             return call(cmd, stdout=dn, stderr=dn)
 
-    def setup(self, parent):
-        raise NotImplemented
-
-    def get_volume(self):
-        raise NotImplemented
-
-    def volume_up(self, delta):
-        raise NotImplemented
-
-    def volume_down(self, delta):
-        raise NotImplemented
-
-    def toggle_mute(self):
-        raise NotImplemented
-
 
 class AlsaBackend(AudioBackend):
     def setup(self, parent):

--- a/py3status/modules/volume_status.py
+++ b/py3status/modules/volume_status.py
@@ -20,9 +20,6 @@ Configuration parameters:
         (default 10)
     channel: Alsamixer channel to track (ignored by pulseaudio)
         (default 'Master')
-    color_muted: set to 1 to color 'format_muted' depending on the volume
-        percent.
-        (default 0)
     device: Device to use.
         (default 'default')
     format: Format of the output.
@@ -199,7 +196,6 @@ class Py3status:
     button_up = 0
     cache_timeout = 10
     channel = 'Master'
-    color_muted = 0
     device = 'default'
     format = u'♪: {percentage}%'
     format_muted = u'♪: muted'
@@ -239,7 +235,7 @@ class Py3status:
         perc, muted = self.backend.get_volume()
 
         # determine the color based on the current volume level
-        color = self._perc_to_color(perc if self.color_muted or not muted else '0')
+        color = self._perc_to_color(perc if not muted else '0')
 
         # format the output
         text = self._format_output(self.format_muted

--- a/py3status/modules/volume_status.py
+++ b/py3status/modules/volume_status.py
@@ -81,7 +81,7 @@ class AudioBackend():
 
     def run_cmd(self, cmd):
         with open(devnull, 'wb') as dn:
-            call(cmd, stdout=dn, stderr=dn)
+            return call(cmd, stdout=dn, stderr=dn)
 
     def get_volume(self):
         raise NotImplemented

--- a/py3status/modules/volume_status.py
+++ b/py3status/modules/volume_status.py
@@ -77,9 +77,10 @@ import shlex
 from subprocess import check_output, call, run, DEVNULL
 
 from abc import ABCMeta, abstractmethod
+from six import with_metaclass
 
 
-class AudioBackend(metaclass=ABCMeta):
+class AudioBackend(with_metaclass(ABCMeta)):
     def __init__(self, device, channel, button_up, button_down, button_mute, volume_delta):
         self.device = device
         self.channel = channel


### PR DESCRIPTION
Adds a new variable `backend` which can be either "alsa" or "pulseaudio". Adding other backend is only a matter of creating a wrapper class which extends the abstract `AudioBackend` class. If the backend specified doesn't exist, an exception is raised in the `post_config_hook`. This stops py3status.

In addition, I added a new variable to optionally color the `format_muted` string depending on the volume. I use it to know if it's safe to unmute.