### PR TITLE
frame: fix possible race

### DIFF
--- a/py3status/modules/frame.py
+++ b/py3status/modules/frame.py
@@ -99,7 +99,9 @@ class Py3status:
                     if out and 'separator' not in out[-1]:
                         # we copy the item as we do not want to change the
                         # original.
-                        out[-1] = out[-1].copy()['separator'] = True
+                        last_item = out[-1].copy()
+                        last_item['separator'] = True
+                        out[-1] = last_item
                 else:
                     if self.format_separator:
                         out += [{'full_text': self.format_separator}]


### PR DESCRIPTION
I was getting an occasional error.  I think it was some sort of race in that horrible looking line.  Anyhow this seems to fix it and looks nicer.

```
2017-01-16 15:46:38 WARNING Instance `frame time`, user method `frame` failed (AttributeError) frame.py line 105.
2017-01-16 15:46:38 INFO Traceback
AttributeError: 'bool' object has no attribute 'copy'
  File "/home/toby/dev/py3status/py3status/module.py", line 584, in run
    response = method()
  File "/home/toby/dev/py3status/py3status/modules/frame.py", line 105, in frame
    out[-1] = out[-1].copy()['separator'] = True
```