### PR TITLE
clementine: Add format

### DIFF
--- a/py3status/modules/clementine.py
+++ b/py3status/modules/clementine.py
@@ -4,7 +4,7 @@ Display the current "artist - title" playing in Clementine.
 
 Configuration parameters:
     cache_timeout: how often we refresh this module in seconds (default 5)
-    format: string to print (default '♫ {current}')
+    format: Display format for Clementine (default '♫ {current}')
 
 Format placeholders:
     {current} print current song, artist, title, and/or internet radio

--- a/py3status/modules/clementine.py
+++ b/py3status/modules/clementine.py
@@ -73,14 +73,10 @@ class Py3status:
         """
         Get the current "artist - title" and return it.
         """
-        response = {'full_text': ''}
-
-        response['cached_until'] = self.py3.time_in(self.cache_timeout)
-        response['full_text'] = self._getMetadatas()
-        response['full_text'] = self.py3.safe_format(self.format,
-                                                     {'current': self._getMetadatas()})
-
-        return response
+        return {
+            'cached_until': self.py3.time_in(self.cache_timeout),
+            'full_text': self.py3.safe_format(self.format, {'current': self._getMetadatas()})
+        }
 
 
 if __name__ == "__main__":

--- a/py3status/modules/clementine.py
+++ b/py3status/modules/clementine.py
@@ -4,7 +4,7 @@ Display the current "artist - title" playing in Clementine.
 
 Configuration parameters:
     cache_timeout: how often we refresh this module in seconds (default 5)
-    format: string to print (default '{current}')
+    format: string to print (default '♫ {current}')
 
 Format placeholders:
     {current} print current song, artist, title, and/or internet radio
@@ -26,7 +26,7 @@ class Py3status:
     """
     # available configuration parameters
     cache_timeout = 5
-    format = '{current}'
+    format = '♫ {current}'
 
     def _getMetadatas(self):
         """
@@ -59,13 +59,13 @@ class Py3status:
                 internet_radio = True
 
             if artist and title:
-                now_playing = '♫ {} - {}'.format(artist, title)
+                now_playing = '{} - {}'.format(artist, title)
             elif artist:
-                now_playing = '♫ {}'.format(artist)
+                now_playing = '{}'.format(artist)
             elif title:
-                now_playing = '♫ {}'.format(title)
+                now_playing = '{}'.format(title)
             elif internet_radio:
-                now_playing = '♫ Internet Radio'
+                now_playing = 'Internet Radio'
 
         return now_playing
 

--- a/py3status/modules/clementine.py
+++ b/py3status/modules/clementine.py
@@ -7,7 +7,7 @@ Configuration parameters:
     format: Display format for Clementine (default '♫ {current}')
 
 Format placeholders:
-    {current} print current song, artist, title, and/or internet radio
+    {current} currently playing
 
 Requires:
     clementine:

--- a/py3status/modules/clementine.py
+++ b/py3status/modules/clementine.py
@@ -61,9 +61,9 @@ class Py3status:
             if artist and title:
                 now_playing = '{} - {}'.format(artist, title)
             elif artist:
-                now_playing = '{}'.format(artist)
+                now_playing = artist
             elif title:
-                now_playing = '{}'.format(title)
+                now_playing = title
             elif internet_radio:
                 now_playing = 'Internet Radio'
 

--- a/py3status/modules/clementine.py
+++ b/py3status/modules/clementine.py
@@ -4,6 +4,10 @@ Display the current "artist - title" playing in Clementine.
 
 Configuration parameters:
     cache_timeout: how often we refresh this module in seconds (default 5)
+    format: string to print (default '{current}')
+
+Format placeholders:
+    {current} print current song, artist, title, and/or internet radio
 
 Requires:
     clementine:
@@ -22,6 +26,7 @@ class Py3status:
     """
     # available configuration parameters
     cache_timeout = 5
+    format = '{current}'
 
     def _getMetadatas(self):
         """
@@ -72,6 +77,7 @@ class Py3status:
 
         response['cached_until'] = self.py3.time_in(self.cache_timeout)
         response['full_text'] = self._getMetadatas()
+        response['full_text'] = self.py3.safe_format(self.format, {'current': self._getMetadatas()})
 
         return response
 

--- a/py3status/modules/clementine.py
+++ b/py3status/modules/clementine.py
@@ -26,7 +26,7 @@ class Py3status:
     """
     # available configuration parameters
     cache_timeout = 5
-    format = '♫ {current}'
+    format = u'♫ {current}'
 
     def _getMetadatas(self):
         """

--- a/py3status/modules/clementine.py
+++ b/py3status/modules/clementine.py
@@ -77,7 +77,8 @@ class Py3status:
 
         response['cached_until'] = self.py3.time_in(self.cache_timeout)
         response['full_text'] = self._getMetadatas()
-        response['full_text'] = self.py3.safe_format(self.format, {'current': self._getMetadatas()})
+        response['full_text'] = self.py3.safe_format(self.format,
+                                                     {'current': self._getMetadatas()})
 
         return response
 


### PR DESCRIPTION
This adds format: string to print (default '{current}')

This adds format placeholders:
&nbsp;&nbsp;&nbsp;&nbsp;{current} print current song, artist, title, and/or internet radio

This is still incomplete.
&nbsp;&nbsp;&nbsp;&nbsp;Missing placeholders for song, artist, title, and internet radio.

EDIT: Srsly. What to do here? .__.
```
clementine.py:80:100: E501 line too long (100 > 99 characters)
* response['full_text'] = self.py3.safe_format(self.format, {'current': self._getMetadatas()})
```
EDIT: Are you thinking what I'm thinking? PLS REPLY.

Ongoing efforts to `FORMAT ALL THE THINGS!` (meme). https://github.com/ultrabug/py3status/issues/98
