### PR TITLE
xsel: Fix xsel

### DIFF
--- a/py3status/modules/xsel.py
+++ b/py3status/modules/xsel.py
@@ -5,7 +5,7 @@ Display the X selection.
 Configuration parameters:
     cache_timeout: how often we refresh this module in seconds
         (default 0.5)
-    command: the xsel command to run (default 'xsel')
+    command: the xsel command to run (default 'xsel -o')
     max_size: stip the selection to this value (default 15)
     symmetric: show the beginning and the end of the selection string
         with respect to configured max_size. (default True)
@@ -17,17 +17,13 @@ Requires:
 @license BSD
 """
 
-import shlex
-
-from subprocess import check_output
-
 
 class Py3status:
     """
     """
     # available configuration parameters
     cache_timeout = 0.5
-    command = 'xsel'
+    command = 'xsel -o'
     max_size = 15
     symmetric = True
 
@@ -35,17 +31,16 @@ class Py3status:
         """
         Display the content of xsel.
         """
-        current_value = check_output(shlex.split(self.command))
-        if len(current_value) >= self.max_size:
+        output = self.py3.command_output(self.command)
+        if len(output) >= self.max_size:
             if self.symmetric is True:
                 split = int(self.max_size / 2) - 1
-                current_value = current_value[:split].decode(
-                    'utf-8') + '..' + current_value[-split:].decode('utf-8')
+                output = output[:split] + '..' + output[-split:]
             else:
-                current_value = current_value[:self.max_size]
+                output = output[:self.max_size]
         response = {
             'cached_until': self.py3.time_in(self.cache_timeout),
-            'full_text': current_value,
+            'full_text': output,
         }
         return response
 


### PR DESCRIPTION
Switching from `xsel` to `xsel -o` make it more bearable. 
`-o, --output:    write the selection to standard output.`

With `xsel` alone, I get this error.
```
2017-01-14 13:23:14 WARNING Instance `xsel`, user method `xsel` failed (Exception) py3.py line 699.
2017-01-14 13:23:14 INFO Traceback
Exception: Command 'xsel' returned non-zero exit status -15
  File "/usr/lib/python3.6/site-packages/py3status/module.py", line 584, in run
    response = method()
  File "/home/chris/src/py3status/py3status/modules/xsel.py", line 38, in xsel
    output = self.py3.command_output(self.command)
  File "/usr/lib/python3.6/site-packages/py3status/py3.py", line 699, in command_output
    raise Exception(msg.format(cmd=command[0], error=retcode))

2017-01-14 13:23:14 ERROR py3status: Instance `xsel`, user method `xsel` failed (Exception) py3.py line 699. Please try to fix this and reload i3wm (Mod+Shift+R)
```
You mentioned `self.py3.command_output`. It's there.

This currently works, but is ugly/broken sometimes.