### PR TITLE
arch_updates fixes

### DIFF
--- a/py3status/modules/arch_updates.py
+++ b/py3status/modules/arch_updates.py
@@ -19,6 +19,7 @@ Configuration parameters:
 Format placeholders:
     {aur} Number of pending aur updates
     {pacman} Number of pending pacman updates
+    {total} Total updates pending
 
 Requires:
     cower: Needed to display pending 'aur' updates
@@ -30,6 +31,10 @@ Requires:
 import subprocess
 import sys
 
+FORMAT_PACMAN_ONLY = 'UPD: {pacman}'
+FORMAT_PACMAN_AND_AUR = 'UPD: {pacman}/{aur}'
+LINE_SEPARATOR = "\\n" if sys.version_info > (3, 0) else "\n"
+
 
 class Py3status:
     # available configuration parameters
@@ -38,33 +43,46 @@ class Py3status:
     hide_if_zero = False
     include_aur = False
 
-    _format_pacman_only = 'UPD: {pacman}'
-    _format_pacman_and_aur = 'UPD: {pacman}/{aur}'
-    _line_separator = "\\n" if sys.version_info > (3, 0) else "\n"
+    def post_config_hook(self):
+        if self.format == '':
+            if not self.include_aur:
+                self.format = FORMAT_PACMAN_ONLY
+            else:
+                self.format = FORMAT_PACMAN_AND_AUR
+        self.include_aur = self.py3.format_contains(self.format, 'aur')
+        self.include_pacman = self.py3.format_contains(self.format, 'pacman')
+        if self.py3.format_contains(self.format, 'total'):
+            self.include_aur = True
+            self.include_pacman = True
 
-    if format == '':
-        if not include_aur:
-            format = _format_pacman_only
-        else:
-            format = _format_pacman_and_aur
+        # check cower installed
+        if self.include_aur and not self.py3.check_commands(['cower']):
+            self.pys.notify_user('cower is not installed cannot check aur')
+            self.include_aur = False
 
     def check_updates(self):
         pacman_updates = self._check_pacman_updates()
-
-        response = {'cached_until': self.py3.time_in(self.cache_timeout)}
-
-        if self.include_aur:
-            aur_updates = self._check_aur_updates()
+        aur_updates = self._check_aur_updates()
+        if aur_updates == '?':
+            total = pacman_updates
         else:
-            aur_updates = ''
+            total = pacman_updates + aur_updates
 
-        if self.hide_if_zero and pacman_updates == 0 and aur_updates == 0:
-            response['full_text'] = ''
+        if self.hide_if_zero and total == 0:
+            full_text = ''
         else:
-            response['full_text'] = self.py3.safe_format(self.format,
-                                                         {'pacman': pacman_updates,
-                                                          'aur': aur_updates})
-        return response
+            full_text = self.py3.safe_format(
+                self.format,
+                {
+                    'aur': aur_updates,
+                    'pacman': pacman_updates,
+                    'total': total,
+                }
+            )
+        return {
+            'cached_until': self.py3.time_in(self.cache_timeout),
+            'full_text': full_text,
+        }
 
     def _check_pacman_updates(self):
         """
@@ -72,8 +90,10 @@ class Py3status:
         to determine how many updates are waiting to be installed via
         'pacman -Syu'.
         """
+        if not self.include_pacman:
+            return 0
         pending_updates = str(subprocess.check_output(["checkupdates"]))
-        return pending_updates.count(self._line_separator)
+        return pending_updates.count(LINE_SEPARATOR)
 
     def _check_aur_updates(self):
         """
@@ -84,6 +104,9 @@ class Py3status:
         # For reasons best known to its author, 'cower' returns a non-zero
         # status code upon successful execution, if there is any output.
         # See https://github.com/falconindy/cower/blob/master/cower.c#L2596
+        if not self.include_aur:
+            return '?'
+
         pending_updates = b""
         try:
             pending_updates = str(subprocess.check_output(["cower", "-bu"]))
@@ -91,7 +114,7 @@ class Py3status:
             pending_updates = cp_error.output
         except:
             pending_updates = '?'
-        return str(pending_updates).count(self._line_separator)
+        return str(pending_updates).count(LINE_SEPARATOR)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This fixes arch_updates so that we now care about the user config.  Also some minor cleanups setting some constants.

@lasers could you see if this PR works eg `format='AUR {aur}'` should work now.  I don't have an arch setup to test on.

fixes #498 
should remove need for #607