### PR TITLE
scratchpad_counter: Add format

### DIFF
--- a/py3status/modules/scratchpad_counter.py
+++ b/py3status/modules/scratchpad_counter.py
@@ -4,9 +4,7 @@ Display the amount of windows in your i3 scratchpad.
 
 Configuration parameters:
     cache_timeout: How often we refresh this module in seconds (default 5)
-    format: string to print when one or more window (default '{counter} ⌫')
-    format_none: string to print when no window (default '{counter} ⌫')
-    hide_when_none: old setting. use format_none instead (default False)
+    format: string to print (default '{counter} ⌫')
 
 Format placeholders:
     {counter} number of scratchpad windows
@@ -35,8 +33,6 @@ class Py3status:
     # available configuration parameters
     cache_timeout = 5
     format = u"{counter} ⌫"
-    format_none = u"{counter} ⌫"
-    hide_when_none = False
 
     class Meta:
 
@@ -64,16 +60,16 @@ class Py3status:
 
         response = {
             'cached_until': self.py3.time_in(self.cache_timeout),
-            'full_text': self.py3.safe_format(self.format_none, {'counter': count}),
+            'full_text': self.py3.safe_format(self.format, {'counter': count}),
             'transformed': transformed
         }
 
-        if count > 0:
-            response['full_text'] = self.py3.safe_format(self.format, {'counter': count})
+        #if count > 0:
+        #    response['full_text'] = self.py3.safe_format(self.format, {'counter': count})
 
         # backward compatible (1/11/17)
-        if self.hide_when_none and count == 0:
-            response['full_text'] = ''
+        #if self.hide_when_none and count == 0:
+        #    response['full_text'] = ''
 
         return response
 

--- a/py3status/modules/scratchpad_counter.py
+++ b/py3status/modules/scratchpad_counter.py
@@ -61,12 +61,13 @@ class Py3status:
 
         response = {
             'cached_until': self.py3.time_in(self.cache_timeout),
-            'full_text': self.py3.safe_format(self.format, {'counter': count}),
             'transformed': transformed
         }
 
         if self.hide_when_none and count == 0:
             response['full_text'] = ''
+        else:
+            response['full_text'] = self.py3.safe_format(self.format, {'counter': count})
 
         return response
 

--- a/py3status/modules/scratchpad_counter.py
+++ b/py3status/modules/scratchpad_counter.py
@@ -4,11 +4,8 @@ Display the amount of windows in your i3 scratchpad.
 
 Configuration parameters:
     cache_timeout: How often we refresh this module in seconds (default 5)
