### PR TITLE
dpms: Add format

### DIFF
--- a/py3status/modules/dpms.py
+++ b/py3status/modules/dpms.py
@@ -7,12 +7,12 @@ of DPMS (Display Power Management Signaling)
 by clicking on 'DPMS' in the status bar.
 
 Configuration parameters:
-    format: string to display (default '{state}')
+    format: string to display (default '{icon}')
     icon_off: string to display when dpms is disabled (default 'DPMS')
     icon_on: string to display when dpms is enabled (default 'DPMS')
 
 Format placeholders:
-    {state} display current dpms state
+    {icon} display current dpms icon
 
 Color options:
     color_on: when dpms is enabled, defaults to color_good
@@ -28,7 +28,7 @@ class Py3status:
     """
     """
     # available configuration parameters
-    format = "{state}"
+    format = "{icon}"
     icon_off = "DPMS"
     icon_on = "DPMS"
 
@@ -38,12 +38,12 @@ class Py3status:
                 {
                     'param': 'format_on',
                     'new': 'icon_on',
-                    'msg': 'obsolete parameter // use `icon_on`',
+                    'msg': 'obsolete parameter use `icon_on`',
                 },
                 {
                     'param': 'format_off',
                     'new': 'icon_off',
-                    'msg': 'obsolete parameter // use `icon_off`',
+                    'msg': 'obsolete parameter use `icon_off`',
                 },
             ],
         }
@@ -53,10 +53,10 @@ class Py3status:
         Display a colorful state of DPMS.
         """
         self.run = system('xset -q | grep -iq "DPMS is enabled"') == 0
-        format_dpms = self.icon_on if self.run else self.icon_off
+        icon = self.icon_on if self.run else self.icon_off
 
         return {
-            'full_text': self.py3.safe_format(self.format, {'state': format_dpms}),
+            'full_text': self.py3.safe_format(self.format, {'icon': icon}),
             'color': self.py3.COLOR_ON or self.py3.COLOR_GOOD if self.run
             else self.py3.COLOR_OFF or self.py3.COLOR_BAD
         }

--- a/py3status/modules/dpms.py
+++ b/py3status/modules/dpms.py
@@ -7,12 +7,12 @@ of DPMS (Display Power Management Signaling)
 by clicking on 'DPMS' in the status bar.
 
 Configuration parameters:
-    format: string to display (default '{dpms}')
+    format: string to display (default '{format_dpms}')
     format_off: string to display when dpms is disabled (default 'DPMS')
     format_on: string to display when dpms is enabled (default 'DPMS')
 
 Format placeholders:
-    {dpms} display current dpms setting
+    {format_dpms} display current dpms setting
 
 Color options:
     color_on: when dpms is enabled, defaults to color_good
@@ -28,7 +28,7 @@ class Py3status:
     """
     """
     # available configuration parameters
-    format = "{dpms}"
+    format = "{format_dpms}"
     format_off = "DPMS"
     format_on = "DPMS"
 
@@ -37,10 +37,10 @@ class Py3status:
         Display a colorful state of DPMS.
         """
         self.run = system('xset -q | grep -iq "DPMS is enabled"') == 0
-        dpms = self.format_on if self.run else self.format_off
+        format_dpms = self.format_on if self.run else self.format_off
 
         return {
-            'full_text': self.py3.safe_format(self.format, {'dpms': dpms}),
+            'full_text': self.py3.safe_format(self.format, {'format_dpms': format_dpms}),
             'color': self.py3.COLOR_ON or self.py3.COLOR_GOOD if self.run
             else self.py3.COLOR_OFF or self.py3.COLOR_BAD
         }

--- a/py3status/modules/dpms.py
+++ b/py3status/modules/dpms.py
@@ -7,12 +7,16 @@ of DPMS (Display Power Management Signaling)
 by clicking on 'DPMS' in the status bar.
 
 Configuration parameters:
-    format_off: string to display when DPMS is disabled (default 'DPMS')
-    format_on: string to display when DPMS is enabled (default 'DPMS')
+    format: string to display (default '{query}')
+    format_off: string to display when disabled (default 'DPMS')
+    format_on: string to display when enabled (default 'DPMS')
+
+Format placeholders:
+    {query} display current dpms setting
 
 Color options:
