### PR TITLE
fix py3 call to formatter passing an unexistent 'composites' key

### DIFF
--- a/py3status/py3.py
+++ b/py3status/py3.py
@@ -527,7 +527,6 @@ class Py3:
                 param_dict,
                 force_composite=True,
                 attr_getter=attr_getter,
-                composites=composites,
             )
         except Exception:
             return [{'full_text': 'invalid format'}]


### PR DESCRIPTION
that did throw an 'invalid format' on the bar when using group !