### PR TITLE
allow runtime errors to be handled in i3bar

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -866,6 +866,16 @@ __update(module_name=None)__
 Update a module. If `module_name` is supplied the module of that
 name is updated. Otherwise the module calling is updated.
 
+__error(msg, timeout=None)__
+
+Raise an error for the module.
+
+`msg` message to be displayed explaining the error
+
+`timeout` how long before we should retry.  For permanent errors
+`py3.CACHE_FOREVER` should be returned.  If not supplied then the
+modules `cache_timeout` will be used.
+
 __is_color(color)__
 
 Tests to see if a color is defined.

--- a/py3status/events.py
+++ b/py3status/events.py
@@ -148,15 +148,10 @@ class Events(Thread):
             return
         module = module_info['module']
 
-        try:
-            errors = module.error_messages
-        except AttributeError:
-            errors = False
-
         # execute any configured i3-msg command
         # we do not do this for containers
         # modules that have failed do not execute their config on_click
-        if top_level and not errors:
+        if top_level and module.allow_config_clicks:
             click_module = event['name']
             if event['instance']:
                 click_module += ' ' + event['instance']

--- a/py3status/i3status.py
+++ b/py3status/i3status.py
@@ -49,6 +49,9 @@ class I3statusModule:
     def __init__(self, module_name, py3_wrapper):
         self.module_name = module_name
 
+        # i3status modules always allow user defined click events in the config
+        self.allow_config_clicks = True
+
         # i3status returns different name/instances than it is sent we want to
         # be able to restore the correct ones.
         try:

--- a/py3status/module.py
+++ b/py3status/module.py
@@ -7,7 +7,7 @@ from collections import OrderedDict
 from time import time
 
 from py3status.composite import Composite
-from py3status.py3 import Py3, PY3_CACHE_FOREVER
+from py3status.py3 import Py3, PY3_CACHE_FOREVER, ModuleErrorException
 from py3status.profiling import profile
 from py3status.formatter import Formatter
 
@@ -27,11 +27,13 @@ class Module(Thread):
         We need quite some stuff to occupy ourselves don't we ?
         """
         Thread.__init__(self)
+        self.allow_config_clicks = True
         self.cache_time = None
         self.click_events = False
         self.config = py3_wrapper.config
         self.disabled = False
         self.error_messages = None
+        self.error_hide = False
         self.has_post_config_hook = False
         self.has_kill = False
         self.i3status_thread = py3_wrapper.i3status_thread
@@ -50,6 +52,13 @@ class Module(Thread):
         self.timer = None
         self.urgent = False
 
+        # create a nice name for the module that matches what the module is
+        # called in the user config
+        if self.module_inst.startswith('_anon_module_'):
+            self.module_nice_name = self.module_name
+        else:
+            self.module_nice_name = self.module_full_name
+
         # py3wrapper this is private and any modules accessing their instance
         # should only use it on the understanding that it is not supported.
         self._py3_wrapper = py3_wrapper
@@ -63,14 +72,9 @@ class Module(Thread):
             self.disabled = True
             self.methods['error'] = {}
             self.error_index = 0
-            if self.module_inst.startswith('_anon_module_'):
-                module_name = self.module_name
-            else:
-                module_name = self.module_full_name
-
             self.error_messages = [
-                self.module_name,
-                u'{}: Import Error, {}'.format(module_name, str(e)),
+                self.module_nice_name,
+                u'{}: Import Error, {}'.format(self.module_nice_name, str(e)),
             ]
             self.error_output(self.error_messages[0])
             # log the error
@@ -126,21 +130,35 @@ class Module(Thread):
                 # the module and show error in module output
                 self.terminated = True
                 self.error_index = 0
-                if self.module_inst.startswith('_anon_module_'):
-                    module_name = self.module_name
-                else:
-                    module_name = self.module_full_name
 
                 self.error_messages = [
-                    module_name,
-                    u'{}: {}'.format(module_name, str(e) or e.__class__.__name__),
+                    self.module_nice_name,
+                    u'{}: {}'.format(self.module_nice_name, str(e) or e.__class__.__name__),
                 ]
                 self.error_output(self.error_messages[0])
                 msg = 'Exception in `%s` post_config_hook()' % self.module_full_name
                 self._py3_wrapper.report_exception(msg, notify_user=False)
                 self._py3_wrapper.log('terminating module %s' % self.module_full_name)
 
-    def error_output(self, message):
+    def runtime_error(self, msg, method):
+        """
+        Show the error in the bar
+        """
+        if self.error_hide:
+            self.hide_errors()
+            return
+        errors = [
+            self.module_nice_name,
+            u'{}: {}'.format(self.module_nice_name, msg),
+        ]
+
+        # if we have shown this error then keep in the same state
+        if self.error_messages != errors:
+            self.error_messages = errors
+            self.error_index = 0
+        self.error_output(self.error_messages[self.error_index], method)
+
+    def error_output(self, message, method_affected=None):
         """
         Something is wrong with the module so we want to output the error to
         the i3bar
