### PR TITLE
Systemd status checker

### DIFF
--- a/py3status/modules/systemd.py
+++ b/py3status/modules/systemd.py
@@ -84,9 +84,5 @@ if __name__ == "__main__":
     """
     Run module in test mode.
     """
-    config = {
-        'unit': 'dbus.service',
-        'format': '{status} -> {unit}'
-    }
     from py3status.module_test import module_test
     module_test(Py3status, config=config)

--- a/py3status/modules/systemd.py
+++ b/py3status/modules/systemd.py
@@ -7,7 +7,7 @@ Check the status of a systemd unit.
 Configuration parameters:
     cache_timeout: How often we refresh this module in seconds (default 5)
     format: Format for module output (default "{unit}: {status}")
-    unit: Name of the unit (default None)
+    unit: Name of the unit (default dbus.service)
 
 Format of status string placeholders:
     {unit} name of the unit

--- a/py3status/modules/systemd.py
+++ b/py3status/modules/systemd.py
@@ -85,4 +85,4 @@ if __name__ == "__main__":
     Run module in test mode.
     """
     from py3status.module_test import module_test
-    module_test(Py3status, config=config)
+    module_test(Py3status)

--- a/py3status/modules/systemd.py
+++ b/py3status/modules/systemd.py
@@ -1,0 +1,102 @@
+# -*- coding: utf-8 -*-
+"""
+Check systemd unit status.
+
+Check the status of a systemd unit.
+Color will be GOOD if is active.
+BAD if inactive.
+DEGRADED if unit could not be found.
+
+Configuration parameters:
+    cache_timeout: How often we refresh this module in seconds (default 5)
+    format: Format for module output (default "{unit}: {status}")
+    unit: Name of the unit (default None)
+
+Format of status string placeholders:
+    {unit} name of the unit
+    {status} 'active', 'inactive' or 'not-found'
+
+Color options:
+    color_good: Unit active
+    color_bad: Unit inactive
+    color_degraded: Unit not found
+
+Example:
+
+```
+# Check status of vpn service
+# Start with left click
+# Stop with right click
+systemd vpn {
+    unit = 'vpn.service'
+    on_click 1 = "exec sudo systemctl start vpn"
+    on_click 3 = "exec sudo systemctl stop vpn"
+    format = '🏢'
+}
+```
+
+Requires:
+    pydbus: python lib for dbus
+
+@author Adrian Lopez <adrianlzt@gmail.com>
+@license BSD
+"""
+
+from time import time
+from pydbus import SystemBus
+
+
+class Py3status:
+    # available configuration parameters
+    cache_timeout = 5
+    format = '{unit}: {status}'
+    unit = None
+
+    def __init__(self):
+        """
+        This is the class constructor which will be executed once.
+        """
+        self.systemd_unit = None
+
+    def post_config_hook(self):
+        bus = SystemBus()
+        systemd = bus.get('org.freedesktop.systemd1')
+        s_unit = systemd.LoadUnit(self.unit)
+        self.systemd_unit = bus.get('.systemd1', s_unit)
+
+    def check_status(self, i3s_output_list, i3s_config):
+        """
+        Ask dbus to get Status and loaded status for the unit
+        """
+        status = self.systemd_unit.Get('org.freedesktop.systemd1.Unit', 'ActiveState')
+        exists = self.systemd_unit.Get('org.freedesktop.systemd1.Unit', 'LoadState')
+
+        if exists == 'not-found':
+            color = self.py3.COLOR_DEGRADED
+            status = exists
+        elif status == 'active':
+            color = self.py3.COLOR_GOOD
+        elif status == 'inactive':
+            color = self.py3.COLOR_BAD
+        else:
+            color = self.py3.COLOR_DEGRADED
+
+        full_text = self.format.format(unit=self.unit, status=status)
+        response = {
+            'cached_until': time() + self.cache_timeout,
+            'full_text': full_text,
+            'color': color
+        }
+        return response
+
+
+if __name__ == "__main__":
+    """
+    Run module in test mode.
+    """
+    config = {
+        'unit': 'dbus.service',
+        'format': '{status} -> {unit}'
+    }
+    from py3status.module_test import module_test
+    module_test(Py3status, config=config)

--- a/py3status/modules/systemd.py
+++ b/py3status/modules/systemd.py
@@ -46,7 +46,7 @@ class Py3status:
     # available configuration parameters
     cache_timeout = 5
     format = '{unit}: {status}'
-    unit = None
+    unit = 'dbus.service'
 
     def post_config_hook(self):
         bus = SystemBus()

--- a/py3status/modules/systemd.py
+++ b/py3status/modules/systemd.py
@@ -3,9 +3,6 @@
 Check systemd unit status.
 
 Check the status of a systemd unit.
-Color will be GOOD if is active.
-BAD if inactive.
-DEGRADED if unit could not be found.
 
 Configuration parameters:
     cache_timeout: How often we refresh this module in seconds (default 5)
@@ -31,7 +28,7 @@ systemd vpn {
     unit = 'vpn.service'
     on_click 1 = "exec sudo systemctl start vpn"
     on_click 3 = "exec sudo systemctl stop vpn"
-    format = '🏢'
+    format = '{unit} is {status}'
 }
 ```
 
@@ -42,7 +39,6 @@ Requires:
 @license BSD
 """
 
-from time import time
 from pydbus import SystemBus
 
 
@@ -51,12 +47,6 @@ class Py3status:
     cache_timeout = 5
     format = '{unit}: {status}'
     unit = None
-
-    def __init__(self):
-        """
-        This is the class constructor which will be executed once.
-        """
-        self.systemd_unit = None
 
     def post_config_hook(self):
         bus = SystemBus()
@@ -81,9 +71,9 @@ class Py3status:
         else:
             color = self.py3.COLOR_DEGRADED
 
-        full_text = self.format.format(unit=self.unit, status=status)
+        full_text = self.py3.safe_format(self.format, {'unit': self.unit, 'status': status})
         response = {
-            'cached_until': time() + self.cache_timeout,
+            'cached_until': self.py3.time_in(self.cache_timeout),
             'full_text': full_text,
             'color': color
         }

--- a/py3status/modules/systemd.py
+++ b/py3status/modules/systemd.py
@@ -7,7 +7,7 @@ Check the status of a systemd unit.
 Configuration parameters:
     cache_timeout: How often we refresh this module in seconds (default 5)
     format: Format for module output (default "{unit}: {status}")
-    unit: Name of the unit (default dbus.service)
+    unit: Name of the unit (default "dbus.service")
 
 Format of status string placeholders:
     {unit} name of the unit


### PR DESCRIPTION
Simple module to check the status of systemd services via dbus (using pydbus module).

Example showing the status of two VPNs handled by systemd:
![img-2017-02-24-190756](https://cloud.githubusercontent.com/assets/3237784/23315019/967870e2-fac4-11e6-8a5b-7137e0959b7c.png)
