### PR TITLE
fix color comparison bug

### DIFF
--- a/py3status/core.py
+++ b/py3status/core.py
@@ -43,15 +43,9 @@ CONFIG_SPECIAL_SECTIONS = [
 
 class NoneSetting:
     """
-    This class represents no
-    setting in the config.  We need this so that we can do things like
-
-    color = self.py3.COLOR_MUTED or self.py3.COLOR_BAD
-
-    Py3 provides a helper function is_color() that will treat a NoneSetting as
-    False, whereas a simple if would show True
+    This class represents no setting in the config.
     """
-    # this attribute is used to identify that this is a none color
+    # this attribute is used to identify that this is a none setting
     none_setting = True
 
     def __repr__(self):


### PR DESCRIPTION
There was a bug in #741 Sorry for letting it through but the functionality is not widely used yet.

This is because colors are handled specially to allow things like 
```
color = self.py3.COLOR_MUTED or self.py3.COLOR_BAD
```
This behavior was broken.  This fixes it.  Colors are special they are the only settings that modules can access directly via the current functionality, and we make sure they are cleaned out of module output.

I have also added a minor addition this just helps when calling `self.py3.unknown()` as we get to see the error.  Really it should be as it's own PR but I thought I'd sneak it in.
```
         if not name.startswith('COLOR_'):
-            raise AttributeError
+            raise AttributeError(name)
         return self._get_config_setting(name.lower())
 ```

I think I'm going to have to add some Py3 tests