### PR TITLE
Thresholds

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -9,6 +9,7 @@ py3status documentation
 * [Configuring modules](#configuring_modules)
 * [Configuration obfuscation](#obfuscation)
 * [Configuring colors](#configuring_color)
+* [Configuring thresholds](#configuring_thresholds)
 * [Grouping modules](#group_modules)
 
 [Custom click events](#on_click)
@@ -165,6 +166,55 @@ battery_level {
     color_charging = '#FFFF00'
 }
 ```
+
+#### <a name="configuring_thresholds"></a>Configuring thresholds
+
+Some modules allow you to define thresholds in a module.  These are used to
+determine which color to use when displaying the module.  Thresholds are
+defined in the config as a list of tuples. With each tuple containing a value
+and a color. The color can either be a named color eg `good` referring to
+`color_good` or a hex value.
+
+Example:
+```
+volume_status {
+    thresholds = [
+        (0, "#FF0000"),
+        (20, "degraded"),
+        (50, "bad"),
+    ]
+}
+```
+
+If the value checked against the threshold is equal to or more than a threshold
+then that color supplied will be used.
+
+In the above example the logic would be
+
+if 0 >= value < 20 use #FF0000
+else if 20 >= value < 50 use color_degraded
+else if 50 >= value use color_good
+
+
+Some modules may allow more than one threshold to be defined.  If all the thresholds are the same they can be defined as above but if you wish to specify them separately you can by giving a dict of lists.
+
+Example:
+```
+my_module {
+    thresholds = {
+        'threshold_1': [
+            (0, "#FF0000"),
+            (20, "degraded"),
+            (50, "bad"),
+        ],
+        'threshold_2': [
+            (0, "good"),
+            (30, "bad"),
+        ],
+    }
+}
+```
+
 
 #### <a name="group_modules"></a>Grouping Modules
 
@@ -968,6 +1018,16 @@ Plays sound_file if possible. Requires `paplay` or `play`.
 __stop_sound()__
 
 Stops any currently playing sounds for this module.
+
+__threshold_get_color(value, name=None)__
+
+Obtain color for a value using thresholds.
+
+The value will be checked against any defined thresholds.  These should
+have been set in the i3status configuration.  If more than one
+threshold is needed for a module then the name can also be supplied.
+If the user has not supplied a named threshold but has defined a
+general one that will be used.
 
 ***
 

--- a/py3status/formatter.py
+++ b/py3status/formatter.py
@@ -379,9 +379,11 @@ class Formatter:
                 color_this = item.get('color')
                 if color_this and color_this[0] != '#':
                     color_name = 'color_%s' % color_this
+                    threshold_color_name = 'color_threshold_%s' % color_this
                     # substitute color
                     color_this = (
                         getattr(module, color_name, None) or
+                        getattr(module, threshold_color_name, None) or
                         getattr(module.py3, color_name.upper(), None)
                     )
                     if color_this:

--- a/tests/test_module_doc.py
+++ b/tests/test_module_doc.py
@@ -33,12 +33,15 @@ IGNORE_ITEM = [
     ('arch_updates', '_format_pacman_only'),  # need moving into __init__ etc
     ('arch_updates', '_line_separator'),  # need moving into __init__ etc
     ('arch_updates', 'format'),  # dynamic
+    ('volume_status', 'thresholds'),  # dynamic
 ]
 
 # Obsolete parameters will not have alphabetical order checked
 OBSELETE_PARAM = [
     ('battery_level', 'mode'),
     ('battery_level', 'show_percent_with_blocks'),
+    ('volume_status', 'threshold_bad'),
+    ('volume_status', 'threshold_degraded'),
 ]
 
 RE_PARAM = re.compile(


### PR DESCRIPTION
Following my plans set out in issue #451 here is an implementation of thresholds.

* `threshold_check()` function added to Py3.  This both returns the correct threshold color for a value but also sets the color for use in formatting.

* Threshold colors added to module as `color_threshold` accessed as `threshold` or as `color_threshold_<name>` accessed as `<name>` this makes things easy for the user whilst reducing the likelihood of accidentally overwriting variables. 

* single or multiple thresholds can be easily defined.

* thresholds can now have as many steps as the user wishes to define as opposed to just the ones of the module writer.

* Some basic documentation added.

* volume_status module updated as an example.