### PR TITLE
Universal module config parameter deprecation

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -28,6 +28,7 @@ py3status documentation
 * [Py3 module helper](#py3)
 * [Composites](#composites)
 * [Module documentation](#docstring)
+* [Deprecation of configuration parameters](#deprecation)
 * [Module testing](#testing)
 
 [Contributing](#contributing)
@@ -1193,6 +1194,130 @@ Here is an example of a docstring.
 
 ***
 
+## <a name="deprecation"></a>Deprecation of configuration parameters
+
+Sometimes it is necessary to deprecate configuration parameters.  Modules
+are able to specify information about deprecation so that it can be done
+automatically.  Deprecation information is specified in the Meta class of a
+py3status module using the deprecated attribute.  The following types of
+deprecation are supported.
+
+The deprecation types will be performed in the order here.
+
+__rename__
+
+The parameter has been renamed.  We will update the configuration to use the
+new name.
+
+```
+class Py3status:
+
+    class Meta:
+
+        deprecated = {
+            'rename': [
+                {
+                    'param': 'format_available',  # parameter name to be renamed
+                    'new': 'icon_available',   # the parameter that will get the value
+                    'msg': 'obsolete parameter use `icon_available`',  # message
+                },
+            ],
+        }
+```
+
+__format_fix_unnamed_param__
+
+Some formats used `{}` as a placeholder this needs to be updated to a named
+placeholder eg `{value}`.
+
+```
+class Py3status:
+
+    class Meta:
+
+        deprecated = {
+            'format_fix_unnamed_param': [
+                {
+                    'param': 'format',  # parameter to be changed
+                    'placeholder': 'percent',  # the place holder to use
+                    'msg': '{} should not be used in format use `{percent}`',  # message
+                },
+            ],
+        }
+```
+
+__substitute_by_value__
+
+This allows one configuration parameter to set the value of another.
+
+```
+class Py3status:
+
+    class Meta:
+
+        deprecated = {
+            'substitute_by_value': [
+                {
+                    'param': 'mode',  # parameter to be checked for substitution
+                    'value': 'ascii_bar',  # value that will trigger the substitution
+                    'substitute': {
+                        'param': 'format',  # parameter to be updated
+                        'value': '{ascii_bar}',  # the value that will be set
+                    },
+                    'msg': 'obsolete parameter use `format = "{ascii_bar}"`',  #message
+                },
+            ],
+        }
+```
+
+__function__
+
+For more complex substitutions a function can be defined that will be called with the config as a parameter.  This function must return a dict of key value pairs of parameters to update
+
+```
+class Py3status:
+
+    class Meta:
+
+        # Create a function to be called
+        def deprecate_function(config):
+            # This function must return a dict
+            return {'thresholds': [
+                        (0, 'bad'),
+                        (config.get('threshold_bad', 20), 'degraded'),
+                        (config.get('threshold_degraded', 50), 'good'),
+                    ],
+            }
+
+        deprecated = {
+            'function': [
+                {
+                    'function': deprecate_function,  # function to be called
+                },
+            ],
+        }
+```
+
+__remove__
+
+The parameters will be removed.
+
+```
+class Py3status:
+
+    class Meta:
+
+        deprecated = {
+            'remove': [
+                {
+                    'param': 'threshold_bad',  # name of parameter to remove
+                    'msg': 'obsolete set using thresholds parameter',  #message
+                },
+            ],
+        }
+```
+
+***
 
 ## <a name="testing"></a>Module testing
 

--- a/py3status/modules/file_status.py
+++ b/py3status/modules/file_status.py
@@ -4,19 +4,22 @@ Display if a file or dir exists.
 
 Configuration parameters:
     cache_timeout: how often to run the check (default 10)
-    format_available: what to display when available (default '●')
-    format_unavailable: what to display when unavailable (default '■')
+    format: format of the output. (default '{icon}')
+    icon_available: icon to display when available (default '●')
+    icon_unavailable: icon to display when unavailable (default '■')
     path: the path to a file or dir to check if it exists (default None)
 
 Color options:
     color_bad: Error or file/directory does not exist
     color_good: File or directory exists
 
+Format placeholders:
+    {icon} icon for the current availability
+
 @author obb, Moritz Lüdecke
 """
 
-import os
-import subprocess
+from os.path import expanduser, exists
 
 ERR_NO_PATH = 'no path given'
 
@@ -26,31 +29,49 @@ class Py3status:
     """
     # available configuration parameters
     cache_timeout = 10
-    format_available = u'●'
-    format_unavailable = u'■'
+    format = '{icon}'
+    icon_available = u'●'
+    icon_unavailable = u'■'
     path = None
 
-    def _get_text(self):
-        fnull = open(os.devnull, 'w')
-        if subprocess.call(["ls", self.path], stdout=fnull, stderr=fnull) == 0:
-            text = self.format_available
-            color = self.py3.COLOR_GOOD
-        else:
-            text = self.format_unavailable
-            color = self.py3.COLOR_BAD
+    class Meta:
+        deprecated = {
+            'rename': [
+                {
+                    'param': 'format_available',
+                    'new': 'icon_available',
+                    'msg': 'obsolete parameter use `icon_available`'
+                },
+                {
+                    'param': 'format_unavailable',
+                    'new': 'icon_unavailable',
+                    'msg': 'obsolete parameter use `icon_unavailable`'
+                },
+            ],
+        }
 
-        return (color, text)
+    def post_config_hook(self):
+        if self.path:
+            self.path = expanduser(self.path)
 
     def file_status(self):
         if self.path is None:
-            color = self.py3.COLOR_BAD
-            text = ERR_NO_PATH
+            return {
+                'color': self.py3.COLOR_ERROR or self.py3.COLOR_BAD,
+                'full_text': ERR_NO_PATH,
+                'cached_until': self.py3.CACHE_FOREVER,
+            }
+
+        if exists(self.path):
+            icon = self.icon_available
+            color = self.py3.COLOR_GOOD
         else:
-            (color, text) = self._get_text()
+            icon = self.icon_unavailable
+            color = self.py3.COLOR_BAD
 
         response = {
             'cached_until': self.py3.time_in(self.cache_timeout),
-            'full_text': text,
+            'full_text': self.py3.safe_format(self.format, {'icon': icon}),
             'color': color
         }
 

--- a/py3status/modules/spaceapi.py
+++ b/py3status/modules/spaceapi.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-# FIXME closed_color, open_color params
 """
 Display if your favorite hackerspace is open or not.
 
@@ -7,15 +6,17 @@ Configuration parameters:
     button_url: Button that when clicked opens the URL sent in the space's API.
         Setting to None disables. (default 3)
     cache_timeout: Set timeout between calls in seconds (default 60)
-    closed_color: color if space is closed (default None)
     closed_text: text if space is closed, strftime parameters
         will be translated (default 'closed')
-    open_color: color if space is open (default None)
     open_text: text if space is open, strftime parmeters will be translated
         (default 'open')
     time_text: format used for time display (default ' since %H:%M')
     url: URL to SpaceAPI json file of your space
         (default 'http://status.chaospott.de/status.json')
+
+Color options:
+    color_closed: Space is open, defaults to color_bad
+    color_open: Space is closed, defaults to color_good
 
 @author timmszigat
 @license WTFPL <http://www.wtfpl.net/txt/copying/>
@@ -35,12 +36,26 @@ class Py3status:
     # available configuration parameters
     button_url = 3
     cache_timeout = 60
-    closed_color = None
     closed_text = 'closed'
-    open_color = None
     open_text = 'open'
     time_text = ' since %H:%M'
     url = 'http://status.chaospott.de/status.json'
+
+    class Meta:
+        deprecated = {
+            'rename': [
+                {
+                    'param': 'open_color',
+                    'new': 'color_open',
+                    'msg': 'obsolete parameter use `color_open`',
+                },
+                {
+                    'param': 'closed_color',
+                    'new': 'color_closed',
+                    'msg': 'obsolete parameter use `color_closed`',
+                },
+            ],
+        }
 
     def check(self):
 
@@ -49,13 +64,6 @@ class Py3status:
             }
 
         try:
-            # if color isn't set, set basic color schema
-            if not self.open_color:
-                self.open_color = self.py3.COLOR_GOOD
-
-            if not self.closed_color:
-                self.closed_color = ''
-
             # grab json file
             json_file = urllib.request.urlopen(self.url)
             reader = codecs.getreader("utf-8")
@@ -64,8 +72,7 @@ class Py3status:
             self._url = data.get('url')
 
             if(data['state']['open'] is True):
-                if self.open_color:
-                    response['color'] = self.open_color
+                response['color'] = self.py3.COLOR_OPEN or self.py3.COLOR_GOOD
                 if 'lastchange' in data['state'].keys():
                     response['full_text'] = self.open_text + self.time_text
                     response['short_text'] = '%H:%M'
@@ -74,8 +81,7 @@ class Py3status:
                     response['short_text'] = self.open_text
 
             else:
-                if self.closed_color:
-                    response['color'] = self.closed_color
+                response['color'] = self.py3.COLOR_CLOSED or self.py3.COLOR_BAD
                 if 'lastchange' in data['state'].keys():
                     response['full_text'] = self.closed_text + self.time_text
                     response['short_text'] = ''

--- a/tests/test_module_doc.py
+++ b/tests/test_module_doc.py
@@ -33,15 +33,10 @@ IGNORE_ITEM = [
     ('arch_updates', '_format_pacman_only'),  # need moving into __init__ etc
     ('arch_updates', '_line_separator'),  # need moving into __init__ etc
     ('arch_updates', 'format'),  # dynamic
-    ('volume_status', 'thresholds'),  # dynamic
 ]
 
 # Obsolete parameters will not have alphabetical order checked
 OBSELETE_PARAM = [
-    ('battery_level', 'mode'),
-    ('battery_level', 'show_percent_with_blocks'),
-    ('volume_status', 'threshold_bad'),
-    ('volume_status', 'threshold_degraded'),
 ]
 
 RE_PARAM = re.compile(


### PR DESCRIPTION
Currently we have modules that have a variety of configuration parameters that follow different standards.  It would be nice to have consistency in module parameter names eg `format_xx` for format strings, thresholds etc.  This PR allows us to change module configuations.

* Existing configuration files will continue to work for the user.

* If users set parameters they will not be overwritten, although they may be corrected (currently only {} being updated).

* Reduce the complication of code modules have dealing with legacy config options, eg battery_level has an obsolete `mode` parameter.

* Allow updated configurations to be applied to modules as though they were the user supplied ones eg colors will be available via `py3.COLOR_XXX`

* Deprecations across all modules are dealt with the same, logging etc.

* Allows defaults to be set in modules without causing complications.

* Improves docstring tests as less parameters need excluding as defaults can be set etc.

* All module deprecation information is in a single place in the module.  Although the format is slightly verbose it should be easy to understand and is flexible and so can allow for future expansion if needed.

This PR also provides updates to the following modules.  These demonstrate the types of changes that we can easily make to modules if this PR is accepted.

__battery_level__

Replaces the old way of dealing with obsolete parameters - also removes them from the documentation as the updates needed are self documented.

__file_status__

We move the module to having a single more flexible format.  Additionally we also allow `~` to be used in the path and simplify the check.

__spaceapi__

Switch from using `closed_color`, `open_color` to `color_closed`, `color_open`

__volume_status__

Replace `threshold_bad`, `threshold_degraded` with new style `thresholds`.

Documentation
============

Sometimes it is necessary to deprecate configuration parameters.  Modules
are able to specify information about deprecation so that it can be done
automatically.  Deprecation information is specified in the Meta class of a
py3status module using the deprecated attribute.  The following types of
deprecation are supported.

The deprecation types will be performed in the order here.

__rename__

The parameter has been renamed.  We will update the configuration to use the
new name.

```
class Py3status:

    class Meta:

        deprecated = {
            'rename': [
                {
                    'param': 'format_available',  # parameter name to be renamed
                    'new': 'icon_available',   # the parameter that will get the value
                    'msg': 'obsolete parameter use `icon_available`',  # message
                },
            ],
        }
```

__format_fix_unnamed_param__

Some formats used `{}` as a placeholder this needs to be updated to a named
placeholder eg `{value}`.

```
class Py3status:

    class Meta:

        deprecated = {
            'format_fix_unnamed_param': [
                {
                    'param': 'format',  # parameter to be changed
                    'placeholder': 'percent',  # the place holder to use
                    'msg': '{} should not be used in format use `{percent}`',  # message
                },
            ],
        }
```

__substitute_by_value__

This allows one configuration parameter to set the value of another.

```
class Py3status:

    class Meta:

        deprecated = {
            'substitute_by_value': [
                {
                    'param': 'mode',  # parameter to be checked for substitution
                    'value': 'ascii_bar',  # value that will trigger the substitution
                    'substitute': {
                        'param': 'format',  # parameter to be updated
                        'value': '{ascii_bar}',  # the value that will be set
                    },
                    'msg': 'obsolete parameter use `format = "{ascii_bar}"`',  #message
                },
            ],
        }
```

__function__

For more complex substitutions a function can be defined that will be called with the config as a parameter.  This function must return a dict of key value pairs of parameters to update

```
class Py3status:

    class Meta:

        # Create a function to be called
        def deprecate_function(config):
            # This function must return a dict
            return {'thresholds': [
                        (0, 'bad'),
                        (config.get('threshold_bad', 20), 'degraded'),
                        (config.get('threshold_degraded', 50), 'good'),
                    ],
            }

        deprecated = {
            'function': [
                {
                    'function': deprecate_function,  # function to be called
                },
            ],
        }
```

__remove__

The parameters will be removed.

```
class Py3status:

    class Meta:

        deprecated = {
            'remove': [
                {
                    'param': 'threshold_bad',  # name of parameter to remove
                    'msg': 'obsolete set using thresholds parameter',  #message
                },
            ],
        }
```


