### PR TITLE
xsel: add format

### DIFF
--- a/py3status/modules/xsel.py
+++ b/py3status/modules/xsel.py
@@ -5,10 +5,13 @@ Display X selection.
 Configuration parameters:
     cache_timeout: refresh interval for this module (default 0.5)
     command: the clipboard command to run (default 'xsel -o')
-    format: display format for this module (default '{output}')
+    format: display format for this module (default '{selection}')
     max_size: strip the selection to this value (default 15)
     symmetric: show beginning and end of the selection string
         with respect to configured max_size. (default True)
+
+Format placeholders:
+    {selection} output from clipboard command
 
 Requires:
     xsel: a command-line program to retrieve/set the X selection
@@ -24,22 +27,21 @@ class Py3status:
     # available configuration parameters
     cache_timeout = 0.5
     command = 'xsel -o'
-    format = '{output}'
+    format = '{selection}'
     max_size = 15
     symmetric = True
 
     def xsel(self):
-        output = self.py3.command_output(self.command)
-        output = output.splitlines()[0]
-        if len(output) >= self.max_size:
+        selection = self.py3.command_output(self.command)
+        if len(selection) >= self.max_size:
             if self.symmetric is True:
                 split = int(self.max_size / 2) - 1
-                output = output[:split] + '..' + output[-split:]
+                selection = selection[:split] + '..' + selection[-split:]
             else:
-                output = output[:self.max_size]
+                selection = selection[:self.max_size]
         return {
             'cached_until': self.py3.time_in(self.cache_timeout),
-            'full_text': self.py3.safe_format(self.format, {'output': output})
+            'full_text': self.py3.safe_format(self.format, {'selection': selection})
         }
 
 

--- a/py3status/modules/xsel.py
+++ b/py3status/modules/xsel.py
@@ -3,15 +3,15 @@
 Display X selection.
 
 Configuration parameters:
-    cache_timeout: how often we refresh this module in seconds
-        (default 0.5)
-    command: the xsel command to run (default 'xsel -o')
-    max_size: stip the selection to this value (default 15)
-    symmetric: show the beginning and the end of the selection string
+    cache_timeout: refresh interval for this module (default 0.5)
+    command: the clipboard command to run (default 'xsel -o')
+    format: display format for this module (default '{output}')
+    max_size: strip the selection to this value (default 15)
+    symmetric: show beginning and end of the selection string
         with respect to configured max_size. (default True)
 
 Requires:
-    xsel: command line tool
+    xsel: a command-line program to retrieve/set the X selection
 
 @author Sublim3 umbsublime@gamil.com
 @license BSD
@@ -24,25 +24,23 @@ class Py3status:
     # available configuration parameters
     cache_timeout = 0.5
     command = 'xsel -o'
+    format = '{output}'
     max_size = 15
     symmetric = True
 
     def xsel(self):
-        """
-        Display the content of xsel.
-        """
         output = self.py3.command_output(self.command)
+        output = output.splitlines()[0]
         if len(output) >= self.max_size:
             if self.symmetric is True:
                 split = int(self.max_size / 2) - 1
                 output = output[:split] + '..' + output[-split:]
             else:
                 output = output[:self.max_size]
-        response = {
+        return {
             'cached_until': self.py3.time_in(self.cache_timeout),
-            'full_text': output,
+            'full_text': self.py3.safe_format(self.format, {'output': output})
         }
-        return response
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This adds format: string to print (default '{output}').

Reason for missing `format` in xsel earlier... It was already done in new module `external` which would do the job for both `external_script` and `xsel` (via external_script+ `xsel -o`). The code for both is pretty much almost same. That and severe xsel issues.

Things we wouldn't need anymore due to formatter... `max_size`, `symmetric`, 

Ongoing efforts to FORMAT ALL THE THINGS! (meme). #98