### PR TITLE
sysdata: cpu temp no zone bugfix

### DIFF
--- a/py3status/modules/sysdata.py
+++ b/py3status/modules/sysdata.py
@@ -134,6 +134,7 @@ class GetData:
         out temperatures of all codes if more than one.
         """
 
+        sensors = None
         command = ['sensors']
         if unit == u'°F':
             command.append('-f')
@@ -143,7 +144,7 @@ class GetData:
             try:
                 sensors = self.py3.command_output(command + [zone])
             except:
-                sensors = None
+                pass
         if not sensors:
             sensors = self.py3.command_output(command)
         m = re.search("(Core 0|CPU Temp).+\+(.+).+\(.+", sensors)


### PR DESCRIPTION
Found a bug in sysdata whilst testing #679 

```
2017-01-20 13:22:53 WARNING Instance `sysdata`, user method `sysData` failed (UnboundLocalError) sysdata.py line 147.
2017-01-20 13:22:53 INFO Traceback
UnboundLocalError: local variable 'sensors' referenced before assignment
  File "/home/toby/dev/py3status/py3status/module.py", line 584, in run
    response = method()
  File "/home/toby/dev/py3status/py3status/modules/sysdata.py", line 270, in sysData
    cpu_temp = self.data.cpuTemp(self.zone, self.temp_unit)
  File "/home/toby/dev/py3status/py3status/modules/sysdata.py", line 147, in cpuTemp
    if not sensors:
```