### PR TITLE
nicer exceptions on cli-commands

### DIFF
--- a/py3status/__init__.py
+++ b/py3status/__init__.py
@@ -32,12 +32,12 @@ def main():
         if py3:
             py3.notify_user('Setup interrupted')
         sys.exit(0)
-    except Exception as e:
-        if py3:
+    except Exception:
+        if py3 and not py3.config.get('cli_command'):
             py3.report_exception('Setup error')
         else:
             # we cannot report this Exception
-            raise e
+            raise
         sys.exit(2)
 
     try:


### PR DESCRIPTION
When running py3status command line stuff eg `py3status modules list` if there is an exception then it is reported via the nagbar etc.  As running these commands only makes sense from the cli it is better to just show the traceback.

This shouldn't affect users but is a major help in development.