### PR TITLE
Formatter: Allow formatting numeric strings

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -969,6 +969,23 @@ The following functions can be registered
 >
 > Note: This function should only be used by containers.
 
+__format_contains(format_string, name)__
+
+Determines if `format_string` contains placeholder `name`
+
+`name` is tested against placeholders using fnmatch so the following
+patterns can be used:
+
+    * 	    matches everything
+    ? 	    matches any single character
+    [seq] 	matches any character in seq
+    [!seq] 	matches any character not in seq
+
+This is useful because a simple test like
+`'{placeholder}' in format_string`
+will fail if the format string contains placeholder formatting
+eg `'{placeholder:.2f}'`
+
 __safe_format(format_string, param_dict=None, force_composite=False,
 attr_getter=None)__
 

--- a/py3status/modules/sysdata.py
+++ b/py3status/modules/sysdata.py
@@ -175,7 +175,7 @@ class Py3status:
         value_format = '{{:{}.{}f}}'.format(self.padding, self.precision)
 
         # get CPU usage info
-        if '{cpu_usage}' in self.format:
+        if self.py3.format_contains(self.format, 'cpu_usage'):
             cpu_total, cpu_idle = self.data.cpu()
             cpu_usage = (1 - (
                 float(cpu_idle-self.cpu_idle) / float(cpu_total-self.cpu_total)
@@ -186,13 +186,13 @@ class Py3status:
             self.py3.threshold_get_color(cpu_usage, 'cpu')
 
         # if specified as a formatting option, also get the CPU temperature
-        if '{cpu_temp}' in self.format:
+        if self.py3.format_contains(self.format, 'cpu_temp'):
             cpu_temp = self.data.cpuTemp(self.zone)
             self.values['cpu_temp'] = (value_format + '°C').format(cpu_temp)
             self.py3.threshold_get_color(cpu_temp, 'temp')
 
         # get RAM usage info
-        if '{mem_' in self.format:
+        if self.py3.format_contains(self.format, 'mem_*'):
             mem_total, mem_used, mem_used_percent = self.data.memory()
             self.values['mem_total'] = value_format.format(mem_total)
             self.values['mem_used'] = value_format.format(mem_used)

--- a/tests/test_formatter.py
+++ b/tests/test_formatter.py
@@ -27,6 +27,9 @@ param_dict = {
     'zero': 0,
     'zero_str': '0',
     'zero_float': 0.0,
+    'str_int': '123',
+    'str_float': '123.456',
+    'str_nan': "I'm not a number",
 
     'composite_basic': Composite([{'full_text': 'red ', 'color': '#FF0000'},
                                   {'full_text': 'green ', 'color': '#00FF00'},
@@ -889,4 +892,46 @@ def test_min_length_6():
         'format': '[\?min_length=9 [\?color=bad {number}][\?color=good {name}]]',
         'expected':  [{'full_text': '  42', 'color': '#FF0000'},
                       {'full_text': u'Björk', 'color': '#00FF00'}],
+    })
+
+
+def test_numeric_strings_1():
+    run_formatter({
+        'format': '{str_int: d}',
+        'expected': ' 123',
+    })
+
+
+def test_numeric_strings_2():
+    run_formatter({
+        'format': '{str_int:.2f}',
+        'expected': '123.00',
+    })
+
+
+def test_numeric_strings_3():
+    run_formatter({
+        'format': '{str_float: d}',
+        'expected': ' 123',
+    })
+
+
+def test_numeric_strings_4():
+    run_formatter({
+        'format': '{str_float:.1f}',
+        'expected': '123.5',
+    })
+
+
+def test_numeric_strings_5():
+    run_formatter({
+        'format': '{str_nan: d}',
+        'expected': "I'm not a number",
+    })
+
+
+def test_numeric_strings_6():
+    run_formatter({
+        'format': '{str_nan:.1f}',
+        'expected': "I'm not a number",
     })


### PR DESCRIPTION
So @guiniol has been doing things with sysdata and I was doing some testing of #555 and I was finding it a little frustrating.  If I wanted to do custom formatting of say `{cpu_usage}` then the formatting was done in `format_percent` which I understand from the developer perspective but from the users perspective this is confusing in my mind.  I should be able to do `format = '{cpu_usage:.0f}'` and it should work.  But as `{cpu_usage}` is a string even though it looks like a number this fails.

So anyhow I've made this so it now works.  If we have a value that could be numeric and is having numeric formatting applied it will now work.  It also means we can do `{cpu_usage:.0f}` on a string.  we also can do `{cpu_usage:d}` on a float/string as a quick 'make this an int' shortcut.

These changes also highlighted an issue around checking for placeholders in a format string.  modules commonly do
```
if '{cpu_usage}' in self.format:
    ...
```
but this fails if formats are used, so I've added a helper so modules can now do
```
if self.py3.format_contains(self.format, 'cpu_usage'):
    ....
```
It is more verbose but it does catch formatted placeholders and it also allows wildcards like `'mem_*'` to be queried.

There are also a few formatter tests for the new behaviours.

sysdata has been updated to use the new functionality.