### PR TITLE
allow improved access to settings from py3status section

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -96,14 +96,21 @@ imap {
 ```
 
 #### <a name="py3status_section"></a>py3status configuration section
-This special section holds py3status specific configuration. As of now, the
-only possible key is 'nagbar_font'. It will be used as an argument to
-`i3-nagbar -f`, thus setting its font. Example usage:
-```
-py3status {
-    nagbar_font = 'pango:Ubuntu Mono 12'
-}
-```
+This special section holds py3status specific configuration. Settings here
+will affect all py3status modules.  Many settings e.g. colors can still be
+overridden by also defining in the individual module.
+
+Global options:
+
+- `nagbar_font`. It will be used as an argument to
+    `i3-nagbar -f`, thus setting its font.
+
+    Example usage:
+    ```
+    py3status {
+        nagbar_font = 'pango:Ubuntu Mono 12'
+    }
+    ```
 
 #### <a name="obfuscation"></a>Configuration obfuscation
 

--- a/py3status/module.py
+++ b/py3status/module.py
@@ -286,7 +286,7 @@ class Module(Thread):
             if color and 'color' not in item:
                 item['color'] = color
             # Remove any none color from our output
-            if hasattr(item.get('color'), 'none_color'):
+            if hasattr(item.get('color'), 'none_setting'):
                 del item['color']
 
     def _params_type(self, method_name, instance):
@@ -610,7 +610,7 @@ class Module(Thread):
                             err = 'missing "full_text" key in response'
                             raise KeyError(err)
                         # Remove any none color from our output
-                        if hasattr(result.get('color'), 'none_color'):
+                        if hasattr(result.get('color'), 'none_setting'):
                             del result['color']
                         # set universal module options in result
                         result.update(self.module_options)


### PR DESCRIPTION
This PR improves support for the py3status section by making it available via `Py3statusWrapper.get_config_attribute()`.  This means that we can easily get at the settings and inherit first from `py3status` and then `general`.  This is really useful for many features eg the popup font could be set at the application or module level.

So it's not about giving modules access but for global features.

```
general {
    color_good = '#00FF00'
}

py3status {
    color_good = '#00AA00'  # overrides general setting for py3status modules
    nagbar_font = 'pango:Ubuntu Mono 12'  # global setting
    some_new_setting = 'wow'  # module specific setting
}

my_module {
    color_good = '#00CC00'
    some_new_setting = None  # overrides
}
```

Edit:  I did a bit more playing with this.  Adding `py3._get_config_setting(name)`. It adds a bit of noise but we make things more general (less color_xx specific) and moves some stuff into better places.

Again, this does not add much direct functionality, more the capacity to do new things that I have plans for.