### PR TITLE
Clock plugin: Add %s, %T for time_delta calculation

### DIFF
--- a/py3status/modules/clock.py
+++ b/py3status/modules/clock.py
@@ -142,6 +142,12 @@ class Py3status:
             elif '%S' in format_time:
                 # seconds
                 time_delta = 1
+            elif '%s' in format_time:
+                # seconds since unix epoch start
+                time_delta = 1
+            elif '%T' in format_time:
+                # seconds included in "%H:%M:%S"
+                time_delta = 1
             elif '%c' in format_time:
                 # Locale’s appropriate date and time representation
                 time_delta = 1


### PR DESCRIPTION
Strftime formats %s and %T include number of seconds, but time_delta is equal to 60, which leads to the seconds counter to be stuck.