### PR TITLE
i3status time modules fix

### DIFF
--- a/py3status/i3status.py
+++ b/py3status/i3status.py
@@ -101,10 +101,10 @@ class I3statusModule:
         if self.is_time_module:
             # If no timezone or a minute has passed update timezone
             # FIXME we should also check if resuming from suspended
-            if not self.tz or int(time()) % 60 != 0:
+            if not self.tz or int(time()) % 60 == 0:
                 self.set_time_zone()
             # update time to be shown
-            is_updated = self.update_time_value()
+            is_updated = self.update_time_value() or is_updated
         return is_updated
 
     def set_time_format(self):


### PR DESCRIPTION
There were some bugs in the i3status module around handling times.

1) Sometimes the module was not updated when it should have been.  This occurs when py3status is first started and the modules time format is the default.  The module can take several seconds to appear.  We now update as required.

2)  The logic for recreating the Tz timezones once a minute was incorrect and we were regenerating them every second.