### PR TITLE
bluetooth: fix format

### DIFF
--- a/py3status/modules/bluetooth.py
+++ b/py3status/modules/bluetooth.py
@@ -3,22 +3,21 @@
 Display bluetooth status.
 
 Configuration parameters:
-    cache_timeout: how often we refresh this module in seconds (default 10)
-    device_separator: the separator char between devices (only if more than one
-        device) (default '|')
-    format: format when there is a connected device (default '{name}')
-    format_no_conn: format when there is no connected device (default 'OFF')
-    format_no_conn_prefix: prefix when there is no connected device
-        (default 'BT: ')
-    format_prefix: prefix when there is a connected device (default 'BT: ')
+    cache_timeout: refresh interval for this module (default 10)
+    device_separator: show separator only if more than one (default '|')
+    format: display format for this module (default 'BT[: {format_device}]')
+    format_device: display format for bluetooth devices (default '{name}')
 
 Format placeholders:
-    {name} device name
-    {mac} device MAC address
+    {format_device} format for bluetooth devices
+
+format_device placeholders:
+    {mac} bluetooth device address
+    {name} bluetooth device name
 
 Color options:
-    color_bad: Connection on
-    color_good: Connection off
+    color_bad: No connection
+    color_good: Active connection
 
 @author jmdana <https://github.com/jmdana>
 @license GPLv3 <http://www.gnu.org/licenses/gpl-3.0.txt>
@@ -29,14 +28,12 @@ import dbus
 
 def get_connected_devices():
     bus = dbus.SystemBus()
-
     manager = dbus.Interface(
         bus.get_object("org.bluez", "/"),
         "org.freedesktop.DBus.ObjectManager"
     )
 
     objects = manager.GetManagedObjects()
-
     devices = []
 
     for dev_path, interfaces in objects.items():
@@ -55,46 +52,39 @@ class Py3status:
     # available configuration parameters
     cache_timeout = 10
     device_separator = '|'
-    format = '{name}'
-    format_no_conn = 'OFF'
-    format_no_conn_prefix = 'BT: '
-    format_prefix = 'BT: '
+    format = 'BT[: {format_device}]'
+    format_device = '{name}'
+
+    class Meta:
+        def deprecate_function(config):
+            out = {}
+            if 'format_prefix' in config:
+                out['format'] = u'{}{{format_device}}'.format(config['format_prefix'])
+            return out
+        deprecated = {
+            'function': [
+                {'function': deprecate_function},
+            ],
+        }
 
     def bluetooth(self):
-        color = self.py3.COLOR_BAD
-
         devices = get_connected_devices()
 
         if devices:
             data = []
             for mac, name in devices:
-                fmt_str = self.py3.safe_format(
-                    self.format,
-                    {'name': name, 'mac': mac}
-                )
-                data.append(fmt_str)
-
-            output = self.py3.safe_format(
-                '{format_prefix}{data}',
-                {'format_prefix': self.format_prefix,
-                 'data': self.device_separator.join(data)}
-            )
-
+                data.append(self.py3.safe_format(self.format_device, {'name': name, 'mac': mac}))
+            full_text = self.py3.composite_join(self.device_separator, data)
             color = self.py3.COLOR_GOOD
         else:
-            output = self.py3.safe_format(
-                '{format_prefix}{format}',
-                dict(format_prefix=self.format_no_conn_prefix,
-                     format=self.format_no_conn)
-            )
+            full_text = None
+            color = self.py3.COLOR_BAD
 
-        response = {
+        return {
             'cached_until': self.py3.time_in(self.cache_timeout),
-            'full_text': output,
+            'full_text': self.py3.safe_format(self.format, {'format_device': full_text}),
             'color': color,
         }
-
-        return response
 
 
 if __name__ == "__main__":

--- a/py3status/modules/bluetooth.py
+++ b/py3status/modules/bluetooth.py
@@ -26,6 +26,7 @@ Color options:
 import dbus
 
 DEFAULT_FORMAT = 'BT[: {format_device}]'
+STRING_NOT_STARTED = "service isn't running"
 
 
 def get_connected_devices():
@@ -91,7 +92,10 @@ class Py3status:
             self.py3.log(msg)
 
     def bluetooth(self):
-        devices = get_connected_devices()
+        try:
+            devices = get_connected_devices()
+        except dbus.DBusException:
+            self.py3.error(STRING_NOT_STARTED)
 
         if devices:
             data = []


### PR DESCRIPTION
**FORMAT**
```
OLD                    |  NEW
-----------------------|-----------------------
format                 |  format 
format_prefix          |  format_device
format_no_conn         | 
format_no_conn_prefix  |
```
Fixes oops in color options.

~~Deprecates `device_separator` in favor of `string_separator`. Ya I know. Discussion first.~~
* Add _NEW! device_ <-- FUUUUU! (device_separator in bluetooth) to that list too.

**MODULE ENHANCEMENT**

I used `Microsoft Bluetooth Notebook Mouse 5000` F----- long! I fix this now...

button_toggle: mouse button to toggle visibility
* `BT: Microsoft Bluetooth Notebook Mouse 5000` --> `BT` (toggleable, icon_collapse)

always_collapse
* `BT: Microsoft Bluetooth Notebook Mouse 5000` --> `BT` (toggleable, icon_collapse)

~~**DEFAULT**~~

~~Bluetooth symbol. `font-awesome` now a hard dependency. Pretty please.~~
~~We can put `py3status` on the moon! I will put `BT:` back in after reviews...~~

~~**EDIT: EXCEPTION**~~
~~*Adds something to take care of missing `not-installed` binary.~~