### PR TITLE
Do not treat workspace name as window name.

### DIFF
--- a/py3status/modules/window_title_async.py
+++ b/py3status/modules/window_title_async.py
@@ -61,7 +61,7 @@ class Py3status:
 
             else:
                 title = w.name
-                if title is None:
+                if title is None or w.type == "workspace":
                     title = ''
 
                 if len(title) > self.max_width:


### PR DESCRIPTION
It happened when you focused empty workspace and then reloaded i3. (always_show is true)