### PR TITLE
Battery measurement using sys interface

### DIFF
--- a/py3status/modules/README.md
+++ b/py3status/modules/README.md
@@ -248,11 +248,18 @@ Configuration parameters:
   - `hide_when_full` hide any information when battery is fully charged (when
     the battery level is greater than or equal to 'threshold_full')
     *(default False)*
+  - `measurement_mode` either 'acpi' or 'sys'. 'sys' should be more robust and
+  does not have any extra requirements, however the time measurement may be off
+  or not work in some cases
+    *(default sys)*
   - `notification` show current battery state as notification on click
     *(default False)*
   - `notify_low_level` display notification when battery is running low (when
     the battery level is less than 'threshold_degraded')
     *(default False)*
+  - `sys_battery_path` set the path to kernel sys' battery interface. Used only
+  when `measurement_mode=sys`.
+    *(default /sys/class/power_supply/)*
   - `threshold_bad` a percentage below which the battery level should be
     considered bad
     *(default 10)*
@@ -295,7 +302,7 @@ Obsolete configuration parameters:
     *(default None)*
 
 Requires:
-  - the `acpi` command line
+  - the `acpi` command line (only if `measurement_mode='acpi'`)
 
 **author** shadowprince, AdamBSteele, maximbaz, 4iar
 

--- a/py3status/modules/README.md
+++ b/py3status/modules/README.md
@@ -248,17 +248,17 @@ Configuration parameters:
   - `hide_when_full` hide any information when battery is fully charged (when
     the battery level is greater than or equal to 'threshold_full')
     *(default False)*
-  - `measurement_mode` either 'acpi' or 'sys'. 'sys' should be more robust and
-  does not have any extra requirements, however the time measurement may not
-  work in some cases
-    *(default acpi)*
+  - `measurement_mode` either 'acpi' or 'sys', or None to autodetect. 'sys'
+  should be more robust and does not have any extra requirements, however the
+  time measurement may not work in some cases
+    *(default None)*
   - `notification` show current battery state as notification on click
     *(default False)*
   - `notify_low_level` display notification when battery is running low (when
     the battery level is less than 'threshold_degraded')
     *(default False)*
   - `sys_battery_path` set the path to kernel sys' battery interface. Used only
-  when `measurement_mode=sys`.
+  when `measurement_mode=sys`
     *(default /sys/class/power_supply/)*
   - `threshold_bad` a percentage below which the battery level should be
     considered bad

--- a/py3status/modules/README.md
+++ b/py3status/modules/README.md
@@ -249,9 +249,9 @@ Configuration parameters:
     the battery level is greater than or equal to 'threshold_full')
     *(default False)*
   - `measurement_mode` either 'acpi' or 'sys'. 'sys' should be more robust and
