### PR TITLE
Formatter and Composite updates

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -873,26 +873,41 @@ A pipe (vertical bar) `|` can be used to divide sections the first
 valid section only will be shown in the output.
 
 A backslash `\` can be used to escape a character eg `\[` will show `[`
-in the output. Note: `\?` is reserved for future use and is removed.
+in the output.
+
+`\?` is special and is used to provide extra commands to the format
+string,  example `\?color=#FF00FF`. Multiple commands can be given
+using an ampersand `&` as a separator, example `\?color=#FF00FF&show`.
 
 `{<placeholder>}` will be converted, or removed if it is None or empty.
-
 Formating can also be applied to the placeholder eg
 `{number:03.2f}`.
 
-*example format_string:*
+example format_string:
 
 `"[[{artist} - ]{title}]|{file}"`
 This will show `artist - title` if artist is present,
 `title` if title but no artist,
 and `file` if file is present but not artist or title.
 
-
 param_dict is a dictionary of palceholders that will be substituted.
 If a placeholder is not in the dictionary then if the py3status module
 has an attribute with the same name then it will be used.
 
+__Since version 3.3__
+
+Composites can be included in the param_dict.
+
+
+The result returned from this function can either be a string in the
+case of simple parsing or a Composite if more complex.
+
+If force_composite parameter is True a composite will always be
+returned.
+
 __build_composite(format_string, param_dict=None, composites=None)__
+
+__deprecated in 3.3__ use safe_format()
 
 Build a composite output using a format string.
 
@@ -900,6 +915,32 @@ Takes a format_string and treats it the same way as `safe_format` but
 also takes a composites dict where each key/value is the name of the
 placeholder and either an output eg `{'full_text': 'something'}` or a
 list of outputs.
+
+__composite_update(item, update_dict, soft=False)__
+
+Takes a Composite (item) if item is a type that can be converted into a
+Composite then this is done automatically.  Updates all entries it the
+Composite with values from update_dict.  Updates can be soft in which
+case existing values are not overwritten.
+
+A Composite object will be returned.
+
+__composite_join(separator, items)__
+
+Join a list of items with a separator.
+This is used in joining strings, responses and Composites.
+
+A Composite object will be returned.
+
+__composite_create(item)__
+
+Create and return a Composite.
+
+The item may be a string, dict, list of dicts or a Composite.
+
+__is_composite(item)__
+
+Check if item is a Composite and return True if it is.
 
 __check_commands(cmd_list)__
 

--- a/py3status/composite.py
+++ b/py3status/composite.py
@@ -1,0 +1,142 @@
+# basestring does not exist in python3
+try:
+    basestring
+except NameError:
+    basestring = str
+
+
+class Composite:
+    """
+    Helper class to identify a composite and store its content
+    A Composite is essentially a wrapped list containing response items.
+    """
+
+    def __init__(self, content=None):
+        # try and create a composite from various input types
+        if content is None:
+            content = []
+        elif isinstance(content, Composite):
+            content = content.get_content()[:]
+        elif isinstance(content, dict):
+            content = [content]
+        elif isinstance(content, basestring):
+            content = [{'full_text': content}]
+
+        assert(isinstance(content, list))
+        self._content = content
+
+    def __repr__(self):
+        return u'<Composite {}>'.format(self._content)
+
+    def __len__(self):
+        return len(self._content)
+
+    def __getitem__(self, key):
+        if isinstance(key, slice):
+            return Composite(self._content[key])
+        return self._content[key]
+
+    def __setitem__(self, key, value):
+        self._content[key] = value
+
+    def __delitem__(self, key):
+        del self._content[key]
+
+    def __iter__(self):
+        return iter(self._content)
+
+    def __iadd__(self, other):
+        self.append(other)
+        return self
+
+    def copy(self):
+        """
+        Return a shallow copy of the Composite
+        """
+        return Composite([x.copy() for x in self._content])
+
+    def append(self, item):
+        """
+        Add an item to the Composite.  Item can be a Composite, list etc
+        """
+        if isinstance(item, Composite):
+            self._content += item.get_content()
+        elif isinstance(item, list):
+            self._content += item
+        elif isinstance(item, dict):
+            self._content.append(item)
+        elif isinstance(item, basestring):
+            self._content.append({'full_text': item})
+        else:
+            msg = '{!r} not suitable to append to Composite'
+            raise Exception(msg.format(item))
+
+    def get_content(self):
+        """
+        Retrieve the contained list
+        """
+        return self._content
+
+    def simplify(self):
+        """
+        Simplify the content of a Composite merging any parts that can be
+        and returning the new Composite as well as updating itself internally
+        """
+        final_output = []
+        diff_last = None
+        item_last = None
+        for item in self._content:
+            # ignore empty items
+            if not item.get('full_text') and not item.get('separator'):
+                continue
+            # merge items if we can
+            diff = item.copy()
+            del diff['full_text']
+
+            if diff == diff_last or (item['full_text'].strip() == '' and item_last):
+                item_last['full_text'] += item['full_text']
+            else:
+                diff_last = diff
+                item_last = item.copy()  # copy item as we may change it
+                final_output.append(item_last)
+        self._content = final_output
+        return self
+
+    @staticmethod
+    def composite_join(separator, items):
+        """
+        Join a list of items with a separator.
+        This is used in joining strings, responses and Composites.
+        The output will be a Composite.
+        """
+
+        output = Composite()
+        first_item = True
+        for item in items:
+            # add separator but not before the first item
+            if first_item:
+                first_item = False
+            else:
+                output.append(separator)
+            output.append(item)
+        return output
+
+    @staticmethod
+    def composite_update(item, update_dict, soft=False):
+        """
+        Takes a Composite (item) and updates all entries with values from
+        update_dict.  Updates can be soft in which case existing values are not
+        overwritten.
+
+        If item is of type string it is first converted to a Composite
+        """
+        item = Composite(item)
+
+        for part in item.get_content():
+            if soft:
+                for key, value in update_dict.items():
+                    if key not in part:
+                        part[key] = value
+            else:
+                part.update(update_dict)
+        return item

--- a/py3status/formatter.py
+++ b/py3status/formatter.py
@@ -2,30 +2,20 @@
 import re
 import sys
 
+from py3status.composite import Composite
+
 try:
     from urllib.parse import parse_qsl
 except ImportError:
     from urlparse import parse_qsl
 
 
-class Composite:
-    """
-    Helper class to identify a composite
-    and store its content
-    """
-
-    def __init__(self, content, name='__Anon__'):
-        self.content = content
-        self.name = name
-
-    def __repr__(self):
-        return u'<Composite `{}`>'.format(self.name)
-
-
 class BlockConfig:
     """
     Block commands eg [\?color=bad ...] are stored in this object
     """
+
+    REGEX_COLOR = re.compile('#[0-9A-F]{6}')
 
     # defaults
     _if = None
@@ -40,13 +30,27 @@ class BlockConfig:
         commands = dict(parse_qsl(commands_str, keep_blank_values=True))
 
         self._if = commands.get('if', self._if)
-        self.color = commands.get('color', self.color)
+        self.color = self._check_color(commands.get('color'))
 
         max_length = commands.get('max_length')
         if max_length is not None:
             self.max_length = int(max_length)
 
         self.show = 'show' in commands or self.show
+
+    def _check_color(self, color):
+        if not color:
+            return self.color
+        # fix any hex colors so they are #RRGGBB
+        if color.startswith('#'):
+            color = color.upper()
+            if len(color) == 4:
+                color = ('#' + color[1] + color[1] + color[2]
+                         + color[2] + color[3] + color[3])
+            # check color is valid
+            if not self.REGEX_COLOR.match(color):
+                return self.color
+        return color
 
 
 class Block:
@@ -58,10 +62,9 @@ class Block:
     know about their parent block (if they have one)
     """
 
-    def __init__(self, param_dict, composites, module, parent=None):
+    def __init__(self, param_dict, module, parent=None):
         self.block_config = BlockConfig()
         self.commands = {}
-        self.composites = composites
         self.content = []
         self.is_composite = False
         self.module = module
@@ -157,13 +160,16 @@ class Block:
                 out.append(item)
         return out
 
-    def process_composite_chunk_item(self, item):
+    def process_composite_chunk_item(self, items):
         block_config = self.block_config
-        if block_config.max_length is not None:
-            item['full_text'] = item['full_text'][:block_config.max_length]
-            block_config.max_length -= len(item['full_text'])
-        if block_config.color and 'color' not in item:
-            item['color'] = block_config.color
+        if not isinstance(items, list):
+            items = [items]
+        for item in items:
+            if block_config.max_length is not None:
+                item['full_text'] = item['full_text'][:block_config.max_length]
+                block_config.max_length -= len(item['full_text'])
+            if block_config.color and 'color' not in item:
+                item['color'] = block_config.color
 
     def show(self):
         """
@@ -228,12 +234,9 @@ class Block:
                 text = ''
                 if self.parent is None:
                     # This is the main block so we get the actual composites
-                    composite = item.content
-                    if not isinstance(composite, list):
-                        composite = [composite]
-                    data += self.process_composite_chunk(composite)
+                    data += self.process_composite_chunk(item.get_content())
                 else:
-                    self.process_composite_chunk_item(item.content)
+                    self.process_composite_chunk_item(item.get_content())
                     data.append(item)
         if text:
             data.append(self.process_text_chunk(text))
@@ -261,7 +264,7 @@ class Formatter:
     reg_ex = re.compile(TOKENS[0], re.M | re.I)
 
     def format(self, format_string, module=None, param_dict=None,
-               composites=None):
+               force_composite=False):
         """
         Format a string.
         substituting place holders which can be found in
@@ -288,17 +291,14 @@ class Formatter:
         if param_dict is None:
             param_dict = {}
 
-        if composites is None:
-            composites = {}
-
-        block = Block(param_dict, composites, module)
+        block = Block(param_dict, module)
 
         # Tokenize the format string and process them
         for token in re.finditer(self.reg_ex, format_string):
             value = token.group(0)
             if token.group('block_start'):
                 # Create new block
-                new_block = Block(param_dict, composites, module, block)
+                new_block = Block(param_dict, module, block)
                 block.add(new_block)
                 block = new_block
             elif token.group('block_end'):
@@ -315,16 +315,17 @@ class Formatter:
             elif token.group('placeholder'):
                 # Found a {placeholder}
                 key = token.group('key')
-                if key in composites:
-                    # Add the composite
-                    if composites[key]:
-                        block.add(Composite(composites[key], key))
-                        block.is_composite = True
-                        block.mark_valid()
-                elif key in param_dict:
+                if key in param_dict:
                     # was a supplied parameter
                     param = param_dict.get(key)
-                    set_param(param, value, key)
+                    if isinstance(param, Composite):
+                        # supplied parameter is a composite
+                        if param.get_content():
+                            block.add(param.copy())
+                            block.is_composite = True
+                            block.mark_valid()
+                    else:
+                        set_param(param, value, key)
                 elif module and hasattr(module, key):
                     # attribute of the module
                     param = getattr(module, key)
@@ -358,23 +359,19 @@ class Formatter:
         if not block.valid_blocks:
             block.mark_valid()
         output = block.show()
-        if composites and not isinstance(output, list):
-            if output == '':
-                output = []
-            else:
-                output = [{'full_text': output}]
+
+        if force_composite and not isinstance(output, list):
+            output = [{'full_text': output}]
+
+        if isinstance(output, Composite):
+            output = output.get_content()
 
         # post format
         # swap color names to values
-        # merge items if possible
-
         if isinstance(output, list):
-            final_output = []
-            diff_last = None
-            item_last = None
             for item in output:
                 # ignore empty items
-                if not item['full_text'] and not item.get('separator'):
+                if not item.get('full_text') and not item.get('separator'):
                     continue
                 # colors
                 color_this = item.get('color')
@@ -389,18 +386,5 @@ class Formatter:
                             item['color'] = color_this
                     else:
                         del item['color']
-                # merge items if we can
-                diff = (
-                    item.get('index'),
-                    item.get('instance'),
-                    item.get('name'),
-                    color_this,
-                )
-                if diff == diff_last:
-                    item_last['full_text'] += item['full_text']
-                else:
-                    diff_last = diff
-                    item_last = item.copy()  # copy item as we may change it
-                    final_output.append(item_last)
-            return final_output
+            return Composite(output).simplify()
         return output

--- a/py3status/module.py
+++ b/py3status/module.py
@@ -6,6 +6,7 @@ from threading import Thread, Timer
 from collections import OrderedDict
 from time import time
 
+from py3status.composite import Composite
 from py3status.py3 import Py3, PY3_CACHE_FOREVER
 from py3status.profiling import profile
 
@@ -213,6 +214,13 @@ class Module(Thread):
         We need to respect the universal options too.
         """
         composite = response['composite']
+
+        # if the composite is of Composite type then convert this into the
+        # underlying list, simplifying it first.
+        if isinstance(composite, Composite):
+            composite = composite.simplify().get_content()
+            response['composite'] = composite
+
         if not isinstance(composite, list):
             raise Exception('expecting "composite" key in response')
         # if list is empty nothing to do
@@ -448,7 +456,7 @@ class Module(Thread):
                     else:
                         raise TypeError('response should be a dict')
 
-                    if isinstance(response.get('full_text'), list):
+                    if isinstance(response.get('full_text'), (list, Composite)):
                         response['composite'] = response['full_text']
                         del response['full_text']
                     if 'composite' in response:

--- a/tests/test_composite.py
+++ b/tests/test_composite.py
@@ -1,0 +1,85 @@
+from py3status.composite import Composite
+
+
+# Composite initialize
+
+def test_Composite_init_1():
+    result = Composite('moo').get_content()
+    assert result == [{'full_text': 'moo'}]
+
+
+def test_Composite_init_2():
+    result = Composite({'full_text': 'moo'}).get_content()
+    assert result == [{'full_text': 'moo'}]
+
+
+def test_Composite_init_3():
+    result = Composite([{'full_text': 'moo'}]).get_content()
+    assert result == [{'full_text': 'moo'}]
+
+
+def test_Composite_init_4():
+    result = Composite(Composite('moo')).get_content()
+    assert result == [{'full_text': 'moo'}]
+
+
+# Composite append
+
+
+def test_Composite_append_1():
+    c = Composite('moo')
+    c.append('moo')
+    result = c.get_content()
+    assert result == [{'full_text': 'moo'}, {'full_text': 'moo'}]
+
+
+def test_Composite_append_2():
+    c = Composite('moo')
+    c.append({'full_text': 'moo'})
+    result = c.get_content()
+    assert result == [{'full_text': 'moo'}, {'full_text': 'moo'}]
+
+
+def test_Composite_append_3():
+    c = Composite('moo')
+    c.append([{'full_text': 'moo'}])
+    result = c.get_content()
+    assert result == [{'full_text': 'moo'}, {'full_text': 'moo'}]
+
+
+def test_Composite_append_4():
+    c = Composite('moo')
+    c.append(Composite('moo'))
+    result = c.get_content()
+    assert result == [{'full_text': 'moo'}, {'full_text': 'moo'}]
+
+
+# Composite __iadd__
+
+
+def test_Composite_iadd_1():
+    c = Composite('moo')
+    c += ('moo')
+    result = c.get_content()
+    assert result == [{'full_text': 'moo'}, {'full_text': 'moo'}]
+
+
+def test_Composite_iadd_2():
+    c = Composite('moo')
+    c += ({'full_text': 'moo'})
+    result = c.get_content()
+    assert result == [{'full_text': 'moo'}, {'full_text': 'moo'}]
+
+
+def test_Composite_iadd_3():
+    c = Composite('moo')
+    c += ([{'full_text': 'moo'}])
+    result = c.get_content()
+    assert result == [{'full_text': 'moo'}, {'full_text': 'moo'}]
+
+
+def test_Composite_iadd_4():
+    c = Composite('moo')
+    c += (Composite('moo'))
+    result = c.get_content()
+    assert result == [{'full_text': 'moo'}, {'full_text': 'moo'}]

--- a/tests/test_formatter.py
+++ b/tests/test_formatter.py
@@ -5,6 +5,7 @@ Run formatter tests
 
 import platform
 
+from py3status.composite import Composite
 from py3status.formatter import Formatter
 
 is_pypy = platform.python_implementation() == 'PyPy'
@@ -24,12 +25,15 @@ param_dict = {
     'python2_unicode': u'Björk',
     'python2_str': 'Björk',
     'zero': 0,
-}
-
-composites = {
-    'complex': [{'full_text': 'LA 09:34'}, {'full_text': 'NY 12:34'}],
-    'simple': {'full_text': 'NY 12:34'},
-    'empty': [],
+    'composite_basic': Composite([{'full_text': 'red ', 'color': '#FF0000'},
+                                  {'full_text': 'green ', 'color': '#00FF00'},
+                                  {'full_text': 'blue', 'color': '#0000FF'}]),
+    'complex': Composite([{'full_text': 'LA 09:34'},
+                          {'full_text': 'NY 12:34'}]),
+    'complex2': Composite([{'full_text': 'LA 09:34', 'color': '#FF0000'},
+                           {'full_text': 'NY 12:34'}]),
+    'simple': Composite({'full_text': 'NY 12:34'}),
+    'empty_composite': Composite(),
 }
 
 
@@ -56,20 +60,20 @@ def run_formatter(test_dict):
         return
     try:
         module = Module()
-        if test_dict.get('composite'):
-            result = f.format(test_dict['format'], module, param_dict, composites, )
-        else:
-            result = f.format(test_dict['format'], module, param_dict)
+        result = f.format(test_dict['format'], module, param_dict,
+                          force_composite=test_dict.get('composite'))
     except Exception as e:
         if test_dict.get('exception') == str(e):
-            assert(True)
             return
         raise e
+
+    if hasattr(result, 'get_content'):
+        result = result.get_content()
 
     expected = test_dict.get('expected')
     if f.python2 and isinstance(expected, str):
         expected = expected.decode('utf-8')
-    assert (result == expected)
+    assert result == expected
 
 
 def test_1():
@@ -379,8 +383,16 @@ def test_58():
     run_formatter({'format': '[\?if=yes Hello]', 'expected': 'Hello', })
 
 
+def test_58a():
+    run_formatter({'format': '\?if=yes Hello', 'expected': 'Hello', })
+
+
 def test_59():
     run_formatter({'format': '[\?if=no Hello]', 'expected': '', })
+
+
+def test_59a():
+    run_formatter({'format': '\?if=no Hello', 'expected': '', })
 
 
 def test_60():
@@ -441,7 +453,17 @@ def test_70():
     run_formatter(
         # Composites
         {
-            'format': '{empty}',
+            'format': '{empty_composite}',
+            'expected': [],
+            'composite': True,
+        })
+
+
+def test_70a():
+    run_formatter(
+        # Composites
+        {
+            'format': '[{empty_composite} hello]',
             'expected': [],
             'composite': True,
         })
@@ -525,9 +547,86 @@ def test_else_false():
 # block colors
 
 
+def test_color_name_1():
+    run_formatter({
+        'format': '\?color=bad color',
+        'expected':  [{'full_text': 'color', 'color': '#FF0000'}],
+    })
+
+
+def test_color_name_2():
+    run_formatter({
+        'format': '\?color=no_name color',
+        'expected':  [{'full_text': 'color'}],
+    })
+
+
+def test_color_name_3():
+    run_formatter({
+        'format': '\?color=#FF00FF color',
+        'expected':  [{'full_text': 'color', 'color': '#FF00FF'}],
+    })
+
+
+def test_color_name_4():
+    run_formatter({
+        'format': '\?color=#ff00ff color',
+        'expected':  [{'full_text': 'color', 'color': '#FF00FF'}],
+    })
+
+
+def test_color_name_4a():
+    run_formatter({
+        'format': '[\?color=#ff00ff&show color]',
+        'expected':  [{'full_text': 'color', 'color': '#FF00FF'}],
+    })
+
+
+def test_color_name_5():
+    run_formatter({
+        'format': '\?color=#F0F color',
+        'expected':  [{'full_text': 'color', 'color': '#FF00FF'}],
+    })
+
+
+def test_color_name_5a():
+    run_formatter({
+        'format': '[\?color=#F0F&show color]',
+        'expected':  [{'full_text': 'color', 'color': '#FF00FF'}],
+    })
+
+
+def test_color_name_6():
+    run_formatter({
+        'format': '\?color=#f0f color',
+        'expected':  [{'full_text': 'color', 'color': '#FF00FF'}],
+    })
+
+
+def test_color_name_7():
+    run_formatter({
+        'format': '\?color=#BADHEX color',
+        'expected': 'color',
+    })
+
+
+def test_color_name_7a():
+    run_formatter({
+        'format': '[\?color=#BADHEX&show color]',
+        'expected': 'color',
+    })
+
+
 def test_color_1():
     run_formatter({
         'format': '[\?color=bad {name}]',
+        'expected':  [{'full_text': u'Björk', 'color': '#FF0000'}],
+    })
+
+
+def test_color_1a():
+    run_formatter({
+        'format': '\?color=bad {name}',
         'expected':  [{'full_text': u'Björk', 'color': '#FF0000'}],
     })
 
@@ -579,8 +678,129 @@ def test_color_6():
     run_formatter({
         'format': '[\?color=bad {name}] [\?color=good {name}]',
         'expected': [
-            {'full_text': u'Björk', 'color': '#FF0000'},
-            {'full_text': ' '},
+            {'full_text': u'Björk ', 'color': '#FF0000'},
             {'full_text': u'Björk', 'color': '#00FF00'}
         ],
+    })
+
+
+def test_color_7():
+    run_formatter({
+        'format': '\?color=bad {simple}',
+        'expected': [{'full_text': 'NY 12:34', 'color': '#FF0000'}],
+    })
+
+
+def test_color_7a():
+    run_formatter({
+        'format': '[\?color=bad {simple}]',
+        'expected': [{'full_text': 'NY 12:34', 'color': '#FF0000'}],
+    })
+
+
+def test_color_8():
+    run_formatter({
+        'format': '\?color=bad {complex}',
+        'expected': [{'full_text': 'LA 09:34NY 12:34', 'color': '#FF0000'}],
+    })
+
+
+def test_color_8a():
+    run_formatter({
+        'format': '[\?color=#FF00FF {complex}]',
+        'expected': [{'full_text': 'LA 09:34NY 12:34', 'color': '#FF00FF'}],
+    })
+
+
+def test_color_9():
+    run_formatter({
+        'format': '\?color=good {complex2}',
+        'expected': [
+            {'color': '#FF0000', 'full_text': 'LA 09:34'},
+            {'color': '#00FF00', 'full_text': 'NY 12:34'}
+        ],
+    })
+
+
+def test_color_9a():
+    run_formatter({
+        'format': '[\?color=good {complex2}]',
+        'expected': [
+            {'color': '#FF0000', 'full_text': 'LA 09:34'},
+            {'color': '#00FF00', 'full_text': 'NY 12:34'}
+        ],
+    })
+
+
+# Composite tests
+
+def test_composite_1():
+    run_formatter({
+        'format': '{composite_basic}',
+        'expected': [
+            {'color': '#FF0000', 'full_text': 'red '},
+            {'color': '#00FF00', 'full_text': 'green '},
+            {'color': '#0000FF', 'full_text': 'blue'}
+        ],
+    })
+
+
+def test_composite_2():
+    run_formatter({
+        'format': '{composite_basic}',
+        'expected': [
+            {'color': '#FF0000', 'full_text': 'red '},
+            {'color': '#00FF00', 'full_text': 'green '},
+            {'color': '#0000FF', 'full_text': 'blue'}
+        ],
+        'composite': True,
+    })
+
+
+def test_composite_3():
+    run_formatter({
+        'format': 'RGB: {composite_basic}',
+        'expected': [
+            {'full_text': 'RGB: '},
+            {'color': '#FF0000', 'full_text': 'red '},
+            {'color': '#00FF00', 'full_text': 'green '},
+            {'color': '#0000FF', 'full_text': 'blue'}
+        ],
+    })
+
+
+def test_composite_4():
+    run_formatter({
+        'format': '\?color=good {simple} {composite_basic} {complex}',
+        'expected': [
+            {'full_text': 'NY 12:34 ', 'color': '#00FF00'},
+            {'color': '#FF0000', 'full_text': 'red '},
+            {'color': '#00FF00', 'full_text': 'green '},
+            {'color': '#0000FF', 'full_text': 'blue '},
+            {'full_text': 'LA 09:34NY 12:34', 'color': '#00FF00'}
+        ],
+        'composite': True,
+    })
+
+
+def test_composite_5():
+    run_formatter({
+        'format': '[\?color=#FF00FF {simple} {composite_basic} {complex2}]',
+        'expected': [
+            {'full_text': 'NY 12:34 ', 'color': '#FF00FF'},
+            {'color': '#FF0000', 'full_text': 'red '},
+            {'color': '#00FF00', 'full_text': 'green '},
+            {'color': '#0000FF', 'full_text': 'blue '},
+            {'color': '#FF0000', 'full_text': 'LA 09:34'},
+            {'color': '#FF00FF', 'full_text': 'NY 12:34'}
+        ],
+        'composite': True,
+    })
+
+
+def test_composite_6():
+    run_formatter({
+        'format': 'hello',
+        'expected': [{'full_text': 'hello'}],
+        'composite': True,
     })


### PR DESCRIPTION
Updates to the formatter.

* Composites in the formatter now return a `Composite` object rather than a list (if a composite is created eg when `\?color=XXX` is used in a format string).  This allows us to add composites via `param_dict`.

* A `Composite` is basically a wrapped list but allows us to know that it is a composite rather than just a list.  It also allows easier appending/creating as it understands strings, lists, dicts and Composites.  It also has some helper functions.

* Seeing as how `safe_format()` can return a `Composite` and add them via `param_dict` there is less need for `build_composite()` so it can be deprecated.

* `safe_format()` can be forced to return a composite.  This is helpful if the module will manipulate the result etc.

* `composite_join()`, `composite_update()`, `composite_create()`, `is_composite()` helper functions added to `Py3`.

* Fix various bugs in the formatter and add new tests to catch them

* Merging of Composite components improved

* `module.py` accepts Composites in responses

* Hex colors passed to formatter via `\?color=#xxxxxx` are checked, upper-cased to aid merging and now values like `#xxx` are also allowed

* As well as some general formatter fixes this allows us to start doing some more interesting things for example with a few minor changes `weather_yahoo` can allow me to choose custom colors for each weather icon (without having to add any extra config parameters)

* Most modules will just continue to work as they are with no changes, only ones that manipulate the result of `safe_format()` need to worry about these changes and they already need to care to some extent so the disruption to module writers is minimal.

I still need to do some more documentation and write some more Composite tests but the actual code shouldn't be changing so any reviews would be helpful