### PR TITLE
Py3: add command_run() and command_output() helpers

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -906,6 +906,20 @@ __check_commands(cmd_list)__
 Checks to see if the shell commands in list are available using `which`.
 Returns the first available command.
 
+__command_run(command)__
+
+Runs a command and returns the exit code.
+The command can either be supplied as a sequence or string.
+
+An Exception is raised if an error occurs
+
+__command_output(command)__
+
+Run a command and return its output as unicode.
+The command can either be supplied as a sequence or string.
+
+An Exception is raised if an error occurs
+
 __play_sound(sound_file)__
 
 Plays sound_file if possible. Requires `paplay` or `play`.


### PR DESCRIPTION
Running commands and getting output of commands is a common task in modules.  This PR adds some helper functions to Py3 to make this easier and use common methodology.

`command_run()` is similar to `subprocess.call()`
`command_output()` is similar to `subprocess.check_output()`

* commands can either be called as a string eg `'acpi -i -b'` or as a sequence eg `['acpi', '-b', '-i']`

* output from commands is suppressed as needed (command_run).

* output is converted to unicode.

* universal newlines in output

This should make using commands easier for module writers