### PR TITLE
Py3 provide http request functionality

### DIFF
--- a/py3status/exceptions.py
+++ b/py3status/exceptions.py
@@ -1,0 +1,14 @@
+class Py3Exception(Exception):
+    """ Base exception class """
+
+
+class RequestException(Py3Exception):
+    """ A url request base exception """
+
+
+class RequestTimeout(RequestException):
+    """ A Timeout """
+
+
+class RequestURLError(RequestException):
+    """ A URL related error """

--- a/py3status/modules/exchange_rate.py
+++ b/py3status/modules/exchange_rate.py
@@ -16,15 +16,11 @@ Configuration parameters:
         will be replaced by the current exchange rate.
         (default '${USD} £{GBP} ¥{JPY}')
 
-Requires:
-    requests: python lib
-
 @author tobes
 @license BSD
 """
 
 import re
-import requests
 
 URL = 'http://query.yahooapis.com/v1/public/yql?'
 URL += 'q=select * from yahoo.finance.xchange where pair in ({currencies})'
@@ -43,22 +39,20 @@ class Py3status:
         # create url
         currencies = ['"%s%s"' % (self.base, cur) for cur in self.currencies]
         self.data_url = URL.format(currencies=','.join(currencies))
-        # cache for rates data as sometimes we do not recieve valid data
+        # cache for rates data as sometimes we do not receive valid data
         self.rates_data = {currency: '?' for currency in self.currencies}
 
     def rates(self):
         try:
-            result = requests.get(self.data_url, timeout=self.request_timeout)
-        except requests.ConnectionError:
-            result = None
-        except requests.ReadTimeout:
+            result = self.py3.request(self.data_url, timeout=self.request_timeout)
+        except (self.py3.RequestException):
             result = None
         rates = []
         if result:
             data = result.json()
             try:
                 rates = data['query']['results']['rate']
-            except KeyError:
+            except (KeyError, TypeError):
                 pass
 
         # Single currency is not passed as a 1 element list

--- a/py3status/modules/github.py
+++ b/py3status/modules/github.py
@@ -44,9 +44,6 @@ Format placeholders:
     {repo} short name of the repository being checked. eg py3status
     {repo_full} full name of the repository being checked. eg ultrabug/py3status
 
-Requires:
-    python-requests: Python HTTP for Humans https://pypi.python.org/pypi/requests
-
 Examples:
 ```
 # set github access credentials
@@ -66,7 +63,6 @@ github {
 @author tobes
 """
 
-import requests
 GITHUB_API_URL = 'https://api.github.com'
 GITHUB_URL = 'https://github.com/'
 
@@ -112,10 +108,8 @@ class Py3status:
         else:
             auth = None
         try:
-            info = requests.get(url, 'GET', timeout=10, auth=auth)
-        except requests.ConnectionError:
-            return
-        except requests.ReadTimeout:
+            info = self.py3.request(url, timeout=10, auth=auth)
+        except (self.py3.RequestException):
             return
         if info and info.status_code == 200:
             return(int(info.json()['total_count']))
@@ -143,11 +137,9 @@ class Py3status:
             url = GITHUB_API_URL + '/repos/' + self.repo + '/notifications'
         url += '?per_page=100'
         try:
-            info = requests.get(url, timeout=10,
-                                auth=(self.username, self.auth_token))
-        except requests.ConnectionError:
-            return
-        except requests.ReadTimeout:
+            info = self.py3.request(url, timeout=10,
+                                    auth=(self.username, self.auth_token))
+        except (self.py3.RequestException):
             return
         if info.status_code == 200:
             return len(info.json())

