### PR TITLE
external_script: fix exception, remove warning

### DIFF
--- a/py3status/modules/external_script.py
+++ b/py3status/modules/external_script.py
@@ -51,31 +51,21 @@ class Py3status:
                 'full_text': STRING_UNAVAILABLE
             }
         try:
-            full_text = self.py3.command_output(self.script_path, shell=True)
+            output = self.py3.command_output(self.script_path, shell=True)
+            output = output.splitlines()[0]
         except:
             return {
                 'cached_until': self.py3.time_in(self.cache_timeout),
                 'color': self.py3.COLOR_BAD,
                 'full_text': STRING_ERROR
             }
-        # this is a convenience cleanup code to avoid breaking i3bar which
-        # does not support multi lines output
-        if len(full_text.split('\n')) > 2:
-            full_text = full_text.split('\n')[0]
-            self.py3.notify_user(
-                'Script {} output contains new lines.'.format(
-                    self.script_path) +
-                ' Only the first one is being displayed to avoid breaking your i3bar',
-                rate_limit=None)
-        elif full_text[-1] == '\n':
-            full_text = full_text.rstrip('\n')
 
         if self.strip_output:
-            full_text = full_text.strip()
+            output = output.strip()
 
         return {
             'cached_until': self.py3.time_in(self.cache_timeout),
-            'full_text': self.py3.safe_format(self.format, {'output': full_text})
+            'full_text': self.py3.safe_format(self.format, {'output': output})
         }
 
 

--- a/py3status/modules/external_script.py
+++ b/py3status/modules/external_script.py
@@ -30,6 +30,9 @@ external_script {
 @author frimdo ztracenastopa@centrum.cz
 """
 
+STRING_UNAVAILABLE = "external_script: N/A"
+STRING_ERROR = "external_script: error"
+
 
 class Py3status:
     """
@@ -41,34 +44,39 @@ class Py3status:
     strip_output = False
 
     def external_script(self):
-        if self.script_path:
-            return_value = self.py3.command_output(self.script_path, shell=True)
-            # this is a convenience cleanup code to avoid breaking i3bar which
-            # does not support multi lines output
-            if len(return_value.split('\n')) > 2:
-                return_value = return_value.split('\n')[0]
-                self.py3.notify_user(
-                    'Script {} output contains new lines.'.format(
-                        self.script_path) +
-                    ' Only the first one is being displayed to avoid breaking your i3bar',
-                    rate_limit=None)
-            elif return_value[-1] == '\n':
-                return_value = return_value.rstrip('\n')
-
-            if self.strip_output:
-                return_value = return_value.strip()
-
-            response = {
-                'cached_until': self.py3.time_in(self.cache_timeout),
-                'full_text': self.py3.safe_format(self.format,
-                                                  {'output': return_value})
+        if not self.script_path:
+            return {
+                'cached_until': self.py3.CACHE_FOREVER,
+                'color': self.py3.COLOR_BAD,
+                'full_text': STRING_UNAVAILABLE
             }
-        else:
-            response = {
+        try:
+            full_text = self.py3.command_output(self.script_path, shell=True)
+        except:
+            return {
                 'cached_until': self.py3.time_in(self.cache_timeout),
-                'full_text': ''
+                'color': self.py3.COLOR_BAD,
+                'full_text': STRING_ERROR
             }
-        return response
+        # this is a convenience cleanup code to avoid breaking i3bar which
+        # does not support multi lines output
+        if len(full_text.split('\n')) > 2:
+            full_text = full_text.split('\n')[0]
+            self.py3.notify_user(
+                'Script {} output contains new lines.'.format(
+                    self.script_path) +
+                ' Only the first one is being displayed to avoid breaking your i3bar',
+                rate_limit=None)
+        elif full_text[-1] == '\n':
+            full_text = full_text.rstrip('\n')
+
+        if self.strip_output:
+            full_text = full_text.strip()
+
+        return {
+            'cached_until': self.py3.time_in(self.cache_timeout),
+            'full_text': self.py3.safe_format(self.format, {'output': full_text})
+        }
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Adds `try/except` to fix an exception I ran into. Closes https://github.com/ultrabug/py3status/issues/756
EDIT: Remove `strip_output` option (line 73-74)... and use formatter instead? [y/n]