### PR TITLE
bluetooth: use helpers

### DIFF
--- a/py3status/modules/bluetooth.py
+++ b/py3status/modules/bluetooth.py
@@ -28,10 +28,6 @@ Requires:
 """
 
 import re
-import shlex
-
-from subprocess import check_output
-
 BTMAC_RE = re.compile(r'[0-9A-F:]{17}')
 
 
@@ -51,17 +47,16 @@ class Py3status:
         The whole command:
         hcitool name `hcitool con | sed -n -r 's/.*([0-9A-F:]{17}).*/\\1/p'`
         """
-        out = check_output(shlex.split('hcitool con'))
-        macs = set(re.findall(BTMAC_RE, out.decode('utf-8')))
+        macs = set(BTMAC_RE.findall(self.py3.command_output('hcitool con')))
         color = self.py3.COLOR_BAD
 
         if macs:
             data = []
             for mac in macs:
-                out = check_output(shlex.split('hcitool name %s' % mac))
+                name = self.py3.command_output('hcitool name %s' % mac).strip()
                 fmt_str = self.py3.safe_format(
                     self.format,
-                    {'name': out.strip().decode('utf-8'), 'mac': mac}
+                    {'name': name, 'mac': mac}
                 )
                 data.append(fmt_str)
 


### PR DESCRIPTION
Uses `self.py3.command_output()`

I have a module enhancement ready too. Not part of this PR.
It would get rid of two formats at least... similar to nvidia_gpu and adds an on_click
to toggle visibility for `format_bt` only...

Nice if we use BT icon instead of `BT`, but not friendly. People will have to set it themselves if they want to. green ` Microsoft Bluetooth Notebook Mouse 5000` --> green ``

~~Thinking about adding~~ Added option to hide the `format_bt` by default so people don't have to click it everyday as green `BT` is usually more than enough if we are only using one device.
```
-    format: format when there is a connected device (default '{name}')
-    format_no_conn: format when there is no connected device (default 'OFF')
-    format_no_conn_prefix: prefix when there is no connected device (default 'BT ')
-    format_prefix: prefix when there is a connected device (default 'BT ')
+    format: display format for this module (default 'BT {format_bt}')
+    format_bt: display format for this placeholder (default '{name}')
+    string_unavailable: display unavailable (default 'BT: N/A')
```
Anyway, this PR is simple... Uses helpers. It should be ready.