### PR TITLE
sysdata: avoid dividing by 0

### DIFF
--- a/py3status/modules/sysdata.py
+++ b/py3status/modules/sysdata.py
@@ -291,9 +291,11 @@ class Py3status:
         # get CPU usage info
         if self.py3.format_contains(self.format, 'cpu_usage'):
             cpu_total, cpu_idle = self.data.cpu()
-            cpu_usage = (1 - (
-                float(cpu_idle - self.cpu_idle) / float(cpu_total - self.cpu_total)
-            )) * 100
+            cpu_usage = 0
+            if cpu_total != self.cpu_total:
+                cpu_usage = (1 - (
+                    float(cpu_idle - self.cpu_idle) / float(cpu_total - self.cpu_total)
+                )) * 100
             self.values['cpu_usage'] = cpu_usage
             self.cpu_total = cpu_total
             self.cpu_idle = cpu_idle


### PR DESCRIPTION
Fixes #684
If cpu_total hasn't changed over the course of one tick, then no work
has been done, so set cpu_usage to 0.