### PR TITLE
Allow multiple i3status configs and switcher module

### DIFF
--- a/py3status/core.py
+++ b/py3status/core.py
@@ -11,14 +11,14 @@ from json import dumps
 from platform import python_version
 from signal import signal, SIGTERM, SIGUSR1, SIGTSTP, SIGCONT
 from subprocess import Popen
-from threading import Event
+from threading import Event, Thread
 from syslog import syslog, LOG_ERR, LOG_INFO, LOG_WARNING
 from traceback import extract_tb, format_tb, format_stack
 
 import py3status.docstrings as docstrings
 from py3status.events import Events
 from py3status.helpers import print_line, print_stderr
-from py3status.i3status import I3status
+from py3status.i3status import I3statusRunner
 from py3status.parse_config import process_config
 from py3status.module import Module
 from py3status.profiling import profile
@@ -49,15 +49,19 @@ class Py3statusWrapper():
         Useful variables we'll need.
         """
         self.config = {}
+        self.current_config = None
         self.i3bar_running = True
         self.last_refresh_ts = time.time()
         self.lock = Event()
         self.modules = {}
+        self.new_config_path = None
         self.notified_messages = set()
         self.output_modules = {}
         self.py3_modules = []
         self.py3_modules_initialized = False
         self.queue = deque()
+        self.update_config = False
+        self.user_modules = {}
 
     def get_config(self):
         """
@@ -120,8 +124,9 @@ class Py3statusWrapper():
                             '--config',
                             action="store",
                             dest="i3status_conf",
+                            nargs='+',
                             type=str,
