### PR TITLE
Use color 'bad' instead of 'high' as a default threshold in sysdata

### DIFF
--- a/py3status/modules/sysdata.py
+++ b/py3status/modules/sysdata.py
@@ -14,7 +14,7 @@ Configuration parameters:
     precision: precision of values
         (default 2)
     thresholds: thresholds to use for color changes
-        (default [(0, "good"), (40, "degraded"), (75, "high")])
+        (default [(0, "good"), (40, "degraded"), (75, "bad")])
     zone: thermal zone to use. If None try to guess CPU temperature
         (default None)
 
@@ -162,7 +162,7 @@ class Py3status:
     mem_unit = 'GiB'
     padding = 0
     precision = 2
-    thresholds = [(0, "good"), (40, "degraded"), (75, "high")]
+    thresholds = [(0, "good"), (40, "degraded"), (75, "bad")]
     zone = None
 
     class Meta:


### PR DESCRIPTION
It doesn't make sense to use "high" as a default color, there is no such color in py3status and without extra configuration it won't be colorized at all. It should have been "bad", which is rendered as red.

Also see line 176 which shows that the default value is "bad" for those who still use the obsolete way of configuring thresholds.