### PR TITLE
remove i3-py dependencies

### DIFF
--- a/py3status/modules/scratchpad_counter.py
+++ b/py3status/modules/scratchpad_counter.py
@@ -14,7 +14,7 @@ Format placeholders:
 @license Eclipse Public License
 """
 
-import i3
+from json import loads
 
 
 def find_scratch(tree):
@@ -25,7 +25,7 @@ def find_scratch(tree):
             result = find_scratch(x)
             if result:
                 return result
-        return None
+        return {}
 
 
 class Py3status:
@@ -51,7 +51,8 @@ class Py3status:
         self.count = -1
 
     def scratchpad_counter(self):
-        count = len(find_scratch(i3.get_tree()).get("floating_nodes", []))
+        tree = loads(self.py3.command_output('i3-msg -t get_tree'))
+        count = len(find_scratch(tree).get("floating_nodes", []))
 
         if self.count != count:
             transformed = True

--- a/py3status/modules/window_title.py
+++ b/py3status/modules/window_title.py
@@ -8,20 +8,11 @@ Configuration parameters:
     max_width: If width of title is greater, shrink it and add '...'
         (default 120)
 
-Requires:
-    i3-py: (https://github.com/ziberna/i3-py)
-        `pip install i3-py`
-
-If payload from server contains wierd utf-8
-(for example one window have something bad in title) - the plugin will
-give empty output UNTIL this window is closed.
-I can't fix or workaround that in PLUGIN, problem is in i3-py library.
-
 @author shadowprince
 @license Eclipse Public License
 """
 
-import i3
+from json import loads
 
 
 def find_focused(tree):
@@ -35,6 +26,7 @@ def find_focused(tree):
             return tree
         else:
             return find_focused(tree['nodes'] + tree['floating_nodes'])
+    return ''
 
 
 class Py3status:
@@ -49,7 +41,8 @@ class Py3status:
         self.title = ''
 
     def window_title(self):
-        window = find_focused(i3.get_tree())
+        tree = loads(self.py3.command_output('i3-msg -t get_tree'))
+        window = find_focused(tree)
 
         transformed = False
         if window and 'name' in window and window['name'] != self.title:


### PR DESCRIPTION
#620 and #622 revealed some bugs in `window_title` and `scratchpad_counter`

the bugs were the searching functions returning None and i3-py unicode issues.

As i3-py is broken/unmaintained and we only use it to get the tree we can just remove it and use `i3-msg -t get_tree`