-                            default=i3status_config_file_default,
+                            default=[i3status_config_file_default],
                             help="path to i3status config file")
         parser.add_argument('-d',
                             '--debug',
@@ -185,7 +190,7 @@ class Py3statusWrapper():
         config['interval'] = int(options.interval)
         config['log_file'] = options.log_file
         config['standalone'] = options.standalone
-        config['i3status_config_path'] = options.i3status_conf
+        config['i3status_config_paths'] = options.i3status_conf
 
         # all done
         return config
@@ -308,35 +313,8 @@ class Py3statusWrapper():
             self.log(
                 'py3status started with config {}'.format(self.config))
 
-        # read i3status.conf
-        config_path = self.config['i3status_config_path']
-        config = process_config(config_path, self)
-
-        # setup i3status thread
-        self.i3status_thread = I3status(self, config)
-
-        # If standalone or no i3status modules then use the mock i3status
-        # else start i3status thread.
-        i3s_modules = self.i3status_thread.config['i3s_modules']
-        if self.config['standalone'] or not i3s_modules:
-            self.i3status_thread.mock()
-            i3s_mode = 'mocked'
-        else:
-            i3s_mode = 'started'
-            self.i3status_thread.start()
-            while not self.i3status_thread.ready:
-                if not self.i3status_thread.is_alive():
-                    # i3status is having a bad day, so tell the user what went
-                    # wrong and do the best we can with just py3status modules.
-                    err = self.i3status_thread.error
-                    self.notify_user(err)
-                    self.i3status_thread.mock()
-                    i3s_mode = 'mocked'
-                    break
-                time.sleep(0.1)
-        if self.config['debug']:
-            self.log('i3status thread {} with config {}'.format(
-                i3s_mode, self.i3status_thread.config))
+        # create i3status runner
+        self.i3status_runner = I3statusRunner(self)
 
         # setup input events thread
         self.events_thread = Events(self)
@@ -349,17 +327,114 @@ class Py3statusWrapper():
             sys.stdout = open('/dev/null', 'w')
             sys.stderr = open('/dev/null', 'w')
 
-        # get the list of py3status configured modules
-        self.py3_modules = self.i3status_thread.config['py3_modules']
-
         # get a dict of all user provided modules
-        user_modules = self.get_user_configured_modules()
+        self.user_modules = self.get_user_configured_modules()
         if self.config['debug']:
-            self.log('user_modules={}'.format(user_modules))
+            self.log('user_modules={}'.format(self.user_modules))
+
+    def select_i3status_config(self):
+        """
+        Select a config file for py3status to use
+        """
+        config_path = self.new_config_path
+        self.new_config_path = None
+        # update py3status to use config file
+        self.process_i3status_config(config_path)
+
+    def process_i3status_config(self, config_path):
+        """
+        Use config file to prepare py3status
+        """
+
+        # if i3status is running we want to stop it.
+        self.i3status_runner.kill()
+
+        # stop any updates to containers
+        self.py3_modules_initialized = False
+
+        # stop all running py3status modules
+        for module in self.modules.values():
+            module.kill()
+
+        # clear output data and update queue
+        self.output_modules.clear()
+        self.queue = deque()
+
+        self.log('Using config {}'.format(config_path))
+
+        self.config['i3status_config_path'] = config_path
+
+        config = process_config(config_path, self)
+
+        # position in the bar of the modules
+        # we need this info for creating output_modules dict
+        positions = {}
+        for index, name in enumerate(config['order']):
+            if name not in positions:
+                positions[name] = []
+            positions[name].append(index)
+        self.positions = positions
+
+        # start a new i3status thread with new config
+        self.i3status_runner.set_config(config)
+
+        # update events thread to use new config
+        self.events_thread.set_config(config)
+
+        # get the list of py3status configured modules
+        self.py3_modules = config['py3_modules']
+
+        self.i3status_config = config
+
+        # prepare the color mappings
+        self.create_mappings(config)
+
+        self.modules = {}
 
         if self.py3_modules:
-            # load and spawn i3status.conf configured modules threads
-            self.load_modules(self.py3_modules, user_modules)
+            self.start_py3status_modules()
+
+        self.update_config = False
+
+    def start_py3status_modules(self):
+        """
+        Start all py3status modules
+        """
+        # load and spawn i3status.conf configured modules threads
+        self.load_modules(self.py3_modules, self.user_modules)
+
+        # self.output_modules needs to have been created before modules are
+        # started.  This is so that modules can do things like register their
+        # content_function.
+        self.create_py3status_output_modules()
+
+        # We need to know when all py3status modules have been started so that
+        # we can re-enable updates to containers so store a list of names we
+        # can check against.
+        self.py3status_modules = list(self.modules.keys())
+
+        # start each module but in a thread so we don't delay
+        for module in self.modules.values():
+            thread = Thread(target=self.start_py3status_module, args=(module,))
+            thread.daemon = True
+            thread.start()
+
+    def start_py3status_module(self, module):
+        """
+        Start the py3status module
+        """
+        # Some modules need to be prepared before they can run
+        # eg run their post_config_hook
+        module.prepare_module()
+
+        # see if we are all started?
+        self.py3status_modules.remove(module.module_full_name)
+        if len(self.py3status_modules) == 0:
+            # modules can now receive updates
+            self.py3_modules_initialized = True
+
+        # start module
+        module.start_module()
 
     def notify_user(self, msg, level='error', rate_limit=None, module_name=''):
         """
@@ -420,6 +495,8 @@ class Py3statusWrapper():
         """
         try:
             self.lock.clear()
+            self.i3status_runner.kill()
+
             if self.config['debug']:
                 self.log('lock cleared, exiting')
             # run kill() method on all py3status modules
@@ -458,7 +535,7 @@ class Py3statusWrapper():
                         self.log('refresh i3status module {}'.format(name))
                     update_i3status = True
         if update_i3status:
-            self.i3status_thread.refresh_i3status()
+            self.i3status_runner.refresh_i3status()
 
     def sig_handler(self, signum, frame):
         """
@@ -487,7 +564,7 @@ class Py3statusWrapper():
             return
 
         # find containers that use the modules that updated
-        containers = self.i3status_thread.config['.module_groups']
+        containers = self.i3status_config['.module_groups']
         containers_to_update = set()
         for item in update:
             if item in containers:
@@ -601,20 +678,13 @@ class Py3statusWrapper():
         if notify_user:
             self.notify_user(msg, level=level)
 
-    def create_output_modules(self):
+    def create_py3status_output_modules(self):
         """
         Setup our output modules to allow easy updating of py3modules and
         i3status modules allows the same module to be used multiple times.
         """
-        config = self.i3status_thread.config
-        i3modules = self.i3status_thread.i3modules
+        positions = self.positions
         output_modules = self.output_modules
-        # position in the bar of the modules
-        positions = {}
-        for index, name in enumerate(config['order']):
-            if name not in positions:
-                positions[name] = []
-            positions[name].append(index)
 
         # py3status modules
         for name in self.modules:
@@ -623,15 +693,20 @@ class Py3statusWrapper():
                 output_modules[name]['position'] = positions.get(name, [])
                 output_modules[name]['module'] = self.modules[name]
                 output_modules[name]['type'] = 'py3status'
-        # i3status modules
-        for name in i3modules:
-            if name not in output_modules:
-                output_modules[name] = {}
-                output_modules[name]['position'] = positions.get(name, [])
-                output_modules[name]['module'] = i3modules[name]
-                output_modules[name]['type'] = 'i3status'
 
         self.output_modules = output_modules
+
+    def add_i3status_output_module(self, module_name, module):
+        """
+        Update our output modules info for i3status module
+        """
+        position = self.positions.get(module_name, [])
+        output_modules = self.output_modules
+
+        output_modules[module_name] = {}
+        output_modules[module_name]['position'] = position
+        output_modules[module_name]['module'] = module
+        output_modules[module_name]['type'] = 'i3status'
 
     def get_config_attribute(self, name, attribute):
         """
@@ -639,8 +714,8 @@ class Py3statusWrapper():
         then walk up through any containing group and then try the general
         section of the config.
         """
-        config = self.i3status_thread.config
-        color = config[name].get(attribute, 'missing')
+        config = self.i3status_config
+        color = config.get(name, {}).get(attribute, 'missing')
         if color == 'missing' and name in config['.module_groups']:
             for module in config['.module_groups'][name]:
                 if attribute in config.get(module, {}):
@@ -689,7 +764,7 @@ class Py3statusWrapper():
     def i3bar_stop(self, signum, frame):
         self.i3bar_running = False
         # i3status should be stopped
-        self.i3status_thread.suspend_i3status()
+        self.i3status_runner.suspend_i3status()
         self.sleep_modules()
 
     def i3bar_start(self, signum, frame):
@@ -719,29 +794,11 @@ class Py3statusWrapper():
         signal(SIGUSR1, self.sig_handler)
         signal(SIGTERM, self.terminate)
 
+        self.process_i3status_config(self.config['i3status_config_paths'][0])
+
         # initialize usage variables
-        i3status_thread = self.i3status_thread
-        config = i3status_thread.config
-
-        # prepare the color mappings
-        self.create_mappings(config)
-
-        # self.output_modules needs to have been created before modules are
-        # started.  This is so that modules can do things like register their
-        # content_function.
-        self.create_output_modules()
-
-        # Some modules need to be prepared before they can run
-        # eg run their post_config_hook
-        for module in self.modules.values():
-            module.prepare_module()
-
-        # modules can now receive updates
-        self.py3_modules_initialized = True
-
-        # start modules
-        for module in self.modules.values():
-            module.start_module()
+        i3status_runner = self.i3status_runner
+        config = self.i3status_config
 
         # this will be our output set to the correct length for the number of
         # items in the bar
@@ -776,8 +833,8 @@ class Py3statusWrapper():
                 last_sec = sec
 
                 # check i3status thread
-                if not i3status_thread.is_alive():
-                    err = i3status_thread.error
+                if not i3status_runner.is_alive():
+                    err = i3status_runner.error
                     if not err:
                         err = 'I3status died horribly.'
                     self.notify_user(err)
@@ -792,13 +849,16 @@ class Py3statusWrapper():
 
                 # update i3status time/tztime items
                 if interval == 0 or sec % interval == 0:
-                    i3status_thread.update_times()
+                    i3status_runner.update_times()
 
             # check if an update is needed
             if self.queue:
                 while (len(self.queue)):
                     module_name = self.queue.popleft()
-                    module = self.output_modules[module_name]
+                    module = self.output_modules.get(module_name)
+                    if not module:
+                        self.log('missing module %s' % module_name)
+                        continue
                     for index in module['position']:
                         # store the output as json
                         out = module['module'].get_latest()
@@ -808,6 +868,13 @@ class Py3statusWrapper():
                 out = ','.join([x for x in output if x])
                 # dump the line to stdout
                 print_line(',[{}]'.format(out))
+
+            # check if config has changed
+            if self.new_config_path:
+                self.select_i3status_config()
+                # this will be our output set to the correct length for the
+                # number of items in the bar
+                output = [None] * len(config['order'])
 
     def handle_cli_command(self, config):
         """Handle a command from the CLI.

--- a/py3status/events.py
+++ b/py3status/events.py
@@ -62,10 +62,10 @@ class Events(Thread):
         Thread.__init__(self)
         self.config = py3_wrapper.config
         self.error = None
-        self.i3s_config = py3_wrapper.i3status_thread.config
+        self.i3s_config = {}
         self.lock = py3_wrapper.lock
         self.modules = py3_wrapper.modules
-        self.on_click = self.i3s_config['on_click']
+        self.on_click = {}
         self.output_modules = py3_wrapper.output_modules
         self.poller_inp = IOPoller(sys.stdin)
         self.py3_wrapper = py3_wrapper
@@ -96,6 +96,10 @@ class Events(Thread):
             else:
                 partial_text = full_text
         return full_text, partial_text
+
+    def set_config(self, config):
+        self.i3s_config = config
+        self.on_click = config['on_click']
 
     def on_click_dispatcher(self, module_name, event, command):
         """
@@ -182,7 +186,7 @@ class Events(Thread):
             self.py3_wrapper.refresh_modules(module_name)
 
         # find container that holds the module and call its onclick
-        module_groups = self.i3s_config['.module_groups']
+        module_groups = self.i3s_config.get('.module_groups', {})
         containers = module_groups.get(module_name, [])
         for container in containers:
             self.process_event(container, event, top_level=False)

--- a/py3status/module.py
+++ b/py3status/module.py
@@ -33,7 +33,8 @@ class Module(Thread):
         self.disabled = False
         self.has_post_config_hook = False
         self.has_kill = False
-        self.i3status_thread = py3_wrapper.i3status_thread
+        self.i3status_config = py3_wrapper.i3status_config
+        self.i3status_runner = py3_wrapper.i3status_runner
         self.last_output = []
         self.lock = py3_wrapper.lock
         self.methods = OrderedDict()
@@ -192,7 +193,7 @@ class Module(Thread):
         https://i3wm.org/i3status/manpage.html#_universal_module_options
         """
         self.module_options = {}
-        mod_config = self.i3status_thread.config.get(module, {})
+        mod_config = self._py3_wrapper.i3status_config.get(module, {})
 
         if 'min_width' in mod_config:
             self.module_options['min_width'] = mod_config['min_width']
@@ -356,7 +357,7 @@ class Module(Thread):
                 pass
 
             # module configuration
-            mod_config = self.i3status_thread.config.get(module, {})
+            mod_config = self._py3_wrapper.i3status_config.get(module, {})
 
             # process any deprecated configuration settings
             try:
@@ -541,8 +542,8 @@ class Module(Thread):
                 click_method(event)
             else:
                 # legacy modules had extra parameters passed
-                click_method(self.i3status_thread.json_list,
-                             self.i3status_thread.config['general'], event)
+                click_method(self.i3status_runner.json_list,
+                             self.i3status_config['general'], event)
             self.set_updated()
         except Exception:
             msg = 'on_click event in `{}` failed'.format(self.module_full_name)
@@ -585,8 +586,8 @@ class Module(Thread):
                     else:
                         # legacy modules had parameters passed
                         response = method(
-                            self.i3status_thread.json_list,
-                            self.i3status_thread.config['general'])
+                            self.i3status_runner.json_list,
+                            self.i3status_config['general'])
 
                     if isinstance(response, dict):
                         # this is a shiny new module giving a dict response
