### PR TITLE
Don't go to repo when notifications == 'all'

### DIFF
--- a/py3status/modules/github.py
+++ b/py3status/modules/github.py
@@ -16,8 +16,8 @@ Configuration parameters:
         see above.
         (default None)
     button_action: Button that when clicked opens the Github notification page
-        if notifications, else the project page for the repository . Setting to
-        `0` disables.
+        if notifications, else the project page for the repository if there is
+        one (otherwise the github home page). Setting to `0` disables.
         (default 3)
     cache_timeout: How often we refresh this module in seconds
         (default 60)
@@ -220,11 +220,16 @@ class Py3status:
         button = event['button']
         if self.button_action and self.button_action == button:
             if self._notify and self._notify != '?':
-                # open github notifications page in default browser
+                # open github notifications page
                 url = GITHUB_URL + 'notifications'
             else:
-                # open repo page
-                url = GITHUB_URL + self.repo
+                if self.notifications == 'all' and not self.repo:
+                    # open github.com if there are no unread notifications and no repo
+                    url = GITHUB_URL
+                else:
+                    # open repo page if there are no unread notifications
+                    url = GITHUB_URL + self.repo
+            # open url in default browser
             cmd = 'xdg-open {}'.format(url)
             call(split(cmd))
             self.py3.prevent_refresh()


### PR DESCRIPTION
If you are monitoring all notifications, but there are none, a click on
the module took you to the repo page (which would probably be
unconfigured). Now it will take you to the GitHub homepage (since the
empty notification page would be kind of useless).