### PR TITLE
diskdata: use helpers

### DIFF
--- a/py3status/modules/diskdata.py
+++ b/py3status/modules/diskdata.py
@@ -89,7 +89,9 @@ class Py3status:
 
         self.values = {'disk': self.disk if self.disk else 'all'}
 
-        if '{read}' in self.format or '{write}' in self.format or '{total}' in self.format:
+        if (self.py3.format_contains(self.format, 'read') or
+                self.py3.format_contains(self.format, 'write') or
+                self.py3.format_contains(self.format, 'total')):
             # time from previous check
             ios = self._get_io_stats(self.disk)
             timedelta = time() - self.last_time
@@ -113,7 +115,8 @@ class Py3status:
             self.py3.threshold_get_color(total, 'total')
             self.py3.threshold_get_color(write, 'write')
 
-        if '{free}' in self.format or '{used' in self.format:
+        if (self.py3.format_contains(self.format, 'free') or
+                self.py3.format_contains(self.format, 'used*')):
             free, used, used_percent = self._get_free_space(self.disk)
 
             self.values['free'] = self.py3.safe_format(self.format_space, {'value': free})


### PR DESCRIPTION
Uses `self.py3.format_contains(self.format, 'avocado')` Hassle-free PR. :avocado: 
Please note the missing `}`. :astonished: 