### PR TITLE
Formatter add attr_getter

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -923,9 +923,10 @@ The following functions can be registered
 >
 > Note: This function should only be used by containers.
 
-__safe_format(format_string, param_dict=None)__
+__safe_format(format_string, param_dict=None, force_composite=False,
+attr_getter=None)__
 
-Parser for advanced formating.
+Parser for advanced formatting.
 
 Unknown placeholders will be shown in the output eg `{foo}`
 
@@ -969,7 +970,11 @@ case of simple parsing or a Composite if more complex.
 If force_composite parameter is True a composite will always be
 returned.
 
-__build_composite(format_string, param_dict=None, composites=None)__
+attr_getter is a function that will when called with a an attribute name
+as a parameter will return a value.
+
+__build_composite(format_string, param_dict=None, composites=None,
+attr_getter=None)__
 
 __deprecated in 3.3__ use safe_format()
 

--- a/py3status/formatter.py
+++ b/py3status/formatter.py
@@ -264,7 +264,7 @@ class Formatter:
     reg_ex = re.compile(TOKENS[0], re.M | re.I)
 
     def format(self, format_string, module=None, param_dict=None,
-               force_composite=False):
+               force_composite=False, attr_getter=None):
         """
         Format a string.
         substituting place holders which can be found in
@@ -335,6 +335,10 @@ class Formatter:
                         set_param(param, value, key)
                     else:
                         block.add(value)
+                elif attr_getter:
+                    # get value from attr_getter function
+                    param = attr_getter(key)
+                    set_param(param, value, key)
                 else:
                     # substitution not found so add as a literal
                     block.add(value)

--- a/py3status/py3.py
+++ b/py3status/py3.py
@@ -348,9 +348,9 @@ class Py3:
         return requested + offset
 
     def safe_format(self, format_string, param_dict=None,
-                    force_composite=False):
+                    force_composite=False, attr_getter=None):
         """
-        Parser for advanced formating.
+        Parser for advanced formatting.
 
         Unknown placeholders will be shown in the output eg `{foo}`.
 
@@ -392,6 +392,9 @@ class Py3:
 
         If force_composite parameter is True a composite will always be
         returned.
+
+        attr_getter is a function that will when called with an attribute name
+        as a parameter will return a value.
         """
         try:
             return self._formatter.format(
@@ -399,11 +402,13 @@ class Py3:
                 self._py3status_module,
                 param_dict,
                 force_composite=force_composite,
+                attr_getter=attr_getter,
             )
         except Exception:
             return 'invalid format'
 
-    def build_composite(self, format_string, param_dict=None, composites=None):
+    def build_composite(self, format_string, param_dict=None, composites=None,
+                        attr_getter=None):
         """
         __deprecated in 3.3__ use safe_format().
 
@@ -430,6 +435,8 @@ class Py3:
                 self._py3status_module,
                 param_dict,
                 force_composite=True,
+                attr_getter=attr_getter,
+                composites=composites,
             )
         except Exception:
             return [{'full_text': 'invalid format'}]

--- a/tests/test_formatter.py
+++ b/tests/test_formatter.py
@@ -56,15 +56,26 @@ class Module:
         return 'property'
 
 
+def attr_getter_fn(attr):
+    '''
+    test attr_getter function
+    '''
+    return '*{}*'.format(attr)
+
+
 def run_formatter(test_dict):
     if test_dict.get('py3only') and f.python2:
         return
     if not test_dict.get('pypy', True) and is_pypy:
         return
+    if test_dict.get('attr_getter'):
+        attr_getter = attr_getter_fn
+    else:
+        attr_getter = None
     try:
         module = Module()
         result = f.format(test_dict['format'], module, param_dict,
-                          force_composite=test_dict.get('composite'))
+                          force_composite=test_dict.get('composite'), attr_getter=attr_getter)
     except Exception as e:
         if test_dict.get('exception') == str(e):
             return
@@ -76,7 +87,10 @@ def run_formatter(test_dict):
     expected = test_dict.get('expected')
     if f.python2 and isinstance(expected, str):
         expected = expected.decode('utf-8')
-    assert result == expected
+    if result != expected:
+        print('Expected {!r}'.format(expected))
+        print('Got {!r}'.format(result))
+    assert (result == expected)
 
 
 def test_1():
@@ -823,4 +837,12 @@ def test_composite_6():
         'format': 'hello',
         'expected': [{'full_text': 'hello'}],
         'composite': True,
+    })
+
+
+def test_attr_getter():
+    run_formatter({
+        'format': '{test_attr_getter}',
+        'expected': '*test_attr_getter*',
+        'attr_getter': True,
     })


### PR DESCRIPTION
Issue #484 really needs mpd_status to be updated to use safe_format().  The issue with this is that the module gets information (placeholders) via a function, rather than providing a dict like most modules.  This could also potentially be useful for other modules.

This PR adds the ability to provide an attr_getter function to safe_format() that values will be got from.  This functionality is also available via build_composite().

If this PR is merged we can then update mpd_status to use safe_format().  We can add a shim to the module so that both `%...%` and `{...}` formats can still be used.