### PR TITLE
Show import or post_config_hook errors in i3bar

### DIFF
--- a/py3status/core.py
+++ b/py3status/core.py
@@ -493,6 +493,21 @@ class Py3statusWrapper():
         """
         raise KeyboardInterrupt()
 
+    def purge_module(self, module_name):
+        """
+        A module has been removed e.g. a module that had an error.
+        We need to find any containers and remove the module from them.
+        """
+        containers = self.config['py3_config']['.module_groups']
+        containers_to_update = set()
+        if module_name in containers:
+            containers_to_update.update(set(containers[module_name]))
+        for container in containers_to_update:
+            try:
+                self.modules[container].module_class.items.remove(module_name)
+            except ValueError:
+                pass
+
     def notify_update(self, update, urgent=False):
         """
         Name or list of names of modules that have updated.

--- a/py3status/events.py
+++ b/py3status/events.py
@@ -161,9 +161,8 @@ class Events(Thread):
         if not module_info:
             return
         module = module_info['module']
-        # if module is a py3status one and it has an on_click function then
-        # call it.
-        if module_info['type'] == 'py3status' and module.click_events:
+        # if module is a py3status one call it.
+        if module_info['type'] == 'py3status':
             module.click_event(event)
             if self.config['debug']:
                 self.py3_wrapper.log('dispatching event {}'.format(event))

