### PR TITLE
vnstat: use helpers, add exception, cleanup

### DIFF
--- a/py3status/modules/vnstat.py
+++ b/py3status/modules/vnstat.py
@@ -3,27 +3,28 @@
 Display vnstat statistics.
 
 Configuration parameters:
-    cache_timeout: (default 180)
-    coloring: (default {})
-    format: (default '{total}')
-    initial_multi: (default 1024)
+    cache_timeout: refresh interval for this module (default 180)
+    coloring: see coloring rules below (default {})
+    format: display format for this module (default '{total}')
+    initial_multi: set to 1 to disable first bytes
+        (default 1024)
     left_align: (default 0)
-    multiplier_top: (default 1024)
+    multiplier_top: if value is greater, divide it with unit_multi and get
+        next unit from units (default 1024)
     precision: (default 1)
-    statistics_type: (default 'd')
-    unit_multi: (default 1024)
+    statistics_type: d for daily, m for monthly (default 'd')
+    unit_multi: value to divide if rate is greater than multiplier_top
+        (default 1024)
 
-Coloring rules.
-
-If value is bigger that dict key, status string will turn to color, specified
-in the value.
+Coloring rules:
+    If value is more than dict key, the string will change color based on the
+    specified values in the coloring section.
 
 Example:
-        coloring = {
-        800: "#dddd00",
-        900: "#dd0000",
-        }
-        (0 - 800: white, 800-900: yellow, >900 - red)
+    coloring = {
+        800: "#dddd00",     # over 800: yellow
+        900: "#dd0000",     # over 900: red
+    }
 
 Format placeholders:
     {down} download
@@ -31,44 +32,15 @@ Format placeholders:
     {up} upload
 
 Requires:
-    - external program called `vnstat` installed and configured to work.
+    vnstat: a console-based network traffic monitor
 
 @author shadowprince
 @license Eclipse Public License
 """
 
 from __future__ import division  # python2 compatibility
-from subprocess import check_output
-
-
-def get_stat(statistics_type):
-    """
-    Get statistics from devfile in list of lists of words
-    """
-    def filter_stat():
-        out = check_output(["vnstat", "--dumpdb"]).decode("utf-8").splitlines()
-        for x in out:
-            if x.startswith("{};0;".format(statistics_type)):
-                return x
-
-    try:
-        type, number, ts, rxm, txm, rxk, txk, fill = filter_stat().split(";")
-    except OSError as e:
-        print("Looks like you haven't installed or configured vnstat!")
-        raise e
-    except ValueError:
-        err = "vnstat returned wrong output, "
-        err += "maybe it's configured wrong or module is outdated"
-        raise RuntimeError(err)
-
-    up = (int(txm) * 1024 + int(txk)) * 1024
-    down = (int(rxm) * 1024 + int(rxk)) * 1024
-
-    return {
-        "up": up,
-        "down": down,
-        "total": up + down
-    }
+STRING_ERROR = 'vnstat: returned wrong'
+STRING_UNAVAILABLE = "vnstat: isn't installed"
 
 
 class Py3status:
@@ -78,18 +50,14 @@ class Py3status:
     cache_timeout = 180
     coloring = {}
     format = "{total}"
-    # initial multiplier, if you want to get rid of first bytes, set to 1 to
-    # disable
     initial_multi = 1024
     left_align = 0
-    # if value is greater, divide it with unit_multi and get next unit from
-    # units
     multiplier_top = 1024
     precision = 1
-    statistics_type = "d"  # d for daily, m for monthly
-    unit_multi = 1024  # value to divide if rate is greater than multiplier_top
+    statistics_type = "d"
+    unit_multi = 1024
 
-    def __init__(self, *args, **kwargs):
+    def post_config_hook(self):
         """
         Format of total, up and down placeholders under FORMAT.
         As default, substitutes left_align and precision as %s and %s
@@ -97,51 +65,63 @@ class Py3status:
             value - value (float)
             unit - unit (string)
         """
-        self.value_format = "{value:%s.%sf} {unit}" % (
-            self.left_align, self.precision
-        )
+        self.value_format = "{value:%s.%sf} {unit}" % (self.left_align, self.precision)
         # list of units, first one - value/initial_multi, second - value/1024,
         # third - value/1024^2, etc...
         self.units = ["kb", "mb", "gb", "tb", ]
 
     def _divide_and_format(self, value):
-        """
-        Divide a value and return formatted string
-        """
+        # Divide a value and return formatted string
         value /= self.initial_multi
         for i, unit in enumerate(self.units):
             if value > self.multiplier_top:
                 value /= self.unit_multi
             else:
                 break
-
         return self.value_format.format(value=value, unit=unit)
 
-    def currentSpeed(self):
-        stat = get_stat(self.statistics_type)
+    def vntstat(self):
+        if not self.py3.check_commands(["vnstat"]):
+            return {
+                'cached_until': self.py3.CACHE_FOREVER,
+                'color': self.py3.COLOR_BAD,
+                'full_text': STRING_UNAVAILABLE
+            }
 
-        color = None
+        def filter_stat():
+            # Get statistics in list of lists of words
+            out = self.py3.command_output(["vnstat", "--dumpdb"]).splitlines()
+            for x in out:
+                if x.startswith("{};0;".format(self.statistics_type)):
+                    return x
+        try:
+            type, number, ts, rxm, txm, rxk, txk, fill = filter_stat().split(";")
+        except:
+            return {
+                'cached_until': self.py3.time_in(self.cache_timeout),
+                'color': self.py3.COLOR_BAD,
+                'full_text': STRING_ERROR
+            }
+
+        response = {'cached_until': self.py3.time_in(self.cache_timeout)}
+
+        up = (int(txm) * 1024 + int(txk)) * 1024
+        down = (int(rxm) * 1024 + int(rxk)) * 1024
+        stat = {"up": up, "down": down, "total": up + down}
+
         keys = list(self.coloring.keys())
         keys.sort()
         for k in keys:
             if stat["total"] < k * 1024 * 1024:
                 break
             else:
-                color = self.coloring[k]
+                response['color'] = self.coloring[k]
 
-        response = {
-            'cached_until': self.py3.time_in(self.cache_timeout),
-            'full_text': self.py3.safe_format(
-                self.format,
-                dict(total=self._divide_and_format(stat['total']),
-                     up=self._divide_and_format(stat['up']),
-                     down=self._divide_and_format(stat['down'])),
-            ),
-        }
-
-        if color:
-            response["color"] = color
-
+        response['full_text'] = self.py3.safe_format(
+            self.format,
+            dict(total=self._divide_and_format(stat['total']),
+                 up=self._divide_and_format(stat['up']),
+                 down=self._divide_and_format(stat['down'])))
         return response
 
 


### PR DESCRIPTION
Uses `self.py3.command_output()`.

I notice that I can't use `self.py3.command_output()` outside of class Py3status. I put the function inside... since it's the only one thing that's calling that function. If it's possible to use `self.py3.command_output()` outside, please let me know... There are few other modules that are like this. Python2and3 tested OK.

Closes https://github.com/ultrabug/py3status/issues/720. 