### PR TITLE
external_script: use helpers

### DIFF
--- a/py3status/modules/external_script.py
+++ b/py3status/modules/external_script.py
@@ -29,7 +29,6 @@ external_script {
 
 @author frimdo ztracenastopa@centrum.cz
 """
-import os
 
 
 class Py3status:
@@ -43,7 +42,7 @@ class Py3status:
 
     def external_script(self):
         if self.script_path:
-            return_value = self.py3.command_output(os.path.expanduser(self.script_path))
+            return_value = self.py3.command_output(self.script_path, shell=True)
             # this is a convenience cleanup code to avoid breaking i3bar which
             # does not support multi lines output
             if len(return_value.split('\n')) > 2:
@@ -52,7 +51,7 @@ class Py3status:
                     'Script {} output contains new lines.'.format(
                         self.script_path) +
                     ' Only the first one is being displayed to avoid breaking your i3bar',
-                    rate_limit=3600)
+                    rate_limit=None)
             elif return_value[-1] == '\n':
                 return_value = return_value.rstrip('\n')
 

--- a/py3status/modules/external_script.py
+++ b/py3status/modules/external_script.py
@@ -29,8 +29,7 @@ external_script {
 
 @author frimdo ztracenastopa@centrum.cz
 """
-
-import subprocess
+import os
 
 
 class Py3status:
@@ -44,10 +43,7 @@ class Py3status:
 
     def external_script(self):
         if self.script_path:
-            return_value = subprocess.check_output(self.script_path,
-                                                   shell=True,
-                                                   universal_newlines=True)
-
+            return_value = self.py3.command_output(os.path.expanduser(self.script_path))
             # this is a convenience cleanup code to avoid breaking i3bar which
             # does not support multi lines output
             if len(return_value.split('\n')) > 2:

--- a/py3status/py3.py
+++ b/py3status/py3.py
@@ -685,7 +685,7 @@ class Py3:
             msg = "Command '{cmd}' {error}"
             raise Exception(msg.format(cmd=command[0], error=e))
 
-    def command_output(self, command):
+    def command_output(self, command, shell=False):
         """
         Run a command and return its output as unicode.
         The command can either be supplied as a sequence or string.
@@ -697,7 +697,7 @@ class Py3:
             command = shlex.split(command)
         try:
             process = Popen(command, stdout=PIPE, stderr=PIPE,
-                            universal_newlines=True)
+                            universal_newlines=True, shell=shell)
         except Exception as e:
             msg = "Command '{cmd}' {error}"
             raise Exception(msg.format(cmd=command[0], error=e))


### PR DESCRIPTION
Uses `self.py3.command_output` 
Uses `os.path.expanduser` (Discussion in https://github.com/ultrabug/py3status/pull/663)