### PR TITLE
scratchpad_async: Add format

### DIFF
--- a/py3status/modules/scratchpad_async.py
+++ b/py3status/modules/scratchpad_async.py
@@ -3,9 +3,11 @@
 Display the amount of windows and indicate urgency hints on scratchpad (async).
 
 Configuration parameters:
-    always_show: whether the indicator should be shown if there are no
-        scratchpad windows (default False)
-    format: Display format when one or more scratchpad window(s) (default "{counter} ⌫")
+    always_show: always display the format (default False)
+    format: display format for scratchpad_async (default "{counter} ⌫")
+
+Format placeholders:
+    {counter} number of scratchpad windows
 
 Requires:
     i3ipc: (https://github.com/acrisci/i3ipc-python)
@@ -24,6 +26,17 @@ class Py3status:
     # available configuration parameters
     always_show = False
     format = u'{counter} ⌫'
+
+    class Meta:
+        deprecated = {
+            'format_fix_unnamed_param': [
+                {
+                    'param': 'format',
+                    'placeholder': 'counter',
+                    'msg': '{} should not be used in format use `{counter}`',
+                },
+            ],
+        }
 
     def __init__(self):
         self.count = 0
@@ -54,8 +67,12 @@ class Py3status:
             self.py3.update()
 
         conn = i3ipc.Connection()
+
+        update_scratchpad_async(conn)
+
         conn.on('window::move', update_scratchpad_async)
         conn.on('window::urgent', update_scratchpad_async)
+
         conn.main()
 
 

--- a/py3status/modules/scratchpad_async.py
+++ b/py3status/modules/scratchpad_async.py
@@ -3,7 +3,8 @@
 Display the amount of windows and indicate urgency hints on scratchpad (async).
 
 Configuration parameters:
-    always_show: old setting. use format_none instead (default False)
+    always_show: whether the indicator should be shown if there are no
+        scratchpad windows (default False)
     format: Display format when one or more scratchpad window(s) (default "{counter} ⌫")
 
 Requires:
@@ -23,7 +24,6 @@ class Py3status:
     # available configuration parameters
     always_show = False
     format = u'{counter} ⌫'
-    format_none = ''
 
     def __init__(self):
         self.count = 0
@@ -39,12 +39,10 @@ class Py3status:
         if self.urgent:
             response['urgent'] = True
 
-        if self.count > 0:
+        if self.always_show or self.count > 0:
             response['full_text'] = self.py3.safe_format(self.format, {'counter': self.count})
-
-        # backward compatible (1/11/17)
-        if self.always_show:
-            response['full_text'] = self.py3.safe_format(self.format, {'counter': self.count})
+        else:
+            response['full_text'] = ''
 
         return response
 


### PR DESCRIPTION
This adds format: string to print when one or more window (default '{counter} ⌫')
This adds format_none: string to print when no window (default '{counter} ⌫')

This ~~will~~ should not break `always_show`.
This will break `{}`.

Hold off until 3.4 or what?

EDIT: I don't know how to assign `{}` in the string for backward compatible.

Ongoing efforts to `FORMAT ALL THE THINGS!` (meme). https://github.com/ultrabug/py3status/issues/98