### PR TITLE
Bugfix: module_test unicode issue

### DIFF
--- a/py3status/module_test.py
+++ b/py3status/module_test.py
@@ -20,7 +20,7 @@ def module_test(module_class, config=None):
         # find methods that we should test.
         attribute = getattr(module, attribute_name)
 
-        if 'method' not in str(attribute):
+        if 'method' not in repr(attribute):
             continue
         if attribute_name.startswith('_'):
             continue


### PR DESCRIPTION
running `python2 modules/volume_status.py` would crash 
```
UnicodeEncodeError: 'ascii' codec can't encode character u'\u266a' in position 0: ordinal not in range(128)
```
This fixes the issue by using repr not str to test if attribute is a method.