### PR TITLE
Use new Meta/deprecate_function in sysdata

### DIFF
--- a/tests/test_module_doc.py
+++ b/tests/test_module_doc.py
@@ -33,13 +33,10 @@ IGNORE_ITEM = [
     ('arch_updates', '_format_pacman_only'),  # need moving into __init__ etc
     ('arch_updates', '_line_separator'),  # need moving into __init__ etc
     ('arch_updates', 'format'),  # dynamic
-    ('sysdata', 'thresholds'),  # dynamic
 ]
 
 # Obsolete parameters will not have alphabetical order checked
 OBSOLETE_PARAM = [
-    ('sysdata', 'high_threshold'),
-    ('sysdata', 'med_threshold'),
 ]
 
 RE_PARAM = re.compile(


### PR DESCRIPTION
Try to use the new Meta/deprecated function for deprecated config args. Tox doesn't like it.