@@ -684,8 +685,8 @@ class Module(Thread):
                     kill_method()
                 else:
                     # legacy call parameters
-                    kill_method(self.i3status_thread.json_list,
-                                self.i3status_thread.config['general'])
+                    kill_method(self.i3status_runner.json_list,
+                                self.i3status_config['general'])
             except Exception:
                 # this would be stupid to die on exit
                 pass

--- a/py3status/modules/config_switcher.py
+++ b/py3status/modules/config_switcher.py
@@ -1,0 +1,138 @@
+# -*- coding: utf-8 -*-
+"""
+Select config file py3status should use and switch between.
+
+If more than one configuration file is supplied to py3status then this module
+will let you select and switch between them.
+
+Configuration parameters:
+    button_change: button to select next config file.  None disables
+        (default None)
+    button_next: button to display next config file.  None disables
+        (default None)
+    button_previous: button to display previous config file.  None disables
+        (default None)
+    button_select: button to select displayed config file.  None disables
+        (default 3)
+    button_toggle: button to toggle open.  None disables
+        (default 1)
+    format: Display format to use
+        (default '⚙[\?if=open  {file} {button_previous} {button_next}]')
+    icon_next: icon to use for next button (default '→')
+    icon_previous: icon to use for previous button (default '←')
+    open: If the module is considered open (default False)
+
+Format placeholders:
+    {file} the name of the file
+    {path} the path of the file
+    {button_next} button to display next config file
+    {button_previous} button to display previous config file
+
+@author tobes
+"""
+
+import os.path
+
+
+class Py3status:
+
+    button_change = None
+    button_next = None
+    button_previous = None
+    button_select = 3
+    button_toggle = 1
+    format = u'⚙[\?if=open  {file} {button_previous} {button_next}]'
+    icon_next = u'→'
+    icon_previous = u'←'
+    open = False
+
+    def __init__(self):
+        pass
+
+    def post_config_hook(self):
+        py3status_config = self.py3.py3status_config()
+        self.config_paths = py3status_config.get('i3status_config_paths', [])
+
+        path = py3status_config.get('i3status_config_path')
+        try:
+            self.active = self.config_paths.index(path)
+        except ValueError:
+            self.active = 0
+
+        self.buttons = {
+            'button_previous': self.py3.composite_create({
+                'full_text': self.icon_previous,
+                'index': 'previous',
+            }),
+            'button_next': self.py3.composite_create({
+                'full_text': self.icon_next,
+                'index': 'next',
+            }),
+        }
+
+    def config(self):
+        path = self.py3.py3status_config().get('i3status_config_path')
+        try:
+            current = self.config_paths.index(path)
+        except ValueError:
+            current = 0
+
+        if self.config_paths:
+            self.active = self.active % len(self.config_paths)
+
+            display_path = self.config_paths[self.active]
+            display_file = os.path.basename(display_path)
+            params = dict(
+                path=display_path,
+                file=display_file,
+                open=self.open,
+            )
+            self.py3.log(params)
+            params.update(self.buttons)
+            self.py3.log(params)
+        else:
+            params = {}
+
+        response = {
+            'full_text': self.py3.safe_format(self.format, params),
+            'cached_until': self.py3.CACHE_FOREVER,
+        }
+
+        if current == self.active:
+            response['color'] = self.py3.COLOR_GOOD
+
+        return response
+
+    def on_click(self, event):
+        # have we clicked on one of our 'buttons'?
+        index = event.get('index')
+        if index == 'previous':
+            self.active -= 1
+            return
+        elif index == 'next':
+            self.active += 1
+            return
+
+        # just a normal click
+        button = event['button']
+        if button == self.button_toggle:
+            self.open = not self.open
+        elif button == self.button_next:
+            self.active += 1
+        elif button == self.button_previous:
+            self.active -= 1
+        elif button == self.button_change:
+            self.active += 1
+            self.py3.set_config_file(self.config_paths[self.active])
+            self.py3.prevent_refresh()
+        elif button == self.button_select:
+            self.py3.set_config_file(self.config_paths[self.active])
+            self.py3.prevent_refresh()
+
+
+if __name__ == "__main__":
+    """
+    Run module in test mode.
+    """
+    from py3status.module_test import module_test
+    module_test(Py3status)

