### PR TITLE
formatter cleanup and new min_length command

### DIFF
--- a/tests/test_formatter.py
+++ b/tests/test_formatter.py
@@ -591,7 +591,7 @@ def test_color_name_1():
 def test_color_name_2():
     run_formatter({
         'format': '\?color=no_name color',
-        'expected':  [{'full_text': 'color'}],
+        'expected':  'color',
     })
 
 
@@ -845,4 +845,48 @@ def test_attr_getter():
         'format': '{test_attr_getter}',
         'expected': '*test_attr_getter*',
         'attr_getter': True,
+    })
+
+
+def test_min_length_1():
+    run_formatter({
+        'format': '\?min_length=9 Hello',
+        'expected': '    Hello',
+    })
+
+
+def test_min_length_2():
+    run_formatter({
+        'format': '[\?min_length=9&show Hello]',
+        'expected': '    Hello',
+    })
+
+
+def test_min_length_3():
+    run_formatter({
+        'format': '[\?min_length=9 [{name}]]',
+        'expected': u'    Björk',
+    })
+
+
+def test_min_length_4():
+    run_formatter({
+        'format': '[\?min_length=9 [\?color=good {name}]]',
+        'expected':  [{'color': '#00FF00', 'full_text': u'    Björk'}],
+    })
+
+
+def test_min_length_5():
+    run_formatter({
+        'format': '\?min_length=9 [\?color=bad {number}][\?color=good {name}]',
+        'expected':  [{'full_text': '  42', 'color': '#FF0000'},
+                      {'full_text': u'Björk', 'color': '#00FF00'}],
+    })
+
+
+def test_min_length_6():
+    run_formatter({
+        'format': '[\?min_length=9 [\?color=bad {number}][\?color=good {name}]]',
+        'expected':  [{'full_text': '  42', 'color': '#FF0000'},
+                      {'full_text': u'Björk', 'color': '#00FF00'}],
     })


### PR DESCRIPTION
This PR is  another cleanup/refactor of the formatter code.  The main change is that we now treat everything as a Composite so don't have to worry whether items are Composites or not.  This massively simplifies things.

The behaviour is pretty much the same, as can be seen one, of the tests has changed as we still return a simple string as output to safe_format() if we can, and for that test a string could be returned rather than a Composite.

Due to the tests I'm fairly confident that we won't be breaking stuff.

Now the main reason I've done this is that it made it easier to add a new command `min_length` it pads things to a size. eg `format = 'net0: [\?min_length=9 {total} {unit}]'` so the module outputs don't jump about as the output changes.  This is something I'd discussed with @guiniol and that would be useful for the modules he's hacking on. 