### PR TITLE
Py3: helper function format_units()

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -856,6 +856,33 @@ they have.
 Returns True if the event name and instance match that of the module
 checking.
 
+___format_units(value, unit='B', optimal=5, auto=True, si=False)__
+
+Takes a value and formats it for user output, we can choose the unit to
+use eg B, MiB, kbits/second.  This is mainly for use with bytes/bits it
+converts the value into a human readable form.  It has various
+additional options but they are really only for special cases.
+
+The function returns a tuple containing the new value (this is a number
+so that the user can still format it if required) and a unit that is
+the units that we have been converted to.
+
+By supplying unit to the function we can force those units to be used
+eg `unit=KiB` would force the output to be in Kibibytes.  By default we
+use non-si units but if the unit is si eg kB then we will switch to si
+units.  Units can also be things like `Mbit/sec`.
+
+If the auto parameter is False then we use the unit provided.  This
+only makes sense when the unit is singular eg 'Bytes' and we want the
+result in bytes and not say converted to MBytes.
+
+optimal is used to control the size of the output value.  We try to
+provide an output value of that number of characters (including decimal
+point), it may also be less due to rounding.  If a fixed unit is used
+the output may be more than this number of characters.
+
+Added in version 3.3
+
 __get_output(module_name)__
 
 Return the output of the named module. This will be a list.

--- a/tests/test_py3.py
+++ b/tests/test_py3.py
@@ -1,0 +1,69 @@
+from py3status.py3 import Py3
+
+
+def test_format_units():
+
+    tests = [
+        # basic unit guessing
+        (dict(value=100), (100, 'B')),
+        (dict(value=999), (999, 'B')),
+        (dict(value=1000), (0.977, 'KiB')),
+        (dict(value=1024), (1.0, 'KiB')),
+        (dict(value=pow(1024, 2)), (1.0, 'MiB')),
+        (dict(value=pow(1024, 3)), (1.0, 'GiB')),
+        (dict(value=pow(1024, 4)), (1.0, 'TiB')),
+        (dict(value=pow(1024, 5)), (1.0, 'PiB')),
+
+        # no guessing
+        (dict(value=pow(1024, 2), auto=False), (pow(1024, 2), 'B')),
+        (dict(value=pow(1024, 2), auto=False, unit='B'), (pow(1024, 2), 'B')),
+        (dict(value=pow(1024, 2), auto=False, unit='KiB'), (1024, 'KiB')),
+
+        # guess with si units
+        (dict(value=100, si=True), (100, 'B')),
+        (dict(value=1000, si=True), (1.0, 'kB')),
+        (dict(value=pow(1000, 2), si=True), (1.0, 'MB')),
+        (dict(value=pow(1000, 3), si=True), (1.0, 'GB')),
+        (dict(value=pow(1000, 4), si=True), (1.0, 'TB')),
+        (dict(value=pow(1000, 5), si=True), (1.0, 'PB')),
+
+        # forced MiB
+        (dict(value=pow(1024, 1), unit='MiB'), (0.000977, 'MiB')),
+        (dict(value=pow(1024, 2), unit='MiB'), (1.0, 'MiB')),
+        (dict(value=pow(1024, 3), unit='MiB'), (1024, 'MiB')),
+        (dict(value=pow(1024, 4), unit='MiB'), (pow(1024, 2), 'MiB')),
+        (dict(value=pow(1024, 5), unit='MiB'), (pow(1024, 3), 'MiB')),
+
+        # endings
+        (dict(value=100, unit='b/s'), (100, 'b/s')),
+        (dict(value=1024, unit='b/s'), (1.0, 'Kib/s')),
+        (dict(value=pow(1024, 2), unit='b/s'), (1.0, 'Mib/s')),
+        (dict(value=pow(1000, 2), si=True, unit='b/s'), (1.0, 'Mb/s')),
+        (dict(value=pow(1024, 3), unit='Mib/sec'), (1024, 'Mib/sec')),
+
+        # optimal
+        (dict(value=1234567890), (1.15, 'GiB')),
+        (dict(value=1234567890, optimal=None), (1.1497809458523989, 'GiB')),
+        (dict(value=1234567890, optimal=1), (1, 'GiB')),
+        (dict(value=1234567890, optimal=2), (1, 'GiB')),
+        (dict(value=1234567890, optimal=3), (1.1, 'GiB')),
+        (dict(value=1234567890, optimal=5), (1.15, 'GiB')),
+        (dict(value=1234567890, unit='MiB'),
+            (1177, 'MiB')),
+        (dict(value=1234567890, unit='MiB', optimal=None),
+            (1177.3756885528564, 'MiB')),
+        (dict(value=1234567890, unit='MiB', optimal=2),
+            (1177, 'MiB')),
+        (dict(value=1234567890, unit='MiB', optimal=6),
+            (1177.4, 'MiB')),
+        (dict(value=1234567890, unit='MiB', optimal=9),
+            (1177.3757, 'MiB')),
+    ]
+
+    py3 = Py3()
+
+    for test in tests:
+        print(test)
+        # we use repr in the assert to ensure 1 and 1.0 are not treated the
+        # same
+        assert repr(py3.format_units(**test[0])) == repr(test[1])


### PR DESCRIPTION
This adds a helper function to py3

The idea is to create human readable output for modules like sysdata it also means we have one true implementation and so should be less subject to errors etc.  We can force the output if needed say to MiB or we can use something like 'bits/second' and get Mibits/second etc.

The output is a numeric (so users can format in their format strings) and a unit.

I think this would be a useful helper for various modules that need this functionality.

some examples
```
format_units(1024) ->  (1.0, 'KiB')
format_units(1024 * 1024) ->  (1.0, 'MiB')
format_units(1024 * 1024, unit='KiB') ->  (1024, 'KiB')
format_units(1024, unit='b/sec') ->  (1.0, 'Kib/sec')
```

It also adds some tests