--- a/py3status/py3.py
+++ b/py3status/py3.py
@@ -85,7 +85,7 @@ class Py3:
         if module:
             self._output_modules = module._py3_wrapper.output_modules
             if not i3s_config:
-                config = self._module.i3status_thread.config['general']
+                config = self._module._py3_wrapper.i3status_config['general']
                 self._i3s_config = config
             self._py3status_module = module.module_class
 
@@ -97,7 +97,7 @@ class Py3:
         if it exists
         """
         if not name.startswith('COLOR_'):
-            raise AttributeError
+            raise AttributeError(name)
         return self._get_color_by_name(name)
 
     def _get_color_by_name(self, name):
@@ -302,12 +302,24 @@ class Py3:
         """
         return self._i3s_config
 
+    def py3status_config(self):
+        """
+        returns the py3status config dict.
+        """
+        if self._module:
+            return self._module._py3_wrapper.config.copy()
+        return {}
+
     def is_python_2(self):
         """
         True if the version of python being used is 2.x
         Can be helpful for fixing python 2 compatability issues
         """
         return self._is_python_2
+
+    def set_config_file(self, path):
+        if self._module:
+            self._module._py3_wrapper.new_config_path = path
 
     def is_my_event(self, event):
         """


### PR DESCRIPTION
Ok so this is a bit of a monster.

So what's included
- i3status is further separated from core so now there is a I3statusRunner that manages the i3status process better.  We can now stop/start i3status processes including properly killing i3status so that we no longer end up with extra i3status processes.  I3status is also created in a thread that stops the i3status startup blocking the rest of our starting up. 
- py3status modules are now started in threads that allows a much faster startup when lots of modules are in use.
- The real reason for this is that we can now specify multiple config files eg `py3status -c config_1 config_2 ...` and with the help of the new config_switcher module switch between them.

I am sort of toying with the idea of automatically injecting the config_switcher module into the i3status.conf when more than one is specified but the config_switcher is not included as that sort of makes sense so users can then change configs.  Anyhow I'll think about that for a bit and see how I feel about it.
