### PR TITLE
vpn_status: remove shebang

### DIFF
--- a/py3status/modules/vpn_status.py
+++ b/py3status/modules/vpn_status.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 """
 Drop-in replacement for i3status run_watch VPN module.
 


### PR DESCRIPTION
because it should depends on OS setting, not to have harcoded usage
of python3 via env.

Uncovered by rpmlint while building package for Fedora.