### PR TITLE
Allow None colors and use in volume_status color_mute

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -778,6 +778,20 @@ __update(module_name=None)__
 Update a module. If `module_name` is supplied the module of that
 name is updated. Otherwise the module calling is updated.
 
+__is_color(color)__
+
+Tests to see if a color is defined.
+Because colors can be set to None in the config and we want this to be
+respected in an expression like.
+
+color = self.py3.COLOR_MUTED or self.py3.COLOR_BAD
+
+The color is treated as True but sometimes we want to know if the color
+has a value set in which case the color should count as False.  This
+function is a helper for this second case.
+
+Added in version 3.3
+
 __is_python_2()__
 
 True if the version of python being used is 2.x

--- a/py3status/core.py
+++ b/py3status/core.py
@@ -599,7 +599,11 @@ class Py3statusWrapper():
                     color = config[module].get(attribute)
                     break
         if color == 'missing':
-            color = config['general'].get(attribute)
+            # A user can set a color to None in the config to prevent a color
+            # being used.  This is important when modules do something like
+
+            # color = self.py3.COLOR_MUTED or self.py3.COLOR_BAD
+            color = config['general'].get(attribute, False)
         return color
 
     def create_mappings(self, config):

--- a/py3status/module.py
+++ b/py3status/module.py
@@ -260,6 +260,9 @@ class Module(Thread):
             # part does not supply a color, use the composite color.
             if color and 'color' not in item:
                 item['color'] = color
+            # Remove any none color from our output
+            if hasattr(item.get('color'), 'none_color'):
+                del item['color']
 
     def _params_type(self, method_name, instance):
         """
@@ -458,6 +461,9 @@ class Module(Thread):
                         if 'full_text' not in result:
                             err = 'missing "full_text" key in response'
                             raise KeyError(err)
+                        # Remove any none color from our output
+                        if hasattr(result.get('color'), 'none_color'):
+                            del result['color']
                         # set universal module options in result
                         result.update(self.module_options)
 

--- a/py3status/module_test.py
+++ b/py3status/module_test.py
@@ -12,6 +12,7 @@ def module_test(module_class, config=None):
     module = module_class()
     setattr(module, 'py3', Py3(i3s_config=i3s_config, py3status=module))
     if config:
+        i3s_config.update(config)
         for key, value in config.items():
             setattr(module, key, value)
     methods = []

--- a/py3status/modules/volume_status.py
+++ b/py3status/modules/volume_status.py
@@ -42,6 +42,8 @@ Color options:
     color_bad: Volume below threshold_bad or muted
     color_degraded: Volume below threshold_degraded
     color_good: Volume above or equal to threshold_degraded
+    color_muted: Volume is muted, if not supplied color_bad is used
+        if set to `None` then the threshold color will be used.
 
 Example:
 
@@ -193,8 +195,12 @@ class Py3status:
         # call backend
         perc, muted = self.backend.get_volume()
 
-        # determine the color based on the current volume level
-        color = self._perc_to_color(perc if not muted else '0')
+        color = None
+        if muted:
+            color = self.py3.COLOR_MUTED or self.py3.COLOR_BAD
+        if not self.py3.is_color(color):
+            # determine the color based on the current volume level
+            color = self._perc_to_color(perc)
 
         # format the output
         text = self._format_output(self.format_muted


### PR DESCRIPTION
This PR adds extra functionality to dealing with colors and demonstrates this in the volume_status module.

In a module a common usecase is

`color = self.py3.COLOR_MUTED or self.py3.COLOR_BAD`

We would expect color to be `color_bad` if `color_muted` is not in the config and this is how things currently are.  However if `color_muted = None` then I think that this should be respected and color should be `None`.

To enable this we have to know if `color_muted` is actually defined in the config or not.  This PR uses class `NoneColor` to help.  We also add `Py3.is_color()` helper function.

Module volume_status is updated:

1) volume_muted not in config (default behavior muted is color_bad)

2) `volume_muted = '#FF00FF'` the specified color is used when muted

3) `volume_muted = None` When muted the color depending on the volume will be used.

I am not sure what we should call this new config option `color_muted` or `color_mute` but we should try for a consistent tense across all modules.

This achieves the outcome of PR #517 via the use of `color_muted` rather than a new config parameter.