### PR TITLE
frame: use helpers

### DIFF
--- a/py3status/modules/frame.py
+++ b/py3status/modules/frame.py
@@ -111,7 +111,7 @@ class Py3status:
             if self.format_separator:
                 output = output[:-1]
 
-        if '{button}' in self.format:
+        if self.py3.format_contains(self.format, 'button'):
             if self.open:
                 format_control = self.format_button_open
             else:


### PR DESCRIPTION
Uses `self.py3.format_contains(self.format, 'lemon')` Hassle-free PR. :lemon: ~~Untested.~~