### PR TITLE
No device fix

### DIFF
--- a/py3status/modules/backlight.py
+++ b/py3status/modules/backlight.py
@@ -96,8 +96,11 @@ class Py3status:
         return brightness * 100 // brightness_max
 
     def backlight(self):
-        level = self._get_backlight_level()
-        full_text = self.py3.safe_format(self.format, {'level': level})
+        full_text = ""
+        if self.device_path is not None:
+            level = self._get_backlight_level()
+            full_text = self.py3.safe_format(self.format, {'level': level})
+
         response = {
             'cached_until': self.py3.time_in(self.cache_timeout),
             'full_text': full_text

--- a/py3status/modules/battery_level.py
+++ b/py3status/modules/battery_level.py
@@ -170,9 +170,13 @@ class Py3status:
             raise NameError("Invalid measurement mode")
 
     def battery_level(self):
+        if not os.listdir(self.sys_battery_path):
+            return {
+                "full_text": "",
+                "cached_until": self.py3.time_in(self.cache_timeout)
+            }
 
         self._refresh_battery_info()
-
         self._update_icon()
         self._update_ascii_bar()
         self._update_full_text()


### PR DESCRIPTION
Quick fixes for battery and backlight displays (in particular fixes #557):

- Battery module failed when running on a computer without a battery
- Backlight module failed when running on a computer with a monitor that can't have its brightness adjusted.