--- a/py3status/modules/spaceapi.py
+++ b/py3status/modules/spaceapi.py
@@ -22,12 +22,7 @@ Color options:
 @license WTFPL <http://www.wtfpl.net/txt/copying/>
 """
 
-import codecs
 import datetime
-import json
-import urllib.request
-import shlex
-import subprocess
 
 
 class Py3status:
@@ -64,11 +59,7 @@ class Py3status:
         }
 
         try:
-            # grab json file
-            json_file = urllib.request.urlopen(self.url)
-            reader = codecs.getreader("utf-8")
-            data = json.load(reader(json_file))
-            json_file.close()
+            data = self.py3.request(self.url).json()
             self._url = data.get('url')
 
             if(data['state']['open'] is True):
@@ -106,7 +97,7 @@ class Py3status:
         button = event['button']
         if self._url and self.button_url == button:
             cmd = 'xdg-open {}'.format(self._url)
-            subprocess.call(shlex.split(cmd))
+            self.py3.command_run(cmd)
             self.py3.prevent_refresh()
 
 

--- a/py3status/modules/weather_yahoo.py
+++ b/py3status/modules/weather_yahoo.py
@@ -58,8 +58,6 @@ weather_yahoo {
 @author ultrabug, rail
 """
 
-import requests
-
 
 class Py3status:
 
