### PR TITLE
netdata: add format

### DIFF
--- a/tests/test_module_doc.py
+++ b/tests/test_module_doc.py
@@ -24,6 +24,7 @@ IGNORE_MODULE = [
 # Ignored items will not have their default values checked or be included for
 # alphabetical order purposes
 IGNORE_ITEM = [
+    ('netdata', 'format'),  # line too long for docstring parsing
     ('screenshot', 'save_path'),  # home dir issue
     ('rate_counter', 'config_file'),  # home dir issue
     ('group', 'format'),  # dynamic depending on click_mode


### PR DESCRIPTION
This adds format: string to print (default '[\?color=stuffs goes here]')

TODO: Add a missing separator. What magic to use? Pls.
TODO: Fix docstring (obv).
TODO: New PR for module enhancements after this...
└──────── Add new threshold options and such.

Ongoing efforts to FORMAT ALL THE THINGS! (meme). #98