### PR TITLE
Add tuples support to doc checker

### DIFF
--- a/tests/test_module_doc.py
+++ b/tests/test_module_doc.py
@@ -47,11 +47,7 @@ OBSELETE_PARAM = [
 RE_PARAM = re.compile(
     '^  - `(?P<name>[^`]*)`.*?('
     '\*\(default (?P<value>('
-    '("[^"]*")'  # double quote strings
-    '|'
-    "('[^']*')"  # quote strings
-    '|'
-    '([^)]*)'  # anything else
+    '.*'
     '))\)\*)?$'
 )
 
@@ -164,6 +160,8 @@ def get_module_attributes(path):
                     # NameConstant so we use them for the default
                     default = python2_names.get(value.id)
                     attr_value = extra.get(value.id, default)
+                elif class_name == 'Tuple':
+                    attr_value = tuple(map(get_value, value.elts))
                 elif class_name == 'UnaryOp':
                     op = value.op.__class__.__name__
                     attr_value = get_value(value.operand)


### PR DESCRIPTION
I simplified `RE_PARAM` to
```
RE_PARAM = re.compile(
    '^  - `(?P<name>[^`]*)`.*?('
    '\*\(default (?P<value>('
    '.*'
    '))\)\*)?$'
)
```
And it seems to work for all the tests. If it is now too broad (and matches things it shouldn't), I can restrict it a bit, but this allows for nested tuples and everything. And even if it matches things it shouldn't (like unmatched quotes), that should be caught by the eval.