### PR TITLE
volume_status PactlBackend does not read user-specified device

### DIFF
--- a/py3status/modules/volume_status.py
+++ b/py3status/modules/volume_status.py
@@ -161,7 +161,7 @@ class PactlBackend(AudioBackend):
             self.device = "0"
         self.max_volume = parent.max_volume
         self.re_volume = re.compile(
-            r'Sink \#0.*?Mute: (\w{2,3}).*?Volume:.*?(\d{1,3})\%',
+            r'Sink \#{}.*?Mute: (\w{{2,3}}).*?Volume:.*?(\d{{1,3}})\%'.format(self.device),
             re.M | re.DOTALL
         )
 


### PR DESCRIPTION
the volume_status module's PactlBackend regex was hardcoded for sink #0 , now the regex uses self.device

I ran into the error because my computer has two output devices (HDMI=0, Stereo=1).