### PR TITLE
Battery_level: Prevent logic issues when zero

### DIFF
--- a/py3status/modules/battery_level.py
+++ b/py3status/modules/battery_level.py
@@ -277,9 +277,9 @@ class Py3status:
         for path in iglob(os.path.join(self.sys_battery_path, "BAT*")):
             r = _parse_battery_info(path)
 
-            capacity = r.get("POWER_SUPPLY_ENERGY_FULL") or r.get("POWER_SUPPLY_CHARGE_FULL")
-            present_rate = r.get("POWER_SUPPLY_POWER_NOW") or r.get("POWER_SUPPLY_CURRENT_NOW")
-            remaining_energy = r.get("POWER_SUPPLY_ENERGY_NOW") or r.get("POWER_SUPPLY_CHARGE_NOW")
+            capacity = r.get("POWER_SUPPLY_ENERGY_FULL", r.get("POWER_SUPPLY_CHARGE_FULL"))
+            present_rate = r.get("POWER_SUPPLY_POWER_NOW", r.get("POWER_SUPPLY_CURRENT_NOW"))
+            remaining_energy = r.get("POWER_SUPPLY_ENERGY_NOW", r.get("POWER_SUPPLY_CHARGE_NOW"))
 
             battery = {}
             battery["capacity"] = capacity


### PR DESCRIPTION
When a value of zero was obtained we could end up with a value of None. This fixes the issue

```
TypeError: unsupported operand type(s) for /: 'int' and 'NoneType'
  File "/home/toby/dev/py3status/py3status/module.py", line 584, in run
    response = method()
  File "/home/toby/dev/py3status/py3status/modules/battery_level.py", line 174, in battery_level
    self._refresh_battery_info()
  File "/home/toby/dev/py3status/py3status/modules/battery_level.py", line 316, in _refresh_battery_info
    battery_list = self._extract_battery_information_from_sys()
  File "/home/toby/dev/py3status/py3status/modules/battery_level.py", line 294, in _extract_battery_information_from_sys
    time_in_secs = (remaining_energy / present_rate * 3600)
```