### PR TITLE
online_status: Add format

### DIFF
--- a/py3status/modules/online_status.py
+++ b/py3status/modules/online_status.py
@@ -4,11 +4,15 @@ Display if a connection to the internet is established.
 
 Configuration parameters:
     cache_timeout: how often to run the check (default 10)
+    format: string to print (default '{state}')
     format_offline: what to display when offline (default '■')
     format_online: what to display when online (default '●')
     timeout: how long before deciding we're offline (default 2)
     url: connect to this url to check the connection status
          (default 'http://www.google.com')
+
+Format placeholders:
+    {state} display current connection state
 
 Color options:
     color_bad: Offline
@@ -31,6 +35,7 @@ class Py3status:
     """
     # available configuration parameters
     cache_timeout = 10
+    format = '{state}'
     format_offline = u'■'
     format_online = u'●'
     timeout = 2
@@ -56,10 +61,10 @@ class Py3status:
 
         connected = self._connection_present()
         if connected:
-            response['full_text'] = self.format_online
+            response['full_text'] = self.py3.safe_format(self.format, {'state': self.format_online})
             response['color'] = self.py3.COLOR_GOOD
         else:
-            response['full_text'] = self.format_offline
+            response['full_text'] = self.py3.safe_format(self.format, {'state': self.format_offline})
             response['color'] = self.py3.COLOR_BAD
 
         return response

--- a/py3status/modules/online_status.py
+++ b/py3status/modules/online_status.py
@@ -59,11 +59,13 @@ class Py3status:
 
         if self._connection_present():
             response = {
+                'cached_until': self.py3.time_in(self.cache_timeout),
                 'full_text': self.py3.safe_format(self.format, {'state': self.format_online}),
                 'color': self.py3.COLOR_GOOD
             }
         else:
             response = {
+                'cached_until': self.py3.time_in(self.cache_timeout),
                 'full_text': self.py3.safe_format(self.format, {'state': self.format_offline}),
                 'color': self.py3.COLOR_BAD
             }

--- a/py3status/modules/online_status.py
+++ b/py3status/modules/online_status.py
@@ -55,7 +55,6 @@ class Py3status:
                                    stdout=fnull, stderr=fnull) == 0
 
     def online_status(self):
-        response = {'cached_until': self.py3.time_in(self.cache_timeout)}
 
         if self._connection_present():
             response = {

--- a/py3status/modules/online_status.py
+++ b/py3status/modules/online_status.py
@@ -55,9 +55,7 @@ class Py3status:
                                    stdout=fnull, stderr=fnull) == 0
 
     def online_status(self):
-        response = { 'cached_until': self.py3.time_in(self.cache_timeout) }
-
-        connected = self._connection_present()
+        response = {'cached_until': self.py3.time_in(self.cache_timeout)}
 
         if self._connection_present():
             response = {

--- a/py3status/modules/online_status.py
+++ b/py3status/modules/online_status.py
@@ -55,19 +55,19 @@ class Py3status:
                                    stdout=fnull, stderr=fnull) == 0
 
     def online_status(self):
-        response = {
+        reply = {
             'cached_until': self.py3.time_in(self.cache_timeout)
         }
 
         connected = self._connection_present()
         if connected:
-            response['full_text'] = self.py3.safe_format(self.format, {'state': self.format_online})
-            response['color'] = self.py3.COLOR_GOOD
+            reply['full_text'] = self.py3.safe_format(self.format, {'state': self.format_online})
+            reply['color'] = self.py3.COLOR_GOOD
         else:
-            response['full_text'] = self.py3.safe_format(self.format, {'state': self.format_offline})
-            response['color'] = self.py3.COLOR_BAD
+            reply['full_text'] = self.py3.safe_format(self.format, {'state': self.format_offline})
+            reply['color'] = self.py3.COLOR_BAD
 
-        return response
+        return reply
 
 
 if __name__ == "__main__":

--- a/py3status/modules/online_status.py
+++ b/py3status/modules/online_status.py
@@ -55,19 +55,22 @@ class Py3status:
                                    stdout=fnull, stderr=fnull) == 0
 
     def online_status(self):
-        reply = {
-            'cached_until': self.py3.time_in(self.cache_timeout)
-        }
+        response = { 'cached_until': self.py3.time_in(self.cache_timeout) }
 
         connected = self._connection_present()
-        if connected:
-            reply['full_text'] = self.py3.safe_format(self.format, {'state': self.format_online})
-            reply['color'] = self.py3.COLOR_GOOD
-        else:
-            reply['full_text'] = self.py3.safe_format(self.format, {'state': self.format_offline})
-            reply['color'] = self.py3.COLOR_BAD
 
-        return reply
+        if self._connection_present():
+            response = {
+                'full_text': self.py3.safe_format(self.format, {'state': self.format_online}),
+                'color': self.py3.COLOR_GOOD
+            }
+        else:
+            response = {
+                'full_text': self.py3.safe_format(self.format, {'state': self.format_offline}),
+                'color': self.py3.COLOR_BAD
+            }
+
+        return response
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This adds format: string to print (default '{state}')

Ongoing efforts to `FORMAT ALL THE THINGS!` (meme). https://github.com/ultrabug/py3status/issues/98

EDIT: Srsly. What to do here? .__.
```
online_status.py:64:100: E501 line too long (100 > 99 characters)
* response['full_text'] = self.py3.safe_format(self.format, {'state': self.format_online})

online_status.py:67:100: E501 line too long (101 > 99 characters)
* response['full_text'] = self.py3.safe_format(self.format, {'state': self.format_offline})
```
EDIT: 👍 