--- a/py3status/events.py
+++ b/py3status/events.py
@@ -141,9 +141,17 @@ class Events(Thread):
         """
         button = event.get('button', 0)
         default_event = False
+
+        # get the module that the event is for
+        module_info = self.output_modules.get(module_name)
+        if not module_info:
+            return
+        module = module_info['module']
+
         # execute any configured i3-msg command
         # we do not do this for containers
-        if top_level:
+        # modules that have failed do not execute their config on_click
+        if top_level and not module.error_messages:
             click_module = event['name']
             if event['instance']:
                 click_module += ' ' + event['instance']
@@ -156,11 +164,6 @@ class Events(Thread):
             elif button == 2:
                 default_event = True
 
-        # get the module that the event is for
-        module_info = self.output_modules.get(module_name)
-        if not module_info:
-            return
-        module = module_info['module']
         # if module is a py3status one call it.
         if module_info['type'] == 'py3status':
             module.click_event(event)

--- a/py3status/module.py
+++ b/py3status/module.py
@@ -31,6 +31,7 @@ class Module(Thread):
         self.click_events = False
         self.config = py3_wrapper.config
         self.disabled = False
+        self.error_messages = None
         self.has_post_config_hook = False
         self.has_kill = False
         self.i3status_thread = py3_wrapper.i3status_thread
@@ -45,6 +46,7 @@ class Module(Thread):
         self.nagged = False
         self.prevent_refresh = False
         self.sleeping = False
+        self.terminated = False
         self.timer = None
         self.urgent = False
 
@@ -53,7 +55,29 @@ class Module(Thread):
         self._py3_wrapper = py3_wrapper
         #
         self.set_module_options(module)
-        self.load_methods(module, user_modules)
+
+        try:
+            self.load_methods(module, user_modules)
+        except Exception as e:
+            # Import failed notify user in module error output
+            self.disabled = True
+            self.methods['error'] = {}
+            self.error_index = 0
+            if self.module_inst.startswith('_anon_module_'):
+                module_name = self.module_name
+            else:
+                module_name = self.module_full_name
+
+            self.error_messages = [
+                self.module_name,
+                u'{}: Import Error, {}'.format(module_name, str(e)),
+            ]
+            self.error_output(self.error_messages[0])
+            # log the error
+            msg = 'Module `{}` could not be loaded'.format(
+                self.module_full_name
+            )
+            self._py3_wrapper.report_exception(msg, notify_user=False)
 
     def __repr__(self):
         return '<Module {}>'.format(self.module_full_name)
@@ -97,21 +121,55 @@ class Module(Thread):
         if self.has_post_config_hook:
             try:
                 self.module_class.post_config_hook()
-            except:
+            except Exception as e:
                 # An exception has been thrown in post_config_hook() disable
-                # the module.
-                msg = 'post_config_hook in `{}` raised an exception'.format(
-                    self.module_full_name
-                )
-                self._py3_wrapper.report_exception(msg)
-                self.disabled = True
+                # the module and show error in module output
+                self.terminated = True
+                self.error_index = 0
+                if self.module_inst.startswith('_anon_module_'):
+                    module_name = self.module_name
+                else:
+                    module_name = self.module_full_name
+
+                self.error_messages = [
+                    module_name,
+                    u'{}: {}'.format(module_name, str(e) or e.__class__.__name__),
+                ]
+                self.error_output(self.error_messages[0])
+                msg = 'Exception in `%s` post_config_hook()' % self.module_full_name
+                self._py3_wrapper.report_exception(msg, notify_user=False)
+                self._py3_wrapper.log('terminating module %s' % self.module_full_name)
+
+    def error_output(self, message):
+        """
+        Something is wrong with the module so we want to output the error to
+        the i3bar
+        """
+        color_fn = self._py3_wrapper.get_config_attribute
+        color = color_fn(self.module_full_name, 'color_error')
+        if hasattr(color, 'none_setting'):
+            color = color_fn(self.module_full_name, 'color_bad')
+        if hasattr(color, 'none_setting'):
+            color = None
+
+        error = {
+            'full_text': message,
+            'color': color,
+            'instance': self.module_inst,
+            'name': self.module_name,
+        }
+        for method in self.methods.values():
+            method['last_output'] = [error]
+
+        self.set_updated()
 
     def start_module(self):
         """
         Start the module running.
         """
-        if not self.disabled:
+        if not (self.disabled or self.terminated):
             # Start the module and call its output method(s)
+            self._py3_wrapper.log('starting module %s' % self.module_full_name)
             self.start()
 
     def force_update(self):
@@ -137,6 +195,14 @@ class Module(Thread):
         # cancel any existing timer
         if self.timer:
             self.timer.cancel()
+
+    def disable_module(self):
+        # hide message
+        self.disabled = True
+        # purge from any container modules
+        self._py3_wrapper.purge_module(self.module_full_name)
+        self.error_output(u'')
+        self._py3_wrapper.log('disabling module `%s`' % self.module_full_name)
 
     def wake(self):
         self.sleeping = False
@@ -535,15 +601,28 @@ class Module(Thread):
         # py3.prevent_refresh()
         self.prevent_refresh = False
         try:
-            click_method = getattr(self.module_class, 'on_click')
-            if self.click_events == self.PARAMS_NEW:
-                # new style modules
-                click_method(event)
-            else:
-                # legacy modules had extra parameters passed
-                click_method(self.i3status_thread.json_list,
-                             self.config['py3_config']['general'], event)
-            self.set_updated()
+            if self.error_messages:
+                # we have error messages
+                button = event['button']
+                if button == 1:
+                    # cycle through to next message
+                    self.error_index = (self.error_index + 1) % len(self.error_messages)
+                    error = self.error_messages[self.error_index]
+                    self.error_output(error)
+                if button == 3:
+                    self.disable_module()
+                self.prevent_refresh = True
+
+            elif self.click_events:
+                click_method = getattr(self.module_class, 'on_click')
+                if self.click_events == self.PARAMS_NEW:
+                    # new style modules
+                    click_method(event)
+                else:
+                    # legacy modules had extra parameters passed
+                    click_method(self.i3status_thread.json_list,
+                                 self.config['py3_config']['general'], event)
+                self.set_updated()
         except Exception:
             msg = 'on_click event in `{}` failed'.format(self.module_full_name)
             self._py3_wrapper.report_exception(msg)

--- a/py3status/modules/group.py
+++ b/py3status/modules/group.py
@@ -127,6 +127,9 @@ class Py3status:
         This returns a set containing the actively shown module.  This is so we
         only get update events triggered for these modules.
         '''
+        # ensure that active is valid
+        self.active = self.active % len(self.items)
+
         return set([self.items[self.active]])
 
     def _urgent_function(self, module_list):

--- a/py3status/parse_config.py
+++ b/py3status/parse_config.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 import codecs
-import glob
 import imp
 import os
 import re
@@ -515,19 +514,6 @@ def process_config(config_path, py3_wrapper=None):
         else:
             print(error)
 
-    def module_names():
-        # get list of all module names
-        modules = I3S_MODULE_NAMES[:]
-        root = os.path.dirname(os.path.realpath(__file__))
-        module_path = os.path.join(root, 'modules', '*.py')
-        for file in glob.glob(module_path):
-            modules.append(os.path.basename(file)[:-3])
-
-        # FIXME we can do this better
-        if py3_wrapper:
-            modules += list(py3_wrapper.get_user_modules().keys())
-        return modules
-
     def parse_config(config):
         '''
         Parse text or file as a py3status config file.
@@ -659,17 +645,10 @@ def process_config(config_path, py3_wrapper=None):
             # add any children
             add_container_items(item)
 
-    allowed_modules = module_names()
-
     # create config for modules in order
     for name in config_info.get('order', []):
         module = modules.get(name, {})
         module_type = get_module_type(name)
-        if allowed_modules and name.split()[0] not in allowed_modules:
-            if py3_wrapper:
-                error = 'Module {} cannot be found'.format(name.split()[0])
-                py3_wrapper.notify_user(error)
-            continue
         config['order'].append(name)
         add_container_items(name)
         if module_type == 'i3status':

--- a/py3status/py3.py
+++ b/py3status/py3.py
@@ -98,7 +98,7 @@ class Py3:
         if it exists
         """
         if not name.startswith('COLOR_'):
-            raise AttributeError(name)
+            raise AttributeError('Attribute `%s` not in Py3' % name)
         return self._get_config_setting(name.lower())
 
     def _get_config_setting(self, name, default=None):


### PR DESCRIPTION
When a module cannot be imported for example due to a missing python dependency, we notify the user.  A module can also indicate it cannot function by raising an exception in it's `post_config_hook()`.  Again we notify the user.

This can be a pain.  This PR changes the behaviour so that when these happen we put output to the i3bar for the module either `<module_name>` or `<module_name>: <reason>` click 1 will cycle, click 3 will hide.

The reason is `Import Error <error>` or the exception in `post_config_hook()` eg `raise Exception('missing command')`

This should have been added when we added the disable module on `post_config_hook()` exception.

It's pretty basic but we can enhance it as we go along.  I'd like to add something similar for module method call errors at a future time once this has bedded in.