### PR TITLE
[diskstats module] Fix stats for fs mounted multiple times

### DIFF
--- a/py3status/modules/diskdata.py
+++ b/py3status/modules/diskdata.py
@@ -143,6 +143,7 @@ class Py3status:
                 data = line.split()
                 if data[0] in devs:
                     # Make sure to count each block device only one time
+                    # some filesystems eg btrfs have multiple entries
                     continue
                 total += int(data[1]) / 1024 / 1024
                 used += int(data[2]) / 1024 / 1024

--- a/py3status/modules/diskdata.py
+++ b/py3status/modules/diskdata.py
@@ -135,14 +135,18 @@ class Py3status:
         total = 0
         used = 0
         free = 0
+        devs = []
 
         df = self.py3.command_output('df')
         for line in df.splitlines():
             if (disk and line.startswith(disk)) or (disk is None and line.startswith('/dev/')):
                 data = line.split()
+                if data[0] in devs:
+                    continue
                 total += int(data[1]) / 1024 / 1024
                 used += int(data[2]) / 1024 / 1024
                 free += int(data[3]) / 1024 / 1024
+                devs.append(data[0])
 
         if total == 0:
             return free, used, 'err'

--- a/py3status/modules/diskdata.py
+++ b/py3status/modules/diskdata.py
@@ -142,6 +142,7 @@ class Py3status:
             if (disk and line.startswith(disk)) or (disk is None and line.startswith('/dev/')):
                 data = line.split()
                 if data[0] in devs:
+                    # Make sure to count each block device only one time
                     continue
                 total += int(data[1]) / 1024 / 1024
                 used += int(data[2]) / 1024 / 1024


### PR DESCRIPTION
When the same block device has multiple lines in df output, like btrfs subvolumes, the disk usage is multiplied.
There's probably a better way to do this, but not without rewriting it.