-    format: string to print
-        To make empty windows go away, use 'format = '[\?not_zero {counter} ⌫]'
-        To print something else instead, use 'format = '[\?not_zero {counter} ⌫]|Empty`
-        (default '{counter} ⌫')
-    hide_when_none: obsolete parameter - use 'format' (default False)
+    format: string to print (default '{counter} ⌫')
+    hide_when_none: Hide indicator when there is no windows (default False)
 
 Format placeholders:
     {counter} number of scratchpad windows
@@ -68,7 +65,6 @@ class Py3status:
             'transformed': transformed
         }
 
-        # backward compatible (1/11/17)
         if self.hide_when_none and count == 0:
             response['full_text'] = ''
 

--- a/py3status/modules/scratchpad_counter.py
+++ b/py3status/modules/scratchpad_counter.py
@@ -4,10 +4,12 @@ Display the amount of windows in your i3 scratchpad.
 
 Configuration parameters:
     cache_timeout: How often we refresh this module in seconds (default 5)
-    format: Format of indicator. {} replaces with count of windows
-        (default '{} ⌫')
-    hide_when_none: Hide indicator when there is no windows (default False)
+    format: string to print when one or more window (default '{counter} ⌫')
+    format_none: string to print when no window (default '{counter} ⌫')
+    hide_when_none: old setting. use format_none instead (default False)
 
+Format placeholders:
+    {counter} number of scratchpad windows
 
 @author shadowprince
 @license Eclipse Public License
@@ -32,7 +34,8 @@ class Py3status:
     """
     # available configuration parameters
     cache_timeout = 5
-    format = u"{} ⌫"
+    format = u"{counter} ⌫"
+    format_none = u"{counter} ⌫"
     hide_when_none = False
 
     def __init__(self):
@@ -49,12 +52,16 @@ class Py3status:
 
         response = {
             'cached_until': self.py3.time_in(self.cache_timeout),
+            'full_text': self.py3.safe_format(self.format_none, {'counter': count}),
             'transformed': transformed
         }
+
+        if count > 0:
+            response['full_text'] = self.py3.safe_format(self.format, {'counter': count})
+
+        # backward compatible (1/11/17)
         if self.hide_when_none and count == 0:
             response['full_text'] = ''
-        else:
-            response['full_text'] = self.format.format(count)
 
         return response
 

--- a/py3status/modules/scratchpad_counter.py
+++ b/py3status/modules/scratchpad_counter.py
@@ -35,7 +35,6 @@ class Py3status:
     format = u"{counter} ⌫"
 
     class Meta:
-
         deprecated = {
             'format_fix_unnamed_param': [
                 {
@@ -68,8 +67,8 @@ class Py3status:
         #    response['full_text'] = self.py3.safe_format(self.format, {'counter': count})
 
         # backward compatible (1/11/17)
-        #if self.hide_when_none and count == 0:
-        #    response['full_text'] = ''
+        if self.hide_when_none and count == 0:
+            response['full_text'] = ''
 
         return response
 

--- a/py3status/modules/scratchpad_counter.py
+++ b/py3status/modules/scratchpad_counter.py
@@ -4,7 +4,7 @@ Display the amount of windows in your i3 scratchpad.
 
 Configuration parameters:
     cache_timeout: How often we refresh this module in seconds (default 5)
-    format: string to print (default '{counter} ⌫')
+    format: Format of indicator (default '{counter} ⌫')
     hide_when_none: Hide indicator when there is no windows (default False)
 
 Format placeholders:

--- a/py3status/modules/scratchpad_counter.py
+++ b/py3status/modules/scratchpad_counter.py
@@ -38,6 +38,18 @@ class Py3status:
     format_none = u"{counter} ⌫"
     hide_when_none = False
 
+    class Meta:
+
+        deprecated = {
+            'format_fix_unnamed_param': [
+                {
+                    'param': 'format',
+                    'placeholder': 'counter',
+                    'msg': '{} should not be used in format use `{counter}`',
+                },
+            ],
+        }
+
     def __init__(self):
         self.count = -1
 

--- a/py3status/modules/scratchpad_counter.py
+++ b/py3status/modules/scratchpad_counter.py
@@ -4,7 +4,11 @@ Display the amount of windows in your i3 scratchpad.
 
 Configuration parameters:
     cache_timeout: How often we refresh this module in seconds (default 5)
-    format: string to print (default '{counter} ⌫')
+    format: string to print
+        To make empty windows go away, use 'format = '[\?not_zero {counter} ⌫]'
+        To print something else instead, use 'format = '[\?not_zero {counter} ⌫]|Empty`
+        (default '{counter} ⌫')
+    hide_when_none: obsolete parameter - use 'format' (default False)
 
 Format placeholders:
     {counter} number of scratchpad windows
@@ -33,6 +37,7 @@ class Py3status:
     # available configuration parameters
     cache_timeout = 5
     format = u"{counter} ⌫"
+    hide_when_none = False
 
     class Meta:
         deprecated = {
@@ -62,9 +67,6 @@ class Py3status:
             'full_text': self.py3.safe_format(self.format, {'counter': count}),
             'transformed': transformed
         }
-
-        #if count > 0:
-        #    response['full_text'] = self.py3.safe_format(self.format, {'counter': count})
 
         # backward compatible (1/11/17)
         if self.hide_when_none and count == 0:


### PR DESCRIPTION
This adds format: string to print when one or more window (default '{counter} ⌫')
This adds format_none: string to print when no window (default '{counter} ⌫')

This will break `hide_when_none`.
This will break `{}`.

Hold off until 3.4 or what?

EDIT: I don't know how to assign `{}` in the string for backward compatible.

Ongoing efforts to `FORMAT ALL THE THINGS!` (meme). https://github.com/ultrabug/py3status/issues/98