### PR TITLE
Allow modules with multiple files inside folders

### DIFF
--- a/py3status/docstrings.py
+++ b/py3status/docstrings.py
@@ -3,6 +3,7 @@ import ast
 import re
 import os.path
 import difflib
+from glob import glob
 
 from py3status.helpers import print_stderr
 
@@ -52,6 +53,8 @@ def core_module_docstrings(include_core=True, include_user=False, config=None):
                 if name != '__init__':
                     paths[name] = (os.path.join(modules_directory(), file),
                                    'core')
+        for fl in glob(os.path.join(modules_directory(), '*', '__init__.py')):
+            paths[os.path.basename(os.path.dirname(fl))] = (fl, 'core')
 
     if include_user:
         # include user modules

--- a/py3status/parse_config.py
+++ b/py3status/parse_config.py
@@ -522,6 +522,8 @@ def process_config(config_path, py3_wrapper=None):
         module_path = os.path.join(root, 'modules', '*.py')
         for file in glob.glob(module_path):
             modules.append(os.path.basename(file)[:-3])
+        for fl in glob.glob(os.path.join(root, 'modules', '*', '__init__.py')):
+            modules.append(os.path.basename(os.path.dirname(fl)))
 
         # FIXME we can do this better
         if py3_wrapper:


### PR DESCRIPTION
With a few changes it is possible to have modules inside subfolders allowing multiple files in this subfolder. Docstrings are working. Is a feature like this desired? An example module can be found in the refactor-simple-pomodoro branch in my fork.