### PR TITLE
Add ability to set i3-nagbar font

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -7,7 +7,7 @@ py3status documentation
 * [Available modules](#available_modules)
 * [Ordering modules](#ordering_modules)
 * [Configuring modules](#configuring_modules)
-* [Py3status configuration](#py3status_section)
+* [Py3status configuration section](#py3status_section)
 * [Configuration obfuscation](#obfuscation)
 * [Configuring colors](#configuring_color)
 * [Configuring thresholds](#configuring_thresholds)
@@ -95,8 +95,7 @@ imap {
 }
 ```
 
-#### <a name="py3status_section"></a>py3status config section
-##### i3-nagbar font
+#### <a name="py3status_section"></a>py3status configuration section
 This special section holds py3status specific configuration. As of now, the
 only possible key is 'nagbar_font'. Example usage:
 ```

--- a/doc/README.md
+++ b/doc/README.md
@@ -97,7 +97,8 @@ imap {
 
 #### <a name="py3status_section"></a>py3status configuration section
 This special section holds py3status specific configuration. As of now, the
-only possible key is 'nagbar_font'. Example usage:
+only possible key is 'nagbar_font'. It will be used as an argument to
+i3-nagbar -f, thus setting its font. Example usage:
 ```
 py3status {
     nagbar_font = 'pango:Ubuntu Mono 12'

--- a/doc/README.md
+++ b/doc/README.md
@@ -94,6 +94,16 @@ imap {
 }
 ```
 
+#### <a name="nagbar-font"></a>i3-nagbar font
+
+The config file allows you to adjust the font used for calls to i3-nagbar. Use
+the special section 'py3status' to set it:
+```
+py3status {
+    nagbar_font = 'pango:Ubuntu Mono 12'
+}
+```
+
 #### <a name="obfuscation"></a>Configuration obfuscation
 
 __New in version 3.1__

--- a/doc/README.md
+++ b/doc/README.md
@@ -94,10 +94,10 @@ imap {
 }
 ```
 
-#### <a name="nagbar-font"></a>i3-nagbar font
-
-The config file allows you to adjust the font used for calls to i3-nagbar. Use
-the special section 'py3status' to set it:
+#### <a name="py3status_section"></a>py3status config section
+##### i3-nagbar font
+This special section holds py3status specific configuration. As of now, the
+only possible key is 'nagbar_font'. Example usage:
 ```
 py3status {
     nagbar_font = 'pango:Ubuntu Mono 12'

--- a/doc/README.md
+++ b/doc/README.md
@@ -98,7 +98,7 @@ imap {
 #### <a name="py3status_section"></a>py3status configuration section
 This special section holds py3status specific configuration. As of now, the
 only possible key is 'nagbar_font'. It will be used as an argument to
-i3-nagbar -f, thus setting its font. Example usage:
+`i3-nagbar -f`, thus setting its font. Example usage:
 ```
 py3status {
     nagbar_font = 'pango:Ubuntu Mono 12'

--- a/doc/README.md
+++ b/doc/README.md
@@ -7,6 +7,7 @@ py3status documentation
 * [Available modules](#available_modules)
 * [Ordering modules](#ordering_modules)
 * [Configuring modules](#configuring_modules)
+* [Py3status configuration](#py3status_section)
 * [Configuration obfuscation](#obfuscation)
 * [Configuring colors](#configuring_color)
 * [Configuring thresholds](#configuring_thresholds)

--- a/py3status/core.py
+++ b/py3status/core.py
@@ -32,6 +32,7 @@ DBUS_LEVELS = {'error': 'critical', 'warning': 'normal', 'info': 'low', }
 CONFIG_SPECIAL_SECTIONS = [
     '.group_extras',
     '.module_groups',
+    'custom'
     'general',
     'i3s_modules',
     'on_click',
@@ -408,7 +409,12 @@ class Py3statusWrapper():
                 cmd = ['notify-send', '-u', DBUS_LEVELS.get(level, 'normal'),
                        '-t', '10000', 'py3status', msg]
             else:
-                cmd = ['i3-nagbar', '-m', msg, '-t', level]
+                config = self.i3status_thread.config
+                nagbar_font = config.get('custom').get('nagbar_font')
+                if nagbar_font:
+                    cmd = ['i3-nagbar', '-f', nagbar_font, '-m', msg, '-t', level]
+                else:
+                    cmd = ['i3-nagbar', '-m', msg, '-t', level]
             Popen(cmd,
                   stdout=open('/dev/null', 'w'),
                   stderr=open('/dev/null', 'w'))

--- a/py3status/core.py
+++ b/py3status/core.py
@@ -32,12 +32,12 @@ DBUS_LEVELS = {'error': 'critical', 'warning': 'normal', 'info': 'low', }
 CONFIG_SPECIAL_SECTIONS = [
     '.group_extras',
     '.module_groups',
-    'custom'
     'general',
     'i3s_modules',
     'on_click',
     'order',
     'py3_modules',
+    'py3status',
 ]
 
 
@@ -410,7 +410,7 @@ class Py3statusWrapper():
                        '-t', '10000', 'py3status', msg]
             else:
                 config = self.i3status_thread.config
-                nagbar_font = config.get('custom').get('nagbar_font')
+                nagbar_font = config.get('py3status').get('nagbar_font')
                 if nagbar_font:
                     cmd = ['i3-nagbar', '-f', nagbar_font, '-m', msg, '-t', level]
                 else:

--- a/py3status/parse_config.py
+++ b/py3status/parse_config.py
@@ -563,8 +563,7 @@ def process_config(config_path, py3_wrapper=None):
         general_defaults.update(config_info['general'])
     config['general'] = general_defaults
 
-    if 'py3status' in config_info:
-        config['py3status'] = config_info['py3status']
+    config['py3status'] = config_info.get('py3status', {})
     modules = {}
     on_click = {}
     i3s_modules = []

--- a/py3status/parse_config.py
+++ b/py3status/parse_config.py
@@ -563,8 +563,8 @@ def process_config(config_path, py3_wrapper=None):
         general_defaults.update(config_info['general'])
     config['general'] = general_defaults
 
-    if 'custom' in config_info:
-        config['custom'] = config_info['custom']
+    if 'py3status' in config_info:
+        config['py3status'] = config_info['py3status']
     modules = {}
     on_click = {}
     i3s_modules = []

--- a/py3status/parse_config.py
+++ b/py3status/parse_config.py
@@ -563,6 +563,8 @@ def process_config(config_path, py3_wrapper=None):
         general_defaults.update(config_info['general'])
     config['general'] = general_defaults
 
+    if 'custom' in config_info:
+        config['custom'] = config_info['custom']
     modules = {}
     on_click = {}
     i3s_modules = []


### PR DESCRIPTION
This is a proposal to resolve issue #665.

A section named 'custom' has been added as a valid py3status configuration section. If it contains a key named 'nagbar_font', its value will be used as an argument to the i3-nagbar -f option.