### PR TITLE
Sysdata: deprecate precision and padding

### DIFF
--- a/py3status/modules/sysdata.py
+++ b/py3status/modules/sysdata.py
@@ -159,7 +159,7 @@ class Py3status:
     format = "[\?color=cpu CPU: {cpu_usage}%], " \
              "[\?color=mem Mem: {mem_used}/{mem_total} GB ({mem_used_percent}%)]"
     mem_unit = 'GiB'
-    temp_unit = '°C'
+    temp_unit = u'°C'
     thresholds = [(0, "good"), (40, "degraded"), (75, "bad")]
     zone = None
 
@@ -175,10 +175,11 @@ class Py3status:
                         ],
                     }
 
-        def update_placeholder_format(config):
-            # padding = config.get('padding', 0)
+        def update_deprecated_placeholder_format(config):
+            padding = config.get('padding', 0)
             precision = config.get('precision', 2)
-            format_vals = ':.{precision}f'.format(precision=precision)
+            format_vals = ':{padding}.{precision}f'.format(padding=padding,
+                                                           precision=precision)
             return {
                     'cpu_usage': format_vals,
                     'cpu_temp': format_vals,
@@ -211,7 +212,15 @@ class Py3status:
                     ],
                 'update_placeholder_format': [
                     {
-                        'function': update_placeholder_format,
+                        'function': update_deprecated_placeholder_format,
+                        'format_strings': ['format']
+                        },
+                    ],
+                }
+
+        update_config = {
+                'update_placeholder_format': [
+                    {
                         'placeholder_formats': {
                             'cpu_usage': ':.2f',
                             'cpu_temp': ':.2f',
@@ -220,15 +229,15 @@ class Py3status:
                             'mem_used_percent': ':.2f',
                             },
                         'format_strings': ['format']
-                        }
-                    ]
+                        },
+                    ],
                 }
 
     def post_config_hook(self):
         self.data = GetData(self)
         self.cpu_total = 0
         self.cpu_idle = 0
-        self.values = {'temp_unit': '°C'}
+        self.values = {'temp_unit': self.temp_unit}
 
     def sysData(self):
         # get CPU usage info

--- a/py3status/modules/sysdata.py
+++ b/py3status/modules/sysdata.py
@@ -135,10 +135,9 @@ class GetData:
         """
 
         command = ['sensors']
-        unit = unit.upper()
-        if unit in ['F', u'°F']:
+        if unit == u'°F':
             command.append('-f')
-        elif unit not in ['C', u'°C', 'K']:
+        elif unit not in [u'°C', 'K']:
             return 'unknown unit'
         if zone:
             try:
@@ -244,7 +243,15 @@ class Py3status:
         self.data = GetData(self)
         self.cpu_total = 0
         self.cpu_idle = 0
-        self.values = {'temp_unit': self.temp_unit}
+        temp_unit = self.temp_unit.upper()
+        if temp_unit in ['C', u'°C']:
+            temp_unit = u'°C'
+        elif temp_unit in ['F', u'°F']:
+            temp_unit = u'°F'
+        elif not temp_unit == 'K':
+            temp_unit = 'unknown unit'
+        self.values = {'temp_unit': temp_unit}
+        self.temp_unit = temp_unit
 
     def sysData(self):
         # get CPU usage info

--- a/py3status/modules/sysdata.py
+++ b/py3status/modules/sysdata.py
@@ -135,9 +135,10 @@ class GetData:
         """
 
         command = ['sensors']
-        if unit.lower() == 'F' or unit == u'°F':
+        unit = unit.upper()
+        if unit in ['F', u'°F']:
             command.append('-f')
-        elif unit.lower() not in ['C', u'°C', 'K']:
+        elif unit not in ['C', u'°C', 'K']:
             return 'unknown unit'
         if zone:
             try:

--- a/py3status/modules/sysdata.py
+++ b/py3status/modules/sysdata.py
@@ -9,7 +9,7 @@ Configuration parameters:
         '[\?color=mem Mem: {mem_used}/{mem_total} GB ({mem_used_percent}%)]')*
     mem_unit: the unit of memory to use in report, case insensitive.
         ['dynamic', 'KiB', 'MiB', 'GiB'] (default 'GiB')
-    temp_unit: unit used for measuring the temperature
+    temp_unit: unit used for measuring the temperature ('C', 'F' or 'K')
         (default '°C')
     thresholds: thresholds to use for color changes
         (default [(0, "good"), (40, "degraded"), (75, "bad")])


### PR DESCRIPTION
@tobes I used the new Meta thing to deprecate precision and padding.
I have one question. Does that mean that if someone uses any of the deprecated parameters, all the new parameters will be ignored and set from the `deprecate_function` in `Meta`?

EDIT: forgot to mention, this is on top of #553