@@ -85,7 +83,7 @@ class Py3status:
         Ask Yahoo! Weather. for a forecast
         """
         try:
-            q = requests.get(
+            q = self.py3.request(
                 'https://query.yahooapis.com/v1/public/yql?q=' +
                 'select * from weather.forecast ' +
                 'where woeid="{woeid}" and u="{units}"&format=json'.format(
@@ -93,11 +91,11 @@ class Py3status:
                 '&env=store://datatables.org/alltableswithkeys',
                 timeout=self.request_timeout
             )
-        except requests.ConnectionError:
+        except (self.py3.RequestException):
             return None, None
-        except requests.ReadTimeout:
+        if q.status_code != 200:
+            self.py3.log('Non 200 http response returned code %s' % q.status_code)
             return None, None
-        q.raise_for_status()
         r = q.json()
         try:
             today = r['query']['results']['channel']['item']['condition']

--- a/py3status/private.py
+++ b/py3status/private.py
@@ -100,6 +100,11 @@ def catch_factory(attr):
                 # so allow this usage
                 valid = True
                 break
+            if mod.__name__ == 'py3status.py3' and frame[3] == 'request':
+                # Py3.request has special needs due so it is allowed to access
+                # private variables.
+                valid = True
+                break
             if mod.__name__.startswith('py3status'):
                 # We were somewhere else in py3status than the module, maybe we
                 # are doing some logging.  Prevent usage

--- a/py3status/py3.py
+++ b/py3status/py3.py
@@ -10,8 +10,9 @@ from pprint import pformat
 from subprocess import Popen, PIPE
 from time import time
 
+from py3status import exceptions
 from py3status.formatter import Formatter, Composite
-
+from py3status.request import HttpResponse
 
 PY3_CACHE_FOREVER = -1
 PY3_LOG_ERROR = 'error'
@@ -66,6 +67,12 @@ class Py3:
     # Shared by all Py3 Instances
     _formatter = Formatter()
     _none_color = NoneColor()
+
+    # Exceptions
+    Py3Exception = exceptions.Py3Exception
+    RequestException = exceptions.RequestException
+    RequestTimeout = exceptions.RequestTimeout
+    RequestURLError = exceptions.RequestURLError
 
     def __init__(self, module=None, i3s_config=None, py3status=None):
         self._audio = None
@@ -787,3 +794,37 @@ class Py3:
         setattr(self._py3status_module, color_name, color)
 
         return color
+
+    def request(self, url, params=None, data=None, headers=None,
+                timeout=None, auth=None):
+        """
+        Make a request to a url and retrieve the results.
+
+        :param url: url to request eg `http://example.com`
+        :param params: extra query string parameters as a dict
+        :param data: POST data as a dict.  If this is not supplied the GET method will be used
+        :param headers: http headers to be added to the request as a dict
+        :param timeout: timeout for the request in seconds
+        :param auth: authentication info as tuple `(username, password)`
+
+        :returns: HttpResponse
+        """
+
+        # The aim of this function is to be a lmited lightweight replacement
+        # for the requests library but using only pythons standard libs.
+
+        # IMPORTANT NOTICE
+        # This function is excluded from private variable hiding as it is
+        # likely to need api keys etc which people may have obfuscated.
+        # Therefore it is important that no logging is done in this function
+        # that might reveal this information.
+
+        if headers is None:
+            headers = {}
+
+        return HttpResponse(url,
+                            params=params,
+                            data=data,
+                            headers=headers,
+                            timeout=timeout,
+                            auth=auth)

--- a/py3status/request.py
+++ b/py3status/request.py
@@ -1,0 +1,97 @@
+import base64
+import json
+import socket
+
+try:
+    # Python 3
+    from urllib.error import URLError, HTTPError
+    from urllib.parse import urlsplit, urlunsplit, parse_qsl, urlencode
+    from urllib.request import (
+        urlopen, Request
+    )
+    IS_PYTHON_3 = True
+except ImportError:
+    # Python 2
+    from urllib import urlencode
+    from urllib2 import (
+        urlopen, Request, URLError, HTTPError
+    )
+    from urlparse import urlsplit, urlunsplit, parse_qsl
+    IS_PYTHON_3 = False
+
+from py3status.exceptions import RequestTimeout, RequestURLError
+
+
+class HttpResponse:
+    """
+    Simple encapsulation of a http response for a url
+
+    The aim is to support both python 2 and 3 and be a simple as possible
+    """
+
+    def __init__(self, url, params, data, headers, timeout, auth):
+        # fix the url if needed
+        url_parts = urlsplit(url)
+        if url_parts.query or params:
+            # split into parts so we can update
+            parts = list(url_parts)
+            # Make sure the querystring params are correctly encoded
+            url_params = parse_qsl(parts[3])
+            if params:
+                url_params = url_params.update(params)
+            parts[3] = urlencode(url_params)
+            # rebuild the url
+            url = urlunsplit(parts)
+        request = Request(url, headers=headers)
+        if auth:
+            # we need to do the encode/decode to keep python 3 happy
+            auth_str = base64.b64encode(('%s:%s' % (auth)).encode('utf-8'))
+            request.add_header('Authorization', 'Basic %s' % auth_str.decode('utf-8'))
+        if data:
+            data = urlencode(data)
+
+        try:
+            self._response = urlopen(request, data=None, timeout=timeout)
+            self._error_message = None
+        except URLError as e:
+            reason = e.reason
+            if isinstance(reason, socket.timeout):
+                raise RequestTimeout('request timed out')
+            elif isinstance(e, HTTPError):
+                self._status_code = e.code
+                self._error_message = reason
+            else:
+                # unknown exception, so just raise it
+                raise RequestURLError(reason)
+
+    @property
+    def status_code(self):
+        """
+        Get the http status code for the response
+        """
+        try:
+            return self._status_code
+        except AttributeError:
+            self._status_code = self._response.getcode()
+        return self._status_code
+
+    @property
+    def text(self):
+        """
+        Get the raw text for the response
+        """
+        try:
+            return self._text
+        except AttributeError:
+            if IS_PYTHON_3:
+                encoding = self._response.headers.get_content_charset('utf-8')
+            else:
+                encoding = self._response.headers.getparam('charset')
+            self._text = self._response.read().decode(encoding)
+        return self._text
+
+    def json(self):
+        """
+        Return an object representing the return json for the request
+        """
+        return json.loads(self.text)


### PR DESCRIPTION
Seeing as #522 seems to have stalled here is an alternative.

it adds `py3.request()` which returns a simple object that can provide the http status code, text and json.

It allows basic authentication.
request is POST if data is supplied otherwise it will be a GET
query string params can be given in url or as a dict
headers can be supplied.
timeout can be given

I did add proxy support but it ended up getting so complicated (both as code but also testing - https is not supported well) so I removed it all.  For complex things we should just use requests (I'd like to eventually do that via this method so that for example proxies would be usable for all requests)

I've updated all the modules I was able to test.

If it seems good I'll update the documentation