### PR TITLE
timer: fix cache_timeout

### DIFF
--- a/py3status/modules/timer.py
+++ b/py3status/modules/timer.py
@@ -77,7 +77,7 @@ class Py3status:
         seconds = t
 
         if self.running:
-            cached_until = self.py3.time_in(1),
+            cached_until = self.py3.time_in(0, offset=self.cache_offset)
         else:
             cached_until = self.py3.CACHE_FOREVER
 
@@ -145,6 +145,7 @@ class Py3status:
                     self.end_time = time() + self.time_left
                 else:
                     self.end_time = time() + self.time
+                self.cache_offset = self.end_time % 1
                 self.color = '#00FF00'
                 if self.alarm_timer:
                     self.alarm_timer.cancel()


### PR DESCRIPTION
This fixes issue #615

Also an error due to returning a tuple as the cache_timeout.  This was reported by @lasers in #623 but timer module is the cause.

```
2017-01-07 22:59:44 WARNING Runtime error (TypeError) module.py line 152.
2017-01-07 22:59:44 INFO Traceback
TypeError: unsupported operand type(s) for -: 'tuple' and 'float'
  File "/home/toby/dev/py3status/py3status/__init__.py", line 44, in main
    py3.run()
  File "/home/toby/dev/py3status/py3status/core.py", line 778, in run
    time.sleep(0.1)
  File "/home/toby/dev/py3status/py3status/core.py", line 705, in i3bar_start
    self.wake_modules()
  File "/home/toby/dev/py3status/py3status/core.py", line 717, in wake_modules
    module['module'].wake()
  File "/home/toby/dev/py3status/py3status/module.py", line 152, in wake
    delay = max(self.cache_time - time(), 0)
```