### PR TITLE
on_click() logic fix

### DIFF
--- a/py3status/modules/battery_level.py
+++ b/py3status/modules/battery_level.py
@@ -140,10 +140,10 @@ class Py3status:
         if not self.notification:
             return
 
-        if self.time_remaining:
-            format = self.format_notify_discharging
-        else:
+        if self.charging:
             format = self.format_notify_charging
+        else:
+            format = self.format_notify_discharging
 
         message = self.py3.safe_format(format,
                                        dict(ascii_bar=self.ascii_bar,


### PR DESCRIPTION
Instead of checking `self.charging`, the code was checking `self.time_remaining`. Since `self.time_remaining` is always a non-empty String (even in case of error, where you would get a `?` instead of None or something else), this check always evaluated to true and `self.format_notify_charging` was never used.

Fix issue #509 