-    color_on: when dpms is enabled, defaults to color_good
-    color_off: when dpms is disabled, defaults to color_bad
+    color_on: when enabled, defaults to color_good
+    color_off: when disabled, defaults to color_bad
 
 @author Andre Doser <dosera AT tf.uni-freiburg.de>
 """
@@ -24,6 +28,7 @@ class Py3status:
     """
     """
     # available configuration parameters
+    format = "{query}"
     format_off = "DPMS"
     format_on = "DPMS"
 
@@ -31,13 +36,11 @@ class Py3status:
         """
         Display a colorful state of DPMS.
         """
-
         self.run = system('xset -q | grep -iq "DPMS is enabled"') == 0
-
-        format = self.format_on if self.run else self.format_off
+        query = self.format_on if self.run else self.format_off
 
         return {
-            'full_text': self.py3.safe_format(format),
+            'full_text': self.py3.safe_format(self.format, {'query': query}),
             'color': self.py3.COLOR_ON or self.py3.COLOR_GOOD if self.run
             else self.py3.COLOR_OFF or self.py3.COLOR_BAD
         }

--- a/py3status/modules/dpms.py
+++ b/py3status/modules/dpms.py
@@ -7,12 +7,12 @@ of DPMS (Display Power Management Signaling)
 by clicking on 'DPMS' in the status bar.
 
 Configuration parameters:
-    format: string to display (default '{format_dpms}')
+    format: string to display (default '{state}')
     format_off: string to display when dpms is disabled (default 'DPMS')
     format_on: string to display when dpms is enabled (default 'DPMS')
 
 Format placeholders:
-    {format_dpms} display current dpms setting
+    {state} display current dpms state
 
 Color options:
     color_on: when dpms is enabled, defaults to color_good
@@ -28,7 +28,7 @@ class Py3status:
     """
     """
     # available configuration parameters
-    format = "{format_dpms}"
+    format = "{state}"
     format_off = "DPMS"
     format_on = "DPMS"
 

--- a/py3status/modules/dpms.py
+++ b/py3status/modules/dpms.py
@@ -7,12 +7,12 @@ of DPMS (Display Power Management Signaling)
 by clicking on 'DPMS' in the status bar.
 
 Configuration parameters:
-    format: string to display (default '{query}')
+    format: string to display (default '{dpms}')
     format_off: string to display when dpms is disabled (default 'DPMS')
     format_on: string to display when dpms is enabled (default 'DPMS')
 
 Format placeholders:
-    {query} display current dpms setting
+    {dpms} display current dpms setting
 
 Color options:
     color_on: when dpms is enabled, defaults to color_good
@@ -28,7 +28,7 @@ class Py3status:
     """
     """
     # available configuration parameters
-    format = "{query}"
+    format = "{dpms}"
     format_off = "DPMS"
     format_on = "DPMS"
 
@@ -37,10 +37,10 @@ class Py3status:
         Display a colorful state of DPMS.
         """
         self.run = system('xset -q | grep -iq "DPMS is enabled"') == 0
-        query = self.format_on if self.run else self.format_off
+        dpms = self.format_on if self.run else self.format_off
 
         return {
-            'full_text': self.py3.safe_format(self.format, {'query': query}),
+            'full_text': self.py3.safe_format(self.format, {'dpms': dpms}),
             'color': self.py3.COLOR_ON or self.py3.COLOR_GOOD if self.run
             else self.py3.COLOR_OFF or self.py3.COLOR_BAD
         }

--- a/py3status/modules/dpms.py
+++ b/py3status/modules/dpms.py
@@ -32,6 +32,22 @@ class Py3status:
     icon_off = "DPMS"
     icon_on = "DPMS"
 
+    class Meta:
+        deprecated = {
+            'rename': [
+                {
+                    'param': 'format_on',
+                    'new': 'icon_on',
+                    'msg': 'obsolete parameter // use `icon_on`',
+                },
+                {
+                    'param': 'format_off',
+                    'new': 'icon_off',
+                    'msg': 'obsolete parameter // use `icon_off`',
+                },
+            ],
+        }
+
     def dpms(self):
         """
         Display a colorful state of DPMS.

--- a/py3status/modules/dpms.py
+++ b/py3status/modules/dpms.py
@@ -8,8 +8,8 @@ by clicking on 'DPMS' in the status bar.
 
 Configuration parameters:
     format: string to display (default '{state}')
-    format_off: string to display when dpms is disabled (default 'DPMS')
-    format_on: string to display when dpms is enabled (default 'DPMS')
+    icon_off: string to display when dpms is disabled (default 'DPMS')
+    icon_on: string to display when dpms is enabled (default 'DPMS')
 
 Format placeholders:
     {state} display current dpms state
@@ -29,18 +29,18 @@ class Py3status:
     """
     # available configuration parameters
     format = "{state}"
-    format_off = "DPMS"
-    format_on = "DPMS"
+    icon_off = "DPMS"
+    icon_on = "DPMS"
 
     def dpms(self):
         """
         Display a colorful state of DPMS.
         """
         self.run = system('xset -q | grep -iq "DPMS is enabled"') == 0
-        format_dpms = self.format_on if self.run else self.format_off
+        format_dpms = self.icon_on if self.run else self.icon_off
 
         return {
-            'full_text': self.py3.safe_format(self.format, {'format_dpms': format_dpms}),
+            'full_text': self.py3.safe_format(self.format, {'state': format_dpms}),
             'color': self.py3.COLOR_ON or self.py3.COLOR_GOOD if self.run
             else self.py3.COLOR_OFF or self.py3.COLOR_BAD
         }

--- a/py3status/modules/dpms.py
+++ b/py3status/modules/dpms.py
@@ -8,15 +8,15 @@ by clicking on 'DPMS' in the status bar.
 
 Configuration parameters:
     format: string to display (default '{query}')
-    format_off: string to display when disabled (default 'DPMS')
-    format_on: string to display when enabled (default 'DPMS')
+    format_off: string to display when dpms is disabled (default 'DPMS')
+    format_on: string to display when dpms is enabled (default 'DPMS')
 
 Format placeholders:
     {query} display current dpms setting
 
 Color options:
-    color_on: when enabled, defaults to color_good
-    color_off: when disabled, defaults to color_bad
+    color_on: when dpms is enabled, defaults to color_good
+    color_off: when dpms is disabled, defaults to color_bad
 
 @author Andre Doser <dosera AT tf.uni-freiburg.de>
 """


### PR DESCRIPTION
This adds format: string to display (default '~~{query}~~{dpms}'). Closes https://github.com/ultrabug/py3status/issues/617. 

Ongoing efforts to `FORMAT ALL THE THINGS!` (meme). https://github.com/ultrabug/py3status/issues/98