### PR TITLE
Cleanup i3status config access

### DIFF
--- a/py3status/events.py
+++ b/py3status/events.py
@@ -62,10 +62,10 @@ class Events(Thread):
         Thread.__init__(self)
         self.config = py3_wrapper.config
         self.error = None
-        self.i3s_config = py3_wrapper.i3status_thread.config
+        self.py3_config = py3_wrapper.config['py3_config']
         self.lock = py3_wrapper.lock
         self.modules = py3_wrapper.modules
-        self.on_click = self.i3s_config['on_click']
+        self.on_click = self.py3_config['on_click']
         self.output_modules = py3_wrapper.output_modules
         self.poller_inp = IOPoller(sys.stdin)
         self.py3_wrapper = py3_wrapper
@@ -182,7 +182,7 @@ class Events(Thread):
             self.py3_wrapper.refresh_modules(module_name)
 
         # find container that holds the module and call its onclick
-        module_groups = self.i3s_config['.module_groups']
+        module_groups = self.py3_config['.module_groups']
         containers = module_groups.get(module_name, [])
         for container in containers:
             self.process_event(container, event, top_level=False)

--- a/py3status/module.py
+++ b/py3status/module.py
@@ -192,7 +192,7 @@ class Module(Thread):
         https://i3wm.org/i3status/manpage.html#_universal_module_options
         """
         self.module_options = {}
-        mod_config = self.i3status_thread.config.get(module, {})
+        mod_config = self.config['py3_config'].get(module, {})
 
         if 'min_width' in mod_config:
             self.module_options['min_width'] = mod_config['min_width']
@@ -356,7 +356,7 @@ class Module(Thread):
                 pass
 
             # module configuration
-            mod_config = self.i3status_thread.config.get(module, {})
+            mod_config = self.config['py3_config'].get(module, {})
 
             # process any deprecated configuration settings
             try:
@@ -542,7 +542,7 @@ class Module(Thread):
             else:
                 # legacy modules had extra parameters passed
                 click_method(self.i3status_thread.json_list,
-                             self.i3status_thread.config['general'], event)
+                             self.config['py3_config']['general'], event)
             self.set_updated()
         except Exception:
             msg = 'on_click event in `{}` failed'.format(self.module_full_name)
@@ -586,7 +586,7 @@ class Module(Thread):
                         # legacy modules had parameters passed
                         response = method(
                             self.i3status_thread.json_list,
-                            self.i3status_thread.config['general'])
+                            self.config['py3_config']['general'])
 
                     if isinstance(response, dict):
                         # this is a shiny new module giving a dict response
@@ -685,7 +685,7 @@ class Module(Thread):
                 else:
                     # legacy call parameters
                     kill_method(self.i3status_thread.json_list,
-                                self.i3status_thread.config['general'])
+                                self.config['py3_config']['general'])
             except Exception:
                 # this would be stupid to die on exit
                 pass

--- a/py3status/py3.py
+++ b/py3status/py3.py
@@ -86,8 +86,8 @@ class Py3:
         if module:
             self._output_modules = module._py3_wrapper.output_modules
             if not i3s_config:
-                config = self._module.i3status_thread.config['general']
-                self._i3s_config = config
+                i3s_config = self._module.config['py3_config']['general']
+                self._i3s_config = i3s_config
             self._py3status_module = module.module_class
 
     def __getattr__(self, name):


### PR DESCRIPTION
This PR just cleans up the `py3_config` this is what I'm calling our parsed config file.  I'm easy on the name.  The aim it to make it part of the py3status config currently it is I3status and we keep having to reach into it.

As well as improving clarity it also means that the i3status stuff running becomes optional rather than being vital We can probably remove the whole mock thread etc.