### PR TITLE
Formatter bugfix display 0.0

### DIFF
--- a/py3status/formatter.py
+++ b/py3status/formatter.py
@@ -276,7 +276,9 @@ class Formatter:
             """
             if self.python2 and isinstance(param, str):
                 param = param.decode('utf-8')
-            if param or param is 0:
+            # '', None, and False are ignored
+            # numbers like 0 and 0.0 are not.
+            if not (param in ['', None] or param is False):
                 value = value.format(**{key: param})
                 block.add(value)
                 block.mark_valid()

--- a/tests/test_formatter.py
+++ b/tests/test_formatter.py
@@ -24,6 +24,8 @@ param_dict = {
     'python2_unicode': u'Björk',
     'python2_str': 'Björk',
     'zero': 0,
+    'zero_str': '0',
+    'zero_float': 0.0,
 }
 
 composites = {
@@ -193,12 +195,29 @@ def test_23():
     })
 
 
+# zero/False/None etc
+
 def test_24():
     run_formatter(
-        # zero/False/None etc
         {
             'format': '{zero}',
             'expected': '0',
+        })
+
+
+def test_24a():
+    run_formatter(
+        {
+            'format': '{zero_str}',
+            'expected': '0',
+        })
+
+
+def test_24b():
+    run_formatter(
+        {
+            'format': '{zero_float}',
+            'expected': '0.0',
         })
 
 


### PR DESCRIPTION
Testing the battery_level changes led to an error in the formatter.

`0.0` was not displayed as it is treated as False.  This PR treats `0.0` as a valid value to display.  The test looks odd due to how python treats False as a number.  A test has also been added for this behaviour.