### PR TITLE
universal gradients

### DIFF
--- a/py3status/py3.py
+++ b/py3status/py3.py
@@ -14,6 +14,8 @@ from time import time
 from py3status import exceptions
 from py3status.formatter import Formatter, Composite
 from py3status.request import HttpResponse
+from py3status.util import Gradiants
+
 
 PY3_CACHE_FOREVER = -1
 PY3_LOG_ERROR = 'error'
@@ -85,6 +87,7 @@ class Py3:
 
     # Shared by all Py3 Instances
     _formatter = None
+    _gradients = Gradiants()
     _none_color = NoneColor()
 
     # Exceptions
@@ -100,10 +103,11 @@ class Py3:
         self._config_setting = {}
         self._format_placeholders = {}
         self._format_placeholders_cache = {}
-        self._module = module
         self._is_python_2 = sys.version_info < (3, 0)
+        self._module = module
         self._report_exception_cache = set()
         self._thresholds = None
+        self._threshold_gradients = {}
 
         if module:
             self._i3s_config = module._py3_wrapper.config['py3_config']['general']
@@ -916,6 +920,9 @@ class Py3:
         threshold is needed for a module then the name can also be supplied.
         If the user has not supplied a named threshold but has defined a
         general one that will be used.
+
+        If the gradients config parameter is True then rather than sharp
+        thresholds we will use a gradient between the color values.
         """
         # If first run then process the threshold data.
         if self._thresholds is None:
@@ -931,13 +938,33 @@ class Py3:
         name_used = name
         if name_used not in self._thresholds:
             name_used = None
+        thresholds = self._thresholds.get(name_used)
+        if color is None and thresholds:
+            # if gradients are enabled then we use them
+            if self._get_config_setting('gradients'):
+                try:
+                    colors, minimum, maximum = self._threshold_gradients[name_used]
+                except KeyError:
+                    colors = self._gradients.make_threshold_gradient(self, thresholds)
+                    minimum = min(thresholds)[0]
+                    maximum = max(thresholds)[0]
+                    self._threshold_gradients[name_used] = (colors, minimum, maximum)
 
-        if color is None:
-            for threshold in self._thresholds.get(name_used, []):
-                if value >= threshold[0]:
-                    color = threshold[1]
-                else:
-                    break
+                if value < minimum:
+                    return colors[0]
+                if value > maximum:
+                    return colors[-1]
+                value -= minimum
+                col_index = int(((len(colors) - 1) / (maximum - minimum)) * value)
+                color = colors[col_index]
+
+            elif color is None:
+                color = thresholds[0][1]
+                for threshold in thresholds:
+                    if value >= threshold[0]:
+                        color = threshold[1]
+                    else:
+                        break
 
         # save color so it can be accessed via safe_format()
         if name:

--- a/py3status/util.py
+++ b/py3status/util.py
@@ -1,0 +1,140 @@
+# -*- coding: utf-8 -*-
+from __future__ import division
+
+import re
+from colorsys import rgb_to_hsv, hsv_to_rgb
+from math import modf
+
+
+class Gradiants:
+    """
+    Create color gradients
+    """
+
+    RE_HEX = re.compile('#([0-9a-fA-F]{3}|[0-9a-fA-F]{6})')
+
+    _gradients_cache = {}
+
+    def hex_2_rgb(self, color):
+        """
+        convert a hex color to rgb
+        """
+        if not self.RE_HEX.match(color):
+            color = '#FFF'
+        if len(color) == 7:
+            return (int(color[i:i + 2], 16) / 255 for i in [1, 3, 5])
+        return (int(c, 16) / 15 for c in color)
+
+    def rgb_2_hex(self, r, g, b):
+        """
+        convert a rgb color to hex
+        """
+        return '#{:02X}{:02X}{:02X}'.format(
+            int(r * 255), int(g * 255), int(b * 255)
+        )
+
+    def hex_2_hsv(self, color):
+        """
+        convert a hex color to hsv
+        """
+        return rgb_to_hsv(*self.hex_2_rgb(color))
+
+    def hsv_2_hex(self, h, s, v):
+        """
+        convert a hsv color to hex
+        """
+        return self.rgb_2_hex(*hsv_to_rgb(h, s, v))
+
+    def make_mid_color(self, color1, color2, distance, long_route=False):
+        """
+        Generate a mid color between color1 and color2.
+        Colors should be a tuple (hue, saturation, value).
+
+        distance is a float between 0.0 and 1.0 describing how far between
+        color1 and color2 we want to return the color. 0.0 would return color1,
+        1.0 color2, and 0.5 a color midway.
+
+        long_route allows us to choose how we get from color1 to color2 around
+        the color wheel if True we go the long way, through as many colors as
+        we can, if False we go through the minimum number
+        """
+        def fade(a, b):
+            x = (b * distance)
+            x += (a * (1 - distance))
+            return x
+
+        h1, s1, v1 = color1
+        h2, s2, v2 = color2
+
+        hue_diff = h1 - h2
+        if long_route:
+            if hue_diff < 0.5 and hue_diff > -0.5:
+                h1 += 1
+        else:
+            if hue_diff > 0.5:
+                h2 += 1
+            elif hue_diff < -0.5:
+                h1 += 1
+        return (modf(fade(h1, h2))[0], fade(s1, s2), fade(v1, v2))
+
+    def generate_gradient(self, color_list, size=101):
+        """
+        Create a gradient of size colors that passes through the colors
+        give in the list (the resultant list may not be exactly size long).
+        The gradient will be evenly distributed.
+        colors should be in hex format eg '#FF00FF'
+        """
+        list_length = len(color_list)
+        gradient_step = size / (list_length - 1)
+
+        gradient_data = []
+        for x in range(list_length):
+            gradient_data.append((int(gradient_step * x), color_list[x]))
+
+        data = []
+        for i in range(len(gradient_data) - 1):
+            start, color1 = gradient_data[i]
+            end, color2 = gradient_data[i + 1]
+
+            color1 = self.hex_2_hsv(color1)
+            color2 = self.hex_2_hsv(color2)
+
+            steps = end - start
+            for j in range(steps):
+                data.append(self.hsv_2_hex(*self.make_mid_color(color1,
+                                                                color2,
+                                                                j / (steps))))
+        data.append(self.hsv_2_hex(*color2))
+        return data
+
+    def make_threshold_gradient(self, py3, thresholds, size=100):
+
+        """
+        Given a thresholds list, creates a gradient list that covers the range
+        of the thresholds.
+        The number of colors in the gradient is limited by size.
+        Because of how the range is split the exact number of colors in the
+        gradient cannot be guaranteed.
+        """
+        thresholds = sorted(thresholds)
+        key = '{}|{}'.format(thresholds, size)
+        try:
+            return self._gradients_cache[key]
+        except KeyError:
+            pass
+        minimum = min(thresholds)[0]
+        maximum = max(thresholds)[0]
+        if maximum - minimum > size:
+            steps_size = size / (maximum - minimum)
+        else:
+            steps_size = 1
+        colors = []
+        for index in range(len(thresholds) - 1):
+            color_list = [thresholds[index][1], thresholds[index + 1][1]]
+            num_colors = int(
+                (thresholds[index + 1][0] - thresholds[index][0]) * steps_size
+            )
+            colors.extend(self.generate_gradient(color_list, num_colors))
+        # cache gradient
+        self._gradients_cache[key] = colors
+        return colors


### PR DESCRIPTION
This is something that i3pystatus had that I though was a nice feature.

Instead of using sharp color changes on thresholds ie either good/degraded/bad we allow gradients between the colors.

Gradients are disabled by default to enable add `gradients = True` to `py3status` section or to individual module in config.

Any modules that use thresholds will then work.

The code creating the gradients is a little as we need to use hue, saturation, value colorspace rather than rgb so that we can have really good gradients. but it is self-contained.

There may be issues if modules have very small threshold ranges eg `[(0, 'good'), (0.5, 'bad')]` but I don't think modules currently do this and we can always fix if we have some.