### PR TITLE
Module selector

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -26,6 +26,7 @@ py3status documentation
 * [Example 5: Using color constants](#example_5)
 * [Module methods](#module_methods)
 * [Py3 module helper](#py3)
+* [Py3 storage](#py3_storage)
 * [Composites](#composites)
 * [Module documentation](#docstring)
 * [Deprecation of configuration parameters](#deprecation)
@@ -1114,6 +1115,36 @@ general one that will be used.
 
 ***
 
+## <a name="py3_storage"></a>Storage
+
+Py3status allows modules to maintain state through the use of the storage
+functions of the Py3 helper.
+
+Currently bool, int, float, None and unicode types are supported as well as
+dicts or lists made of these simple types.  Basically anything that can be
+converted to json.
+
+The following helper functions are defined in the modules `self.py3`.
+
+__storage_set(key, value)__
+
+Store a value for the module under the given key.
+
+__storage_get(key)__
+
+Retrieve a value of a key for the module. Or `None` if the key has no value for
+the given key.
+
+__storage_clear(key=None)__
+
+Remove the value stored with the key from storage.
+If key is not supplied then all values for the module are removed.
+
+__storage_keys()__
+
+Return a list of the keys for values stored for the module.
+
+***
 
 ## <a name="composites"></a>Composites
 

--- a/doc/README.md
+++ b/doc/README.md
@@ -28,6 +28,7 @@ py3status documentation
 * [Py3 module helper](#py3)
 * [Py3 storage](#py3_storage)
 * [Py3 popups](#py3_popup)
+* [Py3 storage](#py3_storage)
 * [Composites](#composites)
 * [Module documentation](#docstring)
 * [Deprecation of configuration parameters](#deprecation)

--- a/doc/README.md
+++ b/doc/README.md
@@ -879,6 +879,14 @@ they have.
 Returns True if the event name and instance match that of the module
 checking.
 
+__module_name()__
+
+Returns the name of the module, this will be the module name plus its instance
+name if that exists. The name is the same as used in the `order += "..."`
+section of the configuration file.  For modules that are defined inside
+containers and are not given an explicit name, they will have an instance name
+automatically generated.
+
 __format_units(value, unit='B', optimal=5, auto=True, si=False)__
 
 Takes a value and formats it for user output, we can choose the unit to

--- a/doc/README.md
+++ b/doc/README.md
@@ -27,6 +27,7 @@ py3status documentation
 * [Module methods](#module_methods)
 * [Py3 module helper](#py3)
 * [Py3 storage](#py3_storage)
+* [Py3 popups](#py3_popup)
 * [Composites](#composites)
 * [Module documentation](#docstring)
 * [Deprecation of configuration parameters](#deprecation)
@@ -1143,6 +1144,58 @@ If key is not supplied then all values for the module are removed.
 __storage_keys()__
 
 Return a list of the keys for values stored for the module.
+
+***
+
+## <a name="py3_popup"></a>Popups
+
+the Py3 helper contains popup functionality allowing. modules to create popups
+these can be of two types.
+
+`info` these are just plain text.
+
+`menu` these allow the user to click on an item in the popup to trigger an
+action.  It also allows items to be selected or not and the user is able to
+change this selection.
+
+The data for the popup can be one of the following
+
+`string` the data contains the text to display `\n` is used to separate lines.
+
+`'hello\nhow are you?'` would create a popup with two lines.
+
+`list` each line is a separate item in the list.
+
+`['hello', 'how are you?']` would create a popup with two lines.
+
+As well as strings in the list tuples can be provided that contains the the
+text and a value as to if the item is selected.
+
+`['Alarm', ('enabled', true)]` would create a popup an option showing if the
+alarm is enabled or not.
+
+when the user clicks on the popup a callback function will be called if it was
+provided. The function will receive the text of the line that was clicked by
+the user and a dict containing all items as keys and a value corresponding to
+if the item is selected or not.
+
+The following helper functions are defined in the modules `self.py3`.
+
+__popup_open(data, type='info', callback=None)__
+
+Open a popup for the module.
+
+__popup_close()__
+
+Close the modules popup.
+
+__popup_toggle(data, type='info', callback=None)__
+
+Close the menu if it is open else open it.
+
+__popup_update(data)__
+
+Update the popup displaying the new data.
 
 ***
 

--- a/py3status/core.py
+++ b/py3status/core.py
@@ -20,6 +20,7 @@ from py3status.events import Events
 from py3status.helpers import print_line, print_stderr
 from py3status.i3status import I3status
 from py3status.parse_config import process_config
+from py3status.popup import PopupController
 from py3status.module import Module
 from py3status.profiling import profile
 from py3status.version import version
@@ -337,6 +338,9 @@ class Py3statusWrapper():
         if self.config['debug']:
             self.log('i3status thread {} with config {}'.format(
                 i3s_mode, self.i3status_thread.config))
+
+        # popup_controller
+        self.popup_controller = PopupController(self)
 
         # setup input events thread
         self.events_thread = Events(self)

--- a/py3status/core.py
+++ b/py3status/core.py
@@ -8,6 +8,7 @@ import time
 
 from collections import deque
 from json import dumps
+from operator import itemgetter
 from platform import python_version
 from signal import signal, SIGTERM, SIGUSR1, SIGTSTP, SIGCONT
 from subprocess import Popen
@@ -476,6 +477,26 @@ class Py3statusWrapper():
         Received request to terminate (SIGTERM), exit nicely.
         """
         raise KeyboardInterrupt()
+
+    def py3status_function(self, name, data):
+        """
+        Expose core functionality to modules.
+        """
+        if name == 'module_info':
+            output = []
+            for module_name, module in self.output_modules.items():
+                output.append({
+                    'name': module_name,
+                    'enabled': not module['module'].disabled,
+                    'type': not module['type'],
+                })
+            return sorted(output, key=itemgetter('name'))
+        elif name == 'module_enable':
+            if data in self.output_modules:
+                self.output_modules[data]['module'].enable()
+        elif name == 'module_disable':
+            if data in self.output_modules:
+                self.output_modules[data]['module'].disable()
 
     def notify_update(self, update, urgent=False):
         """

--- a/py3status/i3status.py
+++ b/py3status/i3status.py
@@ -272,6 +272,9 @@ class I3status(Thread):
                     if (section_name.split(' ')[0] not in I3S_COLOR_MODULES or
                             key not in I3S_ALLOWED_COLORS):
                         continue
+                # don't include any popup_* options
+                if key.startswith('popup_'):
+                    continue
                 # Set known fixed format for time and tztime so we can work
                 # out the timezone
                 if section_name.split()[0] in TIME_MODULES:

--- a/py3status/i3status.py
+++ b/py3status/i3status.py
@@ -48,6 +48,7 @@ class I3statusModule:
 
     def __init__(self, module_name, py3_wrapper):
         self.module_name = module_name
+        self.disabled = False
 
         # i3status returns different name/instances than it is sent we want to
         # be able to restore the correct ones.
@@ -80,7 +81,17 @@ class I3statusModule:
     def __repr__(self):
         return '<I3statusModule {}>'.format(self.module_name)
 
+    def enable(self):
+        self.disabled = False
+        self.py3_wrapper.notify_update(self.module_name)
+
+    def disable(self):
+        self.disabled = True
+        self.py3_wrapper.notify_update(self.module_name)
+
     def get_latest(self):
+        if self.disabled:
+            return []
         return [self.item.copy()]
 
     def update_from_item(self, item):

--- a/py3status/modules/clock.py
+++ b/py3status/modules/clock.py
@@ -152,10 +152,21 @@ class Py3status:
                 time_delta = 60
             self.time_deltas.append(time_delta)
 
-        self.active_time_format = 0
+        # If we have saved details we use them.
+        saved_format = self.py3.storage_get('time_format')
+        if saved_format in self.format_time:
+            self.active_time_format = self.format_time.index(saved_format)
+        else:
+            self.active_time_format = 0
 
+        saved_timezone = self.py3.storage_get('timezone')
+        if saved_timezone in self.format:
+            self.active = self.format.index(saved_timezone)
+        else:
+            self.active = 0
+
+        # reset the cycle time
         self._cycle_time = time() + self.cycle
-        self.active = 0
 
     def _get_timezone(self, tz):
         '''
@@ -187,20 +198,25 @@ class Py3status:
 
     def _change_active(self, diff):
         self.active = (self.active + diff) % len(self.format)
+        # reset the cycle time
+        self._cycle_time = time() + self.cycle
+        # save the active format
+        timezone = self.format[self.active]
+        self.py3.storage_set('timezone', timezone)
 
     def on_click(self, i3s_output_list, i3s_config, event):
         """
         Switch the displayed module or pass the event on to the active module
         """
-        # reset cycle time
         if event['button'] == self.button_reset:
-            self.active = 0
-            # reset the cycle time
-            self._cycle_time = time() + self.cycle
+            self._change_active(0)
         elif event['button'] == self.button_change_time_format:
             self.active_time_format += 1
             if self.active_time_format >= len(self.format_time):
                 self.active_time_format = 0
+            # save the active format_time
+            time_format = self.format_time[self.active_time_format]
+            self.py3.storage_set('time_format', time_format)
         elif event['button'] == self.button_change_format:
             self._change_active(1)
 

--- a/py3status/modules/module_selector.py
+++ b/py3status/modules/module_selector.py
@@ -1,0 +1,68 @@
+# -*- coding: utf-8 -*-
+"""
+Allow modules to be enabled/disabled whilst py3status is running
+
+Configuration parameters:
+    format: format to display
+        (default '⚙[\?color=good  {enabled}][\?color=bad&if=disabled  {disabled}]')
+
+Format placeholders:
+    {count} total number of modules.
+    {disabled} number of modules currently disabled.
+    {enabled} number of modules currently enabled.
+
+@author tobes
+@license BSD
+"""
+
+
+class Py3status:
+
+    format = u'⚙[\?color=good  {enabled}][\?color=bad&if=disabled  {disabled}]'
+
+    def post_config_hook(self):
+        module_data = self.py3.py3status_function('module_info') or []
+        keys = self.py3.storage_keys()
+        for module in module_data:
+            module_name = module['name']
+            if module_name in keys and not self.py3.storage_get(module_name):
+                self.py3.py3status_function('module_disable', module_name)
+                self.py3.log(u'Disabling module %s' % module_name)
+
+    def select(self):
+        module_info = self.py3.py3status_function('module_info') or []
+        count = len(module_info) - 1  # we don't count this module
+        enabled = sum(1 for x in module_info if x['enabled']) - 1
+        disabled = count - enabled
+
+        return {
+            'full_text': self.py3.safe_format(
+                self.format, dict(count=count,
+                                  enabled=enabled,
+                                  disabled=disabled)
+            ),
+            'cached_until': self.py3.CACHE_FOREVER,
+        }
+
+    def _callback(self, module_name, output):
+        if output[module_name]:
+            self.py3.py3status_function('module_enable', module_name)
+        else:
+            self.py3.py3status_function('module_disable', module_name)
+        self.py3.storage_set(module_name, output[module_name])
+        self.py3.update()
+
+    def on_click(self, event):
+        module_data = self.py3.py3status_function('module_info')
+        data = [(x['name'], x['enabled'])
+                for x in module_data
+                if x['name'] != self.py3.module_name()]
+        self.py3.popup_toggle(data, type='menu', callback=self._callback)
+
+
+if __name__ == "__main__":
+    """
+    Run module in test mode.
+    """
+    from py3status.module_test import module_test
+    module_test(Py3status)

--- a/py3status/popup.py
+++ b/py3status/popup.py
@@ -1,0 +1,468 @@
+import shlex
+import json
+
+from subprocess import Popen, PIPE, check_output
+from threading import Thread
+
+# see if gtk/pango available for font measurement
+# otherwise we will do a best guess
+try:
+    import gtk
+    import pango
+except ImportError:
+    gtk = None
+
+
+PADDING = 10
+BORDER = 1
+FG = '#FFFFFF'
+BG = '#000000'
+BORDER_COLOR = '#666666'
+
+# FIXME get from config
+BAR = 'bar-0'
+
+SELECTOR_ON = u'\u25a0'
+SELECTOR_OFF = u'\u25a1'
+
+
+class PopupController:
+    """
+    This allows popups to be actioned via dzen2
+    """
+
+    def __init__(self, py3_wrapper):
+        self.auto_update = False
+        self.event_x = 0
+        self.module_name = None
+        self.process = None
+        self.py3_wrapper = py3_wrapper
+        self.font_cache = {}
+
+    def close(self, module_name=None):
+        """
+        Close the popup.
+        """
+        # prevent auto closing
+        if module_name and module_name == self.module_name:
+            return
+        if self.process:
+            try:
+                self.process.kill()
+                self.process = None
+            except:
+                pass
+
+    def popup(self, module_name, lines, type, callback=None):
+        """
+        Show a popup
+        """
+
+        self.type = type
+        self.callback = callback
+        x = self.event_x
+        # The popup will be shown in a thread
+        self.thread = Thread(target=self.start_popup,
+                             args=(module_name, x, lines, type))
+        self.thread.daemon = True
+        self.thread.start()
+
+    def popup_toggle(self, module_name, lines, type, callback=None):
+        """
+        Close popup if open else show
+        """
+
+        if self.module_name == module_name:
+            self.close()
+        else:
+            self.popup(module_name, lines, type, callback)
+
+    def popup_update(self, module_name, data):
+        """
+        update the popup info
+        """
+
+        if self.module_name != module_name:
+            return
+        self.auto_update = False
+        self.process_input(data, self.num_lines)
+        if self.num_lines == 1:
+            self.run_dzen2(module_name)
+        else:
+            self.write_lines(self.process)
+
+    def process_input(self, lines, num_lines=None):
+        """
+        Process the info for the popup.
+        converts string to list etc
+        """
+        if not isinstance(lines, list):
+            lines = lines.splitlines()
+
+        items = []
+
+        for text in lines:
+            value = None
+            if isinstance(text, tuple):
+                text, value = text
+            full_text = u'{}{}'.format(self.selector.get(value, ''), text).rstrip()
+            items.append(dict(full_text=full_text, value=value, text=text))
+        # add blank lines to fill height of popup if needed.
+        while num_lines and len(items) < num_lines:
+            items.append(dict(full_text='', value=None, text=''))
+        self.items = items
+
+    def write_lines(self, process):
+        """
+        Writes the full info to the popup
+        """
+
+        if self.num_lines != 1:
+            process.stdin.write('^cs()\n')
+        for index, item in enumerate(self.items):
+            if (self.type == 'menu' or
+                    (self.down and index == self.num_lines - 1) or
+                    (not self.down and index == 0)):
+                line_break = self.line
+            else:
+                line_break = ''
+            process.stdin.write(
+                self.template.format(text=item['full_text'], line=line_break)
+            )
+        if self.num_lines != 1:
+            process.stdin.write('^scrollhome()\n')
+        process.stdin.flush()
+
+    def get_output(self, cmd):
+        """
+        runs a command and gets the output as utf-8
+        """
+
+        output = check_output(shlex.split(cmd), universal_newlines=True).strip()
+        try:
+            output = output.decode('utf-8')
+        except AttributeError:
+            pass
+        return output
+
+    def calculate_width_fallback(self, font_size):
+        """
+        Do a best guess at calculating maximum text width
+        """
+        max_length = 0
+        for item in self.items:
+            length = len(item['full_text']) * font_size / 1.6
+            max_length = max(max_length, length)
+        width = int(max_length)
+        return width
+
+    def calculate_pango_size(self, font):
+        """
+        Calculate maximum text width using gtk and pango
+        """
+        label = gtk.Label()
+        pango_layout = label.get_layout()
+        pango_font_desc = pango.FontDescription(font)
+        pango_layout.set_font_description(pango_font_desc)
+
+        max_length = 0
+        for item in self.items:
+            pango_layout.set_markup(item['full_text'])
+            length = pango_layout.get_pixel_size()[0]
+            max_length = max(max_length, length)
+        width = max_length
+        return width
+
+    def process_font(self, font):
+        """
+        Convert a font to one that dzen2 can understand.
+        """
+        if font in self.font_cache:
+            return self.font_cache[font]
+        if not font.startswith('pango:'):
+            font = font.strip()
+            self.font_cache[font] = font
+            return font
+
+        # pango font definition
+        font = font[6:].strip()
+        # size
+        try:
+            font_size = int(font.split()[-1])
+        except:
+            font_size = 12
+        # family find longest matching font string
+        font_list = self.get_output('fc-list : family').splitlines()
+        fonts = []
+        match = ''
+        for font_name in font_list:
+            fonts += font_name.split(',')
+        for font_name in sorted(fonts):
+            if font.startswith(font_name):
+                if len(font_name) > len(match):
+                    match = font_name
+
+        if match:
+            extras = u''.join(font.split()[:-1])[len(match):]
+            font_str = u'{}-{} {}'.format(match, font_size, extras)
+            self.font_cache[font] = font_str
+            return font_str
+
+    def start_popup(self, module_name, x, lines, type='info'):
+        """
+        Helper to start a popup.  We log any exceptions here
+        """
+        try:
+            self.action_popup(module_name, x, lines, type=type)
+        except Exception:
+            self.py3_wrapper.report_exception('Error processing event')
+
+    def action_popup(self, module_name, x, lines, type):
+        """
+        Actually do the popup here
+        """
+        border = BORDER
+
+        data = json.loads(self.get_output('i3-msg -t get_workspaces'))
+        for workspace in data:
+            if workspace['focused']:
+                output = workspace['output']
+                workspace_height = workspace['rect']['height']
+                break
+
+        data = json.loads(self.get_output('i3-msg -t get_outputs'))
+        for output_info in data:
+            if output_info['name'] == output:
+                screen_width = output_info['rect']['width']
+                screen_height = output_info['rect']['height']
+                break
+
+        # line height is based on the height of the i3bar
+        line_height = screen_height - workspace_height
+        # how many lines can we fit on the screen
+        max_lines = (screen_height // line_height) - 1
+
+        font_size = line_height - PADDING
+
+        data = json.loads(self.get_output('i3-msg -t get_bar_config %s' % BAR))
+        font = data['font']
+        position = data['position']
+        colors = data['colors']
+
+        config_fn = self.py3_wrapper.get_config_attribute
+        fg = config_fn(module_name, 'popup_fg') or colors.get('statusline', FG)
+        bg = config_fn(module_name, 'popup_bg') or colors.get('background', BG)
+        highlight_bg = config_fn(module_name, 'popup_highlight_bg') or fg
+        highlight_fg = config_fn(module_name, 'popup_highlight_fg') or bg
+        border_color = config_fn(module_name, 'popup_border') or BORDER_COLOR
+
+        self.selector = {
+            True: u'{} '.format(
+                config_fn(module_name, 'popup_selector_on') or SELECTOR_ON
+            ),
+            False: u'{} '.format(
+                config_fn(module_name, 'popup_selector_off') or SELECTOR_OFF
+            ),
+        }
+        self.process_input(lines)
+
+        if gtk:
+            width = self.calculate_pango_size(font)
+        else:
+            width = self.calculate_width_fallback(font_size)
+
+        # we want some padding in the popup
+        width += (PADDING * 2)
+
+        # limit to width of screen
+        if width > screen_width:
+            width = screen_width
+
+        font = self.process_font(font)
+        num_lines = len(self.items)
+        self.num_lines = num_lines
+
+        x = x - width // 2
+
+        if x < 0:
+            x = 0
+        elif x > screen_width - width:
+            x = screen_width - width
+
+        events = [
+            'button3=ungrabkeys,exit;',
+            'button4=scrollup;',
+            'button5=scrolldown;',
+            'key_Escape=ungrabkeys,exit;',
+        ]
+
+        extra_options = ''
+        if type == 'menu':
+            if num_lines == 1:
+                events.append('button1=exit:99;')
+            else:
+                extra_options = ' -m'
+                events.append('button1=menuprint;')
+        else:
+            events.append('button1=exit;')
+
+        if position == 'bottom':
+            y = -line_height
+            border_pos = 0
+            self.down = False
+            # if only one line then we will be using the dzen title
+            if num_lines == 1:
+                y *= 2
+        else:
+            y = 0
+            if num_lines == 1:
+                y = line_height
+            border_pos = line_height - border
+            self.down = True
+
+        # if only one line then we will be using the dzen title
+        if num_lines == 1:
+            events.append('onstart=raise;')  # ,grabkeys;'
+        else:
+            events.append('onstart=uncollapse,hide,scrollhome;')  # ,grabkeys;'
+
+        cmd = (
+            'dzen2 -x {x} -y {y} -w {width}'
+            ' {extra_options}'
+            ' -p -ta l -sa l'
+            ' -l {num_lines}'
+            ' -bg "{bg}"'
+            ' -fg "{highlight_bg}"'
+            ' -fn \'{font}\''
+            ' -h {line_height}'
+            ' -e "{events}"'
+        ).format(
+            font=font,
+            extra_options=extra_options,
+            line_height=line_height,
+            num_lines=min(max_lines, num_lines),
+            x=x,
+            y=y,
+            bg=bg,
+            highlight_bg=highlight_bg,
+            width=width,
+            events=''.join(events),
+        )
+
+        template = (
+            '^ib(1)^pa({padding})'
+            '^bg({highlight_fg})'
+            '^fg({fg})'
+            '{{text}}'
+            '^fg({border_color})'
+            '^pa(0;0)'
+            '^r({border}x{line_height})'
+            '{{line}}'
+            '^pa({width};0)'
+            '^r({border}x{line_height})'
+            '^fg({fg})'
+            '\n'
+        )
+        self.template = (template).format(
+            border=border,
+            padding=PADDING,
+            width=width - border,
+            line_height=line_height,
+            border_color=border_color,
+            fg=fg,
+            highlight_fg=highlight_fg,
+        )
+
+        line = (
+            '^pa(0;{border_pos})'
+            '^r({width}x{border})'
+        )
+
+        self.line = (line).format(
+            border=border,
+            border_pos=border_pos,
+            width=width - border,
+        )
+
+        self.dzen2_cmd = cmd
+        self.run_dzen2(module_name)
+
+    def run_dzen2(self, module_name):
+        """
+        Run the actual dzen2 command here.
+        We do this because we need to be able to rerun the command to deal with
+        single line popups as they use the title window not the slave window.
+        """
+        command = shlex.split(self.dzen2_cmd)
+        try:
+            process = Popen(command, stdin=PIPE, stdout=PIPE, stderr=PIPE,
+                            universal_newlines=True)
+        except:
+            self.py3_wrapper.report_exception('popup dzen2 command failed')
+            return
+
+        self.write_lines(process)
+        self.close()
+        self.module_name = module_name
+        self.process = process
+
+        ignore = True
+
+        while True:
+            if not self.process:
+                break
+            nextline = self.process.stdout.readline()
+            if nextline == '':
+                if not self.process:
+                    break
+                err_no = self.process.poll()
+                if err_no is not None:
+                    # single line popup special case
+                    if self.num_lines == 1 and err_no == 99:
+                        item = self.items[0]
+                        if item['value'] is not None:
+                            item['value'] = not item['value']
+                            self.auto_update = True
+                        self.process = None
+                        self.do_callback(item['text'])
+                    break
+            # ignore the first line of output
+            if ignore:
+                ignore = False
+                continue
+
+            # remove \n
+            nextline = nextline[:-1]
+
+            for item in self.items:
+                if item['full_text'] == nextline:
+                    if item['value'] is not None:
+                        item['value'] = not item['value']
+                        self.auto_update = True
+                        # update the display text
+                        item['full_text'] = u'{}{}'.format(
+                            self.selector.get(item['value'], ''),
+                            item['text']
+                        ).rstrip()
+                    self.do_callback(item['text'])
+                    break
+        self.process = None
+        self.module_name = None
+
+    def do_callback(self, clicked_item):
+        """
+        Run the callback if one has been set
+        """
+        if self.callback:
+            module_name = self.module_name
+            output = {}
+            for item in self.items:
+                if item['value'] is not None:
+                    output[item['text']] = item['value']
+            self.auto_update = True
+            self.callback(clicked_item, output)
+        if self.auto_update and self.process:
+            if self.num_lines == 1:
+                self.run_dzen2(module_name)
+            else:
+                self.write_lines(self.process)

--- a/py3status/py3.py
+++ b/py3status/py3.py
@@ -881,3 +881,53 @@ class Py3:
         setattr(self._py3status_module, color_name, color)
 
         return color
+
+    def popup_open(self, data, type='info', callback=None):
+        """
+        Open a popup for the module.
+
+        `type` can be 'info' in which case the popup will contain just text, or
+        'menu' in which case the popup will respond to user actions and call
+        the callback function.
+
+        `data` can be a string using \n to separate each line, a list of
+        strings or a list of tuples (text, value) where text is the string to
+        be displayed and value can be True (item is selected), False (item is
+        not selected), None (item not selectable).
+
+        `callback` is a function that will receive the text of the line that
+        was clicked by the user and a dict containing all items as keys and a
+        value corresponding to if the item is selected or not.
+        """
+        if self._module:
+            module_name = self._module.module_full_name
+            self._module._py3_wrapper.popup_controller.popup(
+                module_name, data, type=type, callback=callback
+            )
+
+    def popup_close(self):
+        """
+        Close the modules popup.
+        """
+        if self._module:
+            self._module._py3_wrapper.popup_controller.close()
+
+    def popup_toggle(self, data, type='info', callback=None):
+        """
+        Close the menu if it is open else open it.
+        """
+        if self._module:
+            module_name = self._module.module_full_name
+            self._module._py3_wrapper.popup_controller.popup_toggle(
+                module_name, data, type=type, callback=callback
+            )
+
+    def popup_update(self, data):
+        """
+        Update the popup displaying the new data.
+        """
+        if self._module:
+            module_name = self._module.module_full_name
+            self._module._py3_wrapper.popup_controller.popup_update(
+                module_name, data
+            )

--- a/py3status/py3.py
+++ b/py3status/py3.py
@@ -848,6 +848,15 @@ class Py3:
             self._audio.kill()
             self._audio = None
 
+    def py3status_function(self, name, data=None):
+        """
+        Exposes core functionality to modules.
+        """
+        if self._module:
+            return self._module._py3_wrapper.py3status_function(
+                name=name, data=data
+            )
+
     def threshold_get_color(self, value, name=None):
         """
         Obtain color for a value using thresholds.

--- a/py3status/py3.py
+++ b/py3status/py3.py
@@ -313,6 +313,13 @@ class Py3:
         """
         return self._is_python_2
 
+    def module_name(self):
+        """
+        Returns the modules name.
+        """
+        if self._module:
+            return self._module.module_full_name
+
     def is_my_event(self, event):
         """
         Checks if an event triggered belongs to the module recieving it.  This


### PR DESCRIPTION
This PR introduces a new module `module_selector` that allows modules to be enabled/disabled whilst py3status is running.  It relies on PRs #585 (data-storage) and #571 (popups) but I thought it would be good to just have it here.  This branch contains those PRs.

Both py3status and i3status modules can be enabled/disabled.

I did consider presenting this as multiple PRs but it started getting a bit messy so I decided to just do a dump here.  It'll be much more readable if the PRs it depends on are merged first.  Anyhow I'm more than happy to split this into many PRs if needed.