### PR TITLE
screenshot: add format, use helpers

### DIFF
--- a/py3status/modules/screenshot.py
+++ b/py3status/modules/screenshot.py
@@ -12,6 +12,8 @@ but this can be configured with the `screenshot_command` configuration parameter
 Configuration parameters:
     cache_timeout: how often to update in seconds (default 5)
     file_length: generated file_name length (default 4)
+    format: format to display (default 'SHOT')
+    format_screenshot: format to display (default '{filename}')
     push: True/False if you want to push your screenshot to your server
         (default True)
     save_path: Directory where to store your screenshots. (default '~/Pictures/')
@@ -20,6 +22,9 @@ Configuration parameters:
     upload_path: the remote path where to push the screenshot (default '/files')
     upload_server: your server address (default 'puzzledge.org')
     upload_user: your ssh user (default 'erol')
+
+format_screenshot placeholder:
+    {filename} randomized filename
 
 Color options:
     color_good: Displayed color
@@ -38,6 +43,8 @@ class Py3status:
     # available configuration parameters
     cache_timeout = 5
     file_length = 4
+    format = 'SHOT'
+    format_screenshot = '{filename}'
     push = True
     save_path = '%s%s' % (os.environ['HOME'], '/Pictures/')
     screenshot_command = 'gnome-screenshot -f'
@@ -58,6 +65,8 @@ class Py3status:
         subprocess.Popen(command.split())
 
         self.full_text = '%s%s' % (file_name, '.jpg')
+        self.full_text = self.py3.safe_format(self.format_screenshot,
+                                              {'filename': self.full_text})
 
         if (self.push and self.upload_server and self.upload_user and
                 self.upload_path):
@@ -73,14 +82,13 @@ class Py3status:
 
     def screenshot(self):
         if self.full_text == '':
-            self.full_text = 'SHOT'
+            self.full_text = self.format
 
-        response = {
+        return {
             'cached_until': self.py3.time_in(self.cache_timeout),
             'color': self.py3.COLOR_GOOD,
             'full_text': self.full_text
         }
-        return response
 
 
 if __name__ == "__main__":

--- a/py3status/modules/screenshot.py
+++ b/py3status/modules/screenshot.py
@@ -34,7 +34,6 @@ Color options:
 import os
 import random
 import string
-import subprocess
 
 
 class Py3status:
@@ -62,7 +61,7 @@ class Py3status:
         command = '%s %s/%s%s' % (self.screenshot_command, self.save_path,
                                   file_name, '.jpg')
 
-        subprocess.Popen(command.split())
+        self.py3.command_run(command.split())
 
         self.full_text = '%s%s' % (file_name, '.jpg')
         self.full_text = self.py3.safe_format(self.format_screenshot,
@@ -73,7 +72,7 @@ class Py3status:
             command = 'scp %s/%s%s %s@%s:%s' % (
                 self.save_path, file_name, '.jpg', self.upload_user,
                 self.upload_server, self.upload_path)
-            subprocess.Popen(command.split())
+            self.py3.command_run(command.split())
 
     def _filename_generator(self,
                             size=6,


### PR DESCRIPTION
I separate one-shot PR. Nothing changes. Hold for pending discussion on strings https://github.com/ultrabug/py3status/issues/660.

This is for format alone. Module enhancement will stay in original PR https://github.com/ultrabug/py3status/pull/642. 

    This adds format: // (default 'SHOT')
    This adds format_ss: // (default '{filename}')

EDIT: For what it's worth... The above code is technically wrong / ugly / not fully customizable. We could make do without `format_ss`, but will "break" how it usually looks after taking a screenshot. To show you this better...

Current: `SHOT` --> `tobes.jpg`  // (totally randomized filename).
New: `SHOT` --> `tobes.jpg SHOT` // Without `format_ss`, we get this. Meh.
PR2: `📷` --> `tobes.jpg 📷`   // Module enhancement PR.

EDIT: Will leave this alone. Fix should belong in module enhancement PR anyway.

Ongoing efforts to FORMAT ALL THE THINGS! (meme). #98