### PR TITLE
hamster: fix potential exceptions

### DIFF
--- a/py3status/modules/hamster.py
+++ b/py3status/modules/hamster.py
@@ -16,6 +16,9 @@ Requires:
 @license BSD
 """
 
+STRING_NOT_INSTALLED = "hamster: isn't installed"
+STRING_ERROR = "hamster: unknown error"
+
 
 class Py3status:
     """
@@ -25,7 +28,21 @@ class Py3status:
     format = '{current}'
 
     def hamster(self):
-        cur_task = self.py3.command_output('hamster current').strip()
+        if not self.py3.check_commands('hamster'):
+            return {
+                'cached_until': self.py3.CACHE_FOREVER,
+                'color': self.py3.COLOR_BAD,
+                'full_text': STRING_NOT_INSTALLED
+            }
+        try:
+            cur_task = self.py3.command_output('hamster current').strip()
+        except:
+            return {
+                'cached_until': self.py3.time_in(self.cache_timeout),
+                'color': self.py3.COLOR_BAD,
+                'full_text': STRING_ERROR
+            }
+
         if cur_task != 'No activity':
             cur_task = cur_task.split()
             time_elapsed = cur_task[-1]

--- a/py3status/modules/hamster.py
+++ b/py3status/modules/hamster.py
@@ -16,8 +16,7 @@ Requires:
 @license BSD
 """
 
-STRING_NOT_INSTALLED = "hamster: isn't installed"
-STRING_ERROR = "hamster: unknown error"
+STRING_NOT_INSTALLED = "isn't installed"
 
 
 class Py3status:
@@ -27,30 +26,22 @@ class Py3status:
     cache_timeout = 10
     format = '{current}'
 
-    def hamster(self):
+    def post_config_hook(self):
         if not self.py3.check_commands('hamster'):
-            return {
-                'cached_until': self.py3.CACHE_FOREVER,
-                'color': self.py3.COLOR_BAD,
-                'full_text': STRING_NOT_INSTALLED
-            }
-        try:
-            cur_task = self.py3.command_output('hamster current').strip()
-        except:
-            return {
-                'cached_until': self.py3.time_in(self.cache_timeout),
-                'color': self.py3.COLOR_BAD,
-                'full_text': STRING_ERROR
-            }
+            raise Exception(STRING_NOT_INSTALLED)
 
-        if cur_task != 'No activity':
-            cur_task = cur_task.split()
-            time_elapsed = cur_task[-1]
-            cur_task = cur_task[2:-1]
-            cur_task = u"%s (%s)" % (" ".join(cur_task), time_elapsed)
+    def hamster(self):
+        activity = self.py3.command_output('hamster current').strip()
+        if activity != 'No activity':
+            activity = activity.split()
+            time_elapsed = activity[-1]
+            activity = activity[2:-1]
+            activity = u"%s (%s)" % (" ".join(activity), time_elapsed)
 
-        return {'cached_until': self.py3.time_in(self.cache_timeout),
-                'full_text': self.py3.safe_format(self.format, {'current': cur_task})}
+        return {
+            'cached_until': self.py3.time_in(self.cache_timeout),
+            'full_text': self.py3.safe_format(self.format, {'current': activity})
+        }
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This module contain `self.py3.command_output`, but not under `try/except`.

May have to be tweaked again to deal with possible new i3bar `post_config_hook` exception for bits and pieces... such as `isn't installed`.