@@ -159,8 +177,12 @@ class Module(Thread):
             'name': self.module_name,
         }
         for method in self.methods.values():
+            if method_affected and method['method'] != method_affected:
+                continue
+
             method['last_output'] = [error]
 
+        self.allow_config_clicks = False
         self.set_updated()
 
     def start_module(self):
@@ -615,8 +637,9 @@ class Module(Thread):
                     error = self.error_messages[self.error_index]
                     self.error_output(error)
                 if button == 3:
-                    self.disable_module()
-                self.prevent_refresh = True
+                    self.hide_errors()
+                if button != 2 or (self.terminated or self.disabled):
+                    self.prevent_refresh = True
 
             elif self.click_events:
                 click_method = getattr(self.module_class, 'on_click')
@@ -735,12 +758,29 @@ class Module(Thread):
                     if self.config['debug']:
                         self._py3_wrapper.log(
                             'method {} returned {} '.format(meth, result))
-                except Exception:
+                    self.allow_config_clicks = True
+                except ModuleErrorException as e:
+                    # module has indicated that it has an error
+                    self.runtime_error(e.msg, meth)
+                    if e.timeout:
+                        if e.timeout is PY3_CACHE_FOREVER:
+                            cache_time = PY3_CACHE_FOREVER
+                        else:
+                            cache_time = time() + e.timeout
+                    else:
+                        cache_time = time() + getattr(self.module_class,
+                                                      'cache_timeout',
+                                                      self.config['cache_timeout'])
+
+                except Exception as e:
                     msg = 'Instance `{}`, user method `{}` failed'
                     msg = msg.format(self.module_full_name, meth)
-                    notify = not self.nagged
-                    self._py3_wrapper.report_exception(msg, notify_user=notify)
-                    self.nagged = True
+                    self._py3_wrapper.report_exception(msg, notify_user=False)
+                    # added error
+                    self.runtime_error(str(e) or e.__class__.__name__, meth)
+                    cache_time = time() + getattr(self.module_class,
+                                                  'cache_timeout',
+                                                  self.config['cache_timeout'])
 
             if cache_time is None:
                 cache_time = time() + self.config['cache_timeout']

--- a/py3status/py3.py
+++ b/py3status/py3.py
@@ -26,6 +26,16 @@ except NameError:
     basestring = str
 
 
+class ModuleErrorException(Exception):
+    """
+    This exception is used to indicate that a module has returned an error
+    """
+
+    def __init__(self, msg, timeout):
+        self.msg = msg
+        self.timeout = timeout
+
+
 class NoneColor:
     """
     This class represents a color that has explicitly been set as None by the user.
@@ -206,6 +216,17 @@ class Py3:
             self._module._py3_wrapper.report_exception(
                 msg, notify_user=False, error_frame=error_frame
             )
+
+    def error(self, msg, timeout=None):
+        """
+        Raise an error for the module.
+
+        :param msg: message to be displayed explaining the error
+        :param timeout: how long before we should retry.  For permanent errors
+            `py3.CACHE_FOREVER` should be returned.  If not supplied then the
+            modules `cache_timeout` will be used.
+        """
+        raise ModuleErrorException(msg, timeout)
 
     def format_units(self, value, unit='B', optimal=5, auto=True, si=False):
         """


### PR DESCRIPTION
Following #734 this PR improves error reporting on modules to cover runtime errors.

Errors are shown in a similar manner to in #734 ie in the i3bar with click actions to `1` show more/less detail and `3` to hide the error.

Two types of runtime error are dealt with.

1) unintended errors, the module raises a uncaught exception

2) module triggered errors.  modules can call `py3.error(msg, timeout)` to trigger an error with a user defined message.  the timeout allows the module to be permanently killed or just for a limited time before trying the modules method again.

__Issue:__

Modules are allowed multiple methods.  As far as I'm aware only `netdata` uses this functionality.  I've done my best to fully support this but there is a small edge case around the event, as we cannot tell which methods output was clicked.  Personally I'd like to remove this capability as it adds complication to modules that I don't think we need (but maybe there is a good case)

