### PR TITLE
Add load support to sysdata

### DIFF
--- a/py3status/modules/sysdata.py
+++ b/py3status/modules/sysdata.py
@@ -358,7 +358,7 @@ class Py3status:
             self.py3.threshold_get_color(swap_used_percent, 'swap')
 
         # get load average
-        if '{load' in self.format:
+        if self.py3.format_contains(self.format, 'load*'):
             load1, load5, load15 = self.data.load()
             self.values['load1'] = load1
             self.values['load5'] = load5

--- a/py3status/modules/sysdata.py
+++ b/py3status/modules/sysdata.py
@@ -248,6 +248,9 @@ class Py3status:
             return {
                 'cpu_usage': format_vals,
                 'cpu_temp': format_vals,
+                'load1': format_vals,
+                'load5': format_vals,
+                'load15': format_vals,
                 'mem_total': format_vals,
                 'mem_used': format_vals,
                 'mem_used_percent': format_vals,
@@ -292,6 +295,9 @@ class Py3status:
                     'placeholder_formats': {
                         'cpu_usage': ':.2f',
                         'cpu_temp': ':.2f',
+                        'load1': ':.2f',
+                        'load5': ':.2f',
+                        'load15': ':.2f',
                         'mem_total': ':.2f',
                         'mem_used': ':.2f',
                         'mem_used_percent': ':.2f',
@@ -364,9 +370,9 @@ class Py3status:
         # get load average
         if '{load' in self.format:
             load1, load5, load15 = self.data.load()
-            self.values['load1'] = value_format.format(load1)
-            self.values['load5'] = value_format.format(load5)
-            self.values['load15'] = value_format.format(load15)
+            self.values['load1'] = load1
+            self.values['load5'] = load5
+            self.values['load15'] = load15
             self.py3.threshold_get_color(load1, 'load')
 
         try:

--- a/py3status/modules/sysdata.py
+++ b/py3status/modules/sysdata.py
@@ -34,16 +34,6 @@ Format placeholders:
     {swap_used_percent} used swap percentage
     {temp_unit} temperature unit
 
-format_mem placeholders:
-    {value} numeric value
-
-format_percent placeholders:
-    {value} numeric value
-
-format_temp placeholders:
-    {unit} temperature unit
-    {value} numeric value
-
 Color thresholds:
     cpu: change color based on the value of cpu_usage
     max_cpu_mem: change the color based on the max value of cpu_usage and mem_used_percent

--- a/py3status/modules/sysdata.py
+++ b/py3status/modules/sysdata.py
@@ -5,14 +5,8 @@ Display system RAM, SWAP and CPU utilization.
 Configuration parameters:
     cache_timeout: how often we refresh this module in seconds (default 10)
     format: output format string
-        *(default '[\?color=cpu CPU: {cpu_usage}%], '
-        '[\?color=mem Mem: {mem_used}/{mem_total} GB ({mem_used_percent}%)]')*
-    format_mem: format for the flat values
-        (default "{value:.2f}")
-    format_percent: format for the values in percent
-        (default "{value:.2f}")
-    format_temp: format for the temperature value
-        (default "{value:.2f}{unit}")
+        *(default '[\?color=cpu CPU: {cpu_usage:.2f}%], '
+        '[\?color=mem Mem: {mem_used:.2f}/{mem_total:.2f} GB ({mem_used_percent:.2f}%)]')*
     mem_unit: the unit of memory to use in report, case insensitive.
         ['dynamic', 'KiB', 'MiB', 'GiB'] (default 'GiB')
     swap_unit: the unit of swap to use in report, case insensitive.

--- a/py3status/modules/sysdata.py
+++ b/py3status/modules/sysdata.py
@@ -7,6 +7,12 @@ Configuration parameters:
     format: output format string
         *(default '[\?color=cpu CPU: {cpu_usage}%], '
         '[\?color=mem Mem: {mem_used}/{mem_total} GB ({mem_used_percent}%)]')*
+    format_mem: format for the flat values
+        (default "{value:.2f}")
+    format_percent: format for the values in percent
+        (default "{value:.2f}")
+    format_temp: format for the temperature value
+        (default "{value:.2f}{unit}")
     mem_unit: the unit of memory to use in report, case insensitive.
         ['dynamic', 'KiB', 'MiB', 'GiB'] (default 'GiB')
     swap_unit: the unit of swap to use in report, case insensitive.
@@ -30,6 +36,16 @@ Format placeholders:
     {swap_used} used swap
     {swap_used_percent} used swap percentage
     {temp_unit} temperature unit
+
+format_mem placeholders:
+    {value} numeric value
+
+format_percent placeholders:
+    {value} numeric value
+
+format_temp placeholders:
+    {unit} temperature unit
+    {value} numeric value
 
 Color thresholds:
     cpu: change color based on the value of cpu_usage
@@ -206,6 +222,12 @@ class Py3status:
 
         def deprecate_function(config):
             # support old thresholds
+            padding = config.get('padding', 0)
+            precision = config.get('precision', 2)
+            format_vals = '[\?min_length={padding} {{value:.{precision}f}}]'.format(
+                    padding=padding, precision=precision)
+            format_temp = '[\?min_length={padding} {{value:.{precision}f}}{{unit}}]'.format(
+                    padding=padding, precision=precision)
             return {
                 'thresholds': [
                     (0, 'good'),

--- a/py3status/modules/sysdata.py
+++ b/py3status/modules/sysdata.py
@@ -5,8 +5,8 @@ Display system RAM, SWAP and CPU utilization.
 Configuration parameters:
     cache_timeout: how often we refresh this module in seconds (default 10)
     format: output format string
-        *(default '[\?color=cpu CPU: {cpu_usage:.2f}%], '
-        '[\?color=mem Mem: {mem_used:.2f}/{mem_total:.2f} GB ({mem_used_percent:.2f}%)]')*
+        *(default '[\?color=cpu CPU: {cpu_usage}%], '
+        '[\?color=mem Mem: {mem_used}/{mem_total} GB ({mem_used_percent}%)]')*
     mem_unit: the unit of memory to use in report, case insensitive.
         ['dynamic', 'KiB', 'MiB', 'GiB'] (default 'GiB')
     swap_unit: the unit of swap to use in report, case insensitive.
@@ -216,12 +216,6 @@ class Py3status:
 
         def deprecate_function(config):
             # support old thresholds
-            padding = config.get('padding', 0)
-            precision = config.get('precision', 2)
-            format_vals = '[\?min_length={padding} {{value:.{precision}f}}]'.format(
-                    padding=padding, precision=precision)
-            format_temp = '[\?min_length={padding} {{value:.{precision}f}}{{unit}}]'.format(
-                    padding=padding, precision=precision)
             return {
                 'thresholds': [
                     (0, 'good'),

--- a/py3status/modules/sysdata.py
+++ b/py3status/modules/sysdata.py
@@ -21,6 +21,9 @@ Configuration parameters:
 Format placeholders:
     {cpu_temp} cpu temperature
     {cpu_usage} cpu usage percentage
+    {load1} load average over the last minute
+    {load5} load average over the five minutes
+    {load15} load average over the fifteen minutes
     {mem_total} total memory
     {mem_unit} unit for memory
     {mem_used} used memory
@@ -44,6 +47,7 @@ format_temp placeholders:
 Color thresholds:
     cpu: change color based on the value of cpu_usage
     max_cpu_mem: change the color based on the max value of cpu_usage and mem_used_percent
+    load: change color based on the value of load1
     mem: change color based on the value of mem_used_percent
     swap: change color based on the value of swap_used_percent
     temp: change color based on the value of cpu_temp
@@ -104,6 +108,18 @@ class GetData:
 
         # return the cpu total&idle time
         return total_cpu_time, cpu_idle_time
+
+    def load(self):
+        """
+        Get the load average from /proc/loadavg :
+        """
+        with open('/proc/loadavg', 'r') as fd:
+            line = fd.readline()
+        load_data = line.split()
+        load1 = float(load_data[0])
+        load5 = float(load_data[1])
+        load15 = float(load_data[2])
+        return load1, load5, load15
 
     def calc_mem_info(self, unit='GiB', memi=dict, keys=list):
         """
@@ -344,6 +360,14 @@ class Py3status:
             self.values['swap_used_percent'] = swap_used_percent
             self.values['swap_unit'] = swap_unit
             self.py3.threshold_get_color(swap_used_percent, 'swap')
+
+        # get load average
+        if '{load' in self.format:
+            load1, load5, load15 = self.data.load()
+            self.values['load1'] = value_format.format(load1)
+            self.values['load5'] = value_format.format(load5)
+            self.values['load15'] = value_format.format(load15)
+            self.py3.threshold_get_color(load1, 'load')
 
         try:
             self.py3.threshold_get_color(max(cpu_usage, mem_used_percent), 'max_cpu_mem')


### PR DESCRIPTION
This reverts commit 4d90fd69d75b83c5e15244f5bf1a043b3b0f83fb, and thus, re-adds load support to sysdata. (There'll be another one for swap).
This adds three new placeholders `load1`, `load5` and `load15` and one new threshold `load` compared to the value of `load1`.