### PR TITLE
Diskdata: add clarification to docs

### DIFF
--- a/py3status/modules/README.md
+++ b/py3status/modules/README.md
@@ -656,7 +656,7 @@ Display disk information.
 Configuration parameters:
   - `cache_timeout` how often we refresh this module in seconds.
     *(default 10)*
-  - `disk` disk or partition whose stat to check. Set to None to get global stats.
+  - `disk` disk  or partition whose stat to check, i.e. `sda1`. Set to None to get global stats.
     *(default None)*
   - `format` format of the output.
     *(default "{disk}: {used_percent}% ({total})")*


### PR DESCRIPTION
Add clarification to docs, that disk /dev name, and not mountpoint, is required