### PR TITLE
support unicode wifi SSID

### DIFF
--- a/py3status/modules/wifi.py
+++ b/py3status/modules/wifi.py
@@ -125,7 +125,7 @@ class Py3status:
         if ssid_out:
             ssid = ssid_out.group(1)
             ssid = ssid.encode('latin-1').decode('unicode_escape')
-            ssid = ssid.encode('latin-1').decode()
+            ssid = ssid.encode('latin-1').decode('utf-8')
         else:
             ssid = None
 

--- a/py3status/modules/wifi.py
+++ b/py3status/modules/wifi.py
@@ -124,6 +124,8 @@ class Py3status:
         ssid_out = re.search('SSID: (.+)', iw)
         if ssid_out:
             ssid = ssid_out.group(1)
+            ssid = ssid.encode('latin-1').decode('unicode_escape')
+            ssid = ssid.encode('latin-1').decode()
         else:
             ssid = None
 

--- a/py3status/modules/wifi.py
+++ b/py3status/modules/wifi.py
@@ -124,6 +124,9 @@ class Py3status:
         ssid_out = re.search('SSID: (.+)', iw)
         if ssid_out:
             ssid = ssid_out.group(1)
+            # `iw` command would prints unicode SSID like `\xe8\x8b\x9f`
+            # the the `ssid` here would be '\\xe8\\x8b\\x9f' (note the escape)
+            # it needs to be decoded using 'unicode_escape', to '苟'
             ssid = ssid.encode('latin-1').decode('unicode_escape')
             ssid = ssid.encode('latin-1').decode('utf-8')
         else:


### PR DESCRIPTION
For unicode SSID name, iw will output: `SSID: \xe5\xaf\x8c\xe5\xbc\xba\xe5\xba\xb7\xe4\xb9\x90`, it should be properly decoded.