### PR TITLE
allow check_commands() to take a string

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -1080,6 +1080,8 @@ __check_commands(cmd_list)__
 Checks to see if the shell commands in list are available using `which`.
 Returns the first available command.
 
+If a string is passed then that command will be checked for.
+
 __command_run(command)__
 
 Runs a command and returns the exit code.

--- a/py3status/py3.py
+++ b/py3status/py3.py
@@ -651,7 +651,14 @@ class Py3:
         """
         Checks to see if commands in list are available using `which`.
         Returns the first available command.
+
+        If a string is passed then that command will be checked for.
         """
+        # if a string is passed then convert it to a list.  This prevents an
+        # easy mistake that could be made
+        if isinstance(cmd_list, basestring):
+            cmd_list = [cmd_list]
+
         for cmd in cmd_list:
             if self.command_run('which {}'.format(cmd)) == 0:
                 return cmd


### PR DESCRIPTION
`py3.check_commands()` takes a list of commands.  It is easy to pass a string instead.  this PR allows us to pass a string and it will be treated as expected.  It also makes it cleaner to just check for a single command.

`py3.check_commands(['foo'])` ->  `py3.check_commands('foo')`