-  does not have any extra requirements, however the time measurement may be off
-  or not work in some cases
-    *(default sys)*
+  does not have any extra requirements, however the time measurement may not
+  work in some cases
+    *(default acpi)*
   - `notification` show current battery state as notification on click
     *(default False)*
   - `notify_low_level` display notification when battery is running low (when
@@ -304,7 +304,7 @@ Obsolete configuration parameters:
 Requires:
   - the `acpi` command line (only if `measurement_mode='acpi'`)
 
-**author** shadowprince, AdamBSteele, maximbaz, 4iar
+**author** shadowprince, AdamBSteele, maximbaz, 4iar, m45t3r
 
 **license** Eclipse Public License
 

--- a/py3status/modules/battery_level.py
+++ b/py3status/modules/battery_level.py
@@ -29,8 +29,8 @@ Configuration parameters:
         (default False)
     measurement_mode: either 'acpi' or 'sys'. 'sys' should be more robust and
         does not have any extra requirements, however the time measurement may
-        be off or not work in some cases
-        (default "sys")
+        not work in some cases
+        (default "acpi")
     notification: show current battery state as notification on click
         (default False)
     notify_low_level: display notification when battery is running low (when
@@ -105,7 +105,7 @@ FORMAT = u"{icon}"
 FORMAT_NOTIFY_CHARGING = u"Charging ({percent}%)"
 FORMAT_NOTIFY_DISCHARGING = u"{time_remaining}"
 SYS_BATTERY_PATH = u"/sys/class/power_supply/"
-MEASUREMENT_MODE = u"sys"
+MEASUREMENT_MODE = u"acpi"
 
 
 class Py3status:

--- a/py3status/modules/battery_level.py
+++ b/py3status/modules/battery_level.py
@@ -82,7 +82,7 @@ Obsolete configuration parameters:
 
 Requires:
     - the `acpi` the acpi command line utility (only if
-    `measurement_mode='acpi'`)
+        `measurement_mode='acpi'`)
 
 @author shadowprince, AdamBSteele, maximbaz, 4iar, m45t3r
 @license Eclipse Public License

--- a/py3status/modules/battery_level.py
+++ b/py3status/modules/battery_level.py
@@ -81,9 +81,10 @@ Obsolete configuration parameters:
         (default None)
 
 Requires:
-    - the `acpi` command line
+    - the `acpi` the acpi command line utility (only if
+    `measurement_mode='acpi'`)
 
-@author shadowprince, AdamBSteele, maximbaz, 4iar
+@author shadowprince, AdamBSteele, maximbaz, 4iar, m45t3r
 @license Eclipse Public License
 """
 

--- a/py3status/modules/battery_level.py
+++ b/py3status/modules/battery_level.py
@@ -273,12 +273,14 @@ class Py3status:
             battery["charging"] = "Charging" in r["POWER_SUPPLY_STATUS"]
             battery["percent_charged"] = math.floor(
                 r["POWER_SUPPLY_ENERGY_NOW"] / battery["capacity"] * 100)
-            power_now = r["POWER_SUPPLY_POWER_NOW"]
             if battery["charging"]:
-                time_in_secs = power_now / battery["capacity"] * 3600
+                time_in_h = ((r["POWER_SUPPLY_ENERGY_FULL"] -
+                              r["POWER_SUPPLY_ENERGY_NOW"]) /
+                              r["POWER_SUPPLY_POWER_NOW"])
             else:
-                time_in_secs = battery["capacity"] / power_now * 3600
-            battery["time_remaining"] = self._seconds_to_hms(time_in_secs)
+                time_in_h = (r["POWER_SUPPLY_ENERGY_NOW"] /
+                              r["POWER_SUPPLY_POWER_NOW"])
+            battery["time_remaining"] = self._seconds_to_hms(time_in_h * 3600)
             battery_list.append(battery)
         return battery_list
 

--- a/py3status/modules/battery_level.py
+++ b/py3status/modules/battery_level.py
@@ -121,13 +121,12 @@ class Py3status:
     format = FORMAT
     format_notify_charging = FORMAT_NOTIFY_CHARGING
     format_notify_discharging = FORMAT_NOTIFY_DISCHARGING
-    sys_battery_path = SYS_BATTERY_PATH
-    measurement_mode = MEASUREMENT_MODE
-    hide_when_full = False
     hide_seconds = False
     hide_when_full = False
+    measurement_mode = MEASUREMENT_MODE
     notification = False
     notify_low_level = False
+    sys_battery_path = SYS_BATTERY_PATH
     threshold_bad = 10
     threshold_degraded = 30
     threshold_full = 100

--- a/py3status/modules/battery_level.py
+++ b/py3status/modules/battery_level.py
@@ -336,28 +336,31 @@ class Py3status:
             self.percent_charged >= self.threshold_full else self.full_text
 
     def _set_bar_color(self):
+        notify_msg = None
         if self.charging:
             self.response['color'] = self.py3.COLOR_CHARGING or "#FCE94F"
             battery_status = 'charging'
         elif self.percent_charged < self.threshold_bad:
             self.response['color'] = self.py3.COLOR_BAD
             battery_status = 'bad'
-            if (self.notify_low_level and
-                    self.last_known_status != battery_status):
-                self.py3.notify_user('Battery level is critically low ({}%)'
-                                     .format(self.percent_charged), 'error')
+            notify_msg = {'msg': 'Battery level is critically low ({}%)',
+                          'level': 'error'}
         elif self.percent_charged < self.threshold_degraded:
             self.response['color'] = self.py3.COLOR_DEGRADED
             battery_status = 'degraded'
-            if (self.notify_low_level and
-                    self.last_known_status != battery_status):
-                self.py3.notify_user('Battery level is running low ({}%)'
-                                     .format(self.percent_charged), 'warning')
+            notify_msg = {'msg': 'Battery level is running low ({}%)',
+                          'level': 'warning'}
         elif self.percent_charged >= self.threshold_full:
             self.response['color'] = self.py3.COLOR_GOOD
             battery_status = 'full'
         else:
             battery_status = 'good'
+
+        if (notify_msg and self.notify_low_level
+                and self.last_known_status != battery_status):
+            self.py3.notify_user(notify_msg['msg'].format(self.percent_charged),
+                                 notify_msg['level'])
+
         self.last_known_status = battery_status
 
     def _set_cache_timeout(self):

--- a/py3status/modules/battery_level.py
+++ b/py3status/modules/battery_level.py
@@ -181,16 +181,6 @@ class Py3status:
         if message:
             self.py3.notify_user(message, 'info')
 
-    def _desktop_notification(self, message):
-        """
-        Display the given message inside a desktop notification
-        """
-        subprocess.call(
-            ['notify-send', '{}'.format(message), '-t',
-                '4000'],
-            stdout=open('/dev/null', 'w'),
-            stderr=open('/dev/null', 'w'))
-
     def _provide_backwards_compatibility(self):
         if self.format == FORMAT:
             # Backwards compatibility for 'mode' parameter

--- a/py3status/modules/battery_level.py
+++ b/py3status/modules/battery_level.py
@@ -273,14 +273,19 @@ class Py3status:
             battery["charging"] = "Charging" in r["POWER_SUPPLY_STATUS"]
             battery["percent_charged"] = math.floor(
                 r["POWER_SUPPLY_ENERGY_NOW"] / battery["capacity"] * 100)
-            if battery["charging"]:
-                time_in_h = ((r["POWER_SUPPLY_ENERGY_FULL"] -
-                              r["POWER_SUPPLY_ENERGY_NOW"]) /
-                              r["POWER_SUPPLY_POWER_NOW"])
-            else:
-                time_in_h = (r["POWER_SUPPLY_ENERGY_NOW"] /
-                              r["POWER_SUPPLY_POWER_NOW"])
-            battery["time_remaining"] = self._seconds_to_hms(time_in_h * 3600)
+            try:
+                if battery["charging"]:
+                    time_in_secs = ((r["POWER_SUPPLY_ENERGY_FULL"] -
+                                    r["POWER_SUPPLY_ENERGY_NOW"]) /
+                                    r["POWER_SUPPLY_POWER_NOW"] * 3600)
+                else:
+                    time_in_secs = (r["POWER_SUPPLY_ENERGY_NOW"] /
+                                    r["POWER_SUPPLY_POWER_NOW"] * 3600)
+                battery["time_remaining"] = self._seconds_to_hms(time_in_secs)
+            except ZeroDivisionError:
+                # Battery is either full charged or is not discharging
+                battery["time_remaining"] = "?"
+
             battery_list.append(battery)
         return battery_list
 

--- a/py3status/modules/battery_level.py
+++ b/py3status/modules/battery_level.py
@@ -27,11 +27,18 @@ Configuration parameters:
     hide_when_full: hide any information when battery is fully charged (when
         the battery level is greater than or equal to 'threshold_full')
         (default False)
+    measurement_mode: either 'acpi' or 'sys'. 'sys' should be more robust and
+        does not have any extra requirements, however the time measurement may
+        be off or not work in some cases
+        (default "sys")
     notification: show current battery state as notification on click
         (default False)
     notify_low_level: display notification when battery is running low (when
         the battery level is less than 'threshold_degraded')
         (default False)
+    sys_battery_path: set the path to your battery(ies), without including its
+        number
+        (default "/sys/class/power_supply/")
     threshold_bad: a percentage below which the battery level should be
         considered bad
         (default 10)
@@ -87,6 +94,7 @@ from glob import iglob
 
 import math
 import subprocess
+import os
 
 BLOCKS = u"_▁▂▃▄▅▆▇█"
 CHARGING_CHARACTER = u"⚡"
@@ -96,7 +104,7 @@ FULL_BLOCK = u'█'
 FORMAT = u"{icon}"
 FORMAT_NOTIFY_CHARGING = u"Charging ({percent}%)"
 FORMAT_NOTIFY_DISCHARGING = u"{time_remaining}"
-SYS_BATTERY_PATH = u"/sys/class/power_supply/BAT"
+SYS_BATTERY_PATH = u"/sys/class/power_supply/"
 MEASUREMENT_MODE = u"sys"
 
 
@@ -243,7 +251,7 @@ class Py3status:
         a similar, yet incompatible interface in /proc
         """
         battery_list = []
-        for path in iglob(self.sys_battery_path + '*'):
+        for path in iglob(os.path.join(self.sys_battery_path, "BAT*")):
             battery = dict()
             with open(path + "/energy_full") as f:
                 battery["capacity"] = int(f.readline())


### PR DESCRIPTION
Implement measurement of battery information using `/sys/class/power_supply` provided by the kernel itself instead of acpi. More robust, however it may give a wonky time measurement and may not work in all cases, for example this one: https://bbs.archlinux.org/viewtopic.php?id=131025