### PR TITLE
timewarrior: fix potential exceptions

### DIFF
--- a/py3status/modules/taskwarrior.py
+++ b/py3status/modules/taskwarrior.py
@@ -17,8 +17,7 @@ Requires
 """
 
 import json
-STRING_NOT_INSTALLED = "taskwarrior: isn't installed"
-STRING_ERROR = "taskwarrior: unknown error"
+STRING_NOT_INSTALLED = "isn't installed"
 
 
 class Py3status:
@@ -28,26 +27,17 @@ class Py3status:
     cache_timeout = 5
     format = '{task}'
 
-    def taskWarrior(self):
+    def post_config_hook(self):
         if not self.py3.check_commands('task'):
-            return {
-                'cached_until': self.py3.CACHE_FOREVER,
-                'color': self.py3.COLOR_BAD,
-                'full_text': STRING_NOT_INSTALLED
-            }
+            raise Exception(STRING_NOT_INSTALLED)
 
+    def taskWarrior(self):
         def describeTask(taskObj):
             return str(taskObj['id']) + ' ' + taskObj['description']
-        try:
-            task_command = 'task start.before:tomorrow status:pending export'
-            task_json = json.loads(self.py3.command_output(task_command))
-            task_result = ', '.join(map(describeTask, task_json))
-        except:
-            return {
-                'cached_until': self.py3.time_in(self.cache_timeout),
-                'color': self.py3.COLOR_BAD,
-                'full_text': STRING_ERROR
-            }
+
+        task_command = 'task start.before:tomorrow status:pending export'
+        task_json = json.loads(self.py3.command_output(task_command))
+        task_result = ', '.join(map(describeTask, task_json))
         return {
             'cached_until': self.py3.time_in(self.cache_timeout),
             'full_text': self.py3.safe_format(self.format, {'task': task_result})


### PR DESCRIPTION
This module contain `self.py3.command_output`, but not under `try/except`.

May have to be tweaked again to deal with possible new i3bar `post_config_hook` exception for bits and pieces... such as `isn't installed`.