### PR TITLE
New module: Do Not Disturb

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 *.pyc
 build
 dist
+tags
 *.egg-info
 .tox/
 .cache/

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,6 @@
 *.pyc
 build
 dist
-tags
 *.egg-info
 .tox/
 .cache/

--- a/py3status/modules/do_not_disturb.py
+++ b/py3status/modules/do_not_disturb.py
@@ -1,0 +1,75 @@
+# -*- coding: utf-8 -*-
+"""
+A simple "Do Not Disturb" module that can turn on and off all system notifications.
+
+A left mouse click will toggle the state of this module.
+
+Configuration parameters:
+    format_off: Display format when the "Do Not Disturb" mode is disabled.
+        (default 'OFF')
+    format_on: Display format when the "Do Not Disturb" mode is enabled.
+        (default 'ON')
+    notification_manager: The process name of your notification manager.
+        (default 'dunst')
+    refresh_interval: Refresh interval to use for killing notification manager process.
+        (default 0.25)
+
+Color options:
+    color_bad: "Do Not Disturb" mode is enabled.
+    color_good: "Do Not Disturb" mode is disabled.
+"""
+
+from time import sleep
+from os import system
+from threading import Thread, Event
+
+
+class Py3status:
+    """
+    """
+
+    # available configuration parameters
+    format_off = 'OFF'
+    format_on = 'ON'
+    notification_manager = 'dunst'
+    refresh_interval = 0.25
+
+    def __init__(self):
+        self.running = Event()
+        self.killed = Event()
+
+        class MyThread(Thread):
+            def run(this):
+                while not self.killed.is_set():
+                    if self.running.wait():
+                        system("killall '{}'".format(self.notification_manager))
+                        sleep(self.refresh_interval)
+
+        MyThread().start()
+
+    def do_not_disturb(self):
+        response = {
+            'cached_until': self.py3.CACHE_FOREVER,
+            'full_text': self.format_on if self.running.is_set() else self.format_off,
+            'color': self.py3.COLOR_BAD if self.running.is_set() else self.py3.COLOR_GOOD
+        }
+        return response
+
+    def on_click(self, event):
+        if event['button'] == 1:
+            if self.running.is_set():
+                self.running.clear()
+            else:
+                self.running.set()
+
+    def kill(self):
+        self.killed.set()
+        self.running.set()  # ensure the thread won't hang
+
+
+if __name__ == "__main__":
+    """
+    Run module in test mode.
+    """
+    from py3status.module_test import module_test
+    module_test(Py3status)

--- a/py3status/modules/do_not_disturb.py
+++ b/py3status/modules/do_not_disturb.py
@@ -5,14 +5,16 @@ A simple "Do Not Disturb" module that can turn on and off all system notificatio
 A left mouse click will toggle the state of this module.
 
 Configuration parameters:
-    format_off: Display format when the "Do Not Disturb" mode is disabled.
-        (default 'OFF')
-    format_on: Display format when the "Do Not Disturb" mode is enabled.
-        (default 'ON')
+    format: Display format for the "Do Not Disturb" module.
+        (default '{state}')
     notification_manager: The process name of your notification manager.
         (default 'dunst')
     refresh_interval: Refresh interval to use for killing notification manager process.
         (default 0.25)
+    state_off: Message when the "Do Not Disturb" mode is disabled.
+        (default 'OFF')
+    state_on: Message when the "Do Not Disturb" mode is enabled.
+        (default 'ON')
 
 Color options:
     color_bad: "Do Not Disturb" mode is enabled.
@@ -29,10 +31,11 @@ class Py3status:
     """
 
     # available configuration parameters
-    format_off = 'OFF'
-    format_on = 'ON'
+    format = '{state}'
     notification_manager = 'dunst'
     refresh_interval = 0.25
+    state_off = 'OFF'
+    state_on = 'ON'
 
     def __init__(self):
         self.running = Event()
@@ -48,9 +51,10 @@ class Py3status:
         MyThread().start()
 
     def do_not_disturb(self):
+        state = self.state_on if self.running.is_set() else self.state_off
         response = {
             'cached_until': self.py3.CACHE_FOREVER,
-            'full_text': self.format_on if self.running.is_set() else self.format_off,
+            'full_text': self.py3.safe_format(self.format, {'state': state}),
             'color': self.py3.COLOR_BAD if self.running.is_set() else self.py3.COLOR_GOOD
         }
         return response


### PR DESCRIPTION
This module has a very simple idea behind it: to be able to turn on and off all the notifications in the system with a single click.

This is easy to achieve if all potentially distracting apps (like email, chat, etc.) use native system notifications rather than their own implementations. This module assumes such setup :wink: 

## Screenshots:

All the notifications are enabled:
![image](https://cloud.githubusercontent.com/assets/1177900/21298569/166b71a8-c593-11e6-8e45-bc3f311e670b.png)

Need to focus? A single mouse click disables the all system notifications:
![image](https://cloud.githubusercontent.com/assets/1177900/21298577/2a40be5e-c593-11e6-9acf-47b2ea913659.png)

Done working? A single mouse click, and you have all your notifications back:
![image](https://cloud.githubusercontent.com/assets/1177900/21298591/476dbbb2-c593-11e6-92e2-d24406fd29bd.png)

## Implementation details

I couldn't figure out a smart way to disable notifications, that would work with all available notification managers. But I saw that many people suggest having a shell script that periodically kills the manager's process... So I took the same approach :smile: a bit ugly, but it works.