### PR TITLE
add -- after pactl call

### DIFF
--- a/py3status/modules/volume_status.py
+++ b/py3status/modules/volume_status.py
@@ -183,10 +183,10 @@ class PactlBackend(AudioBackend):
             change = '{}%'.format(self.max_volume)
         else:
             change = '+{}%'.format(delta)
-        self.run_cmd(['pactl', 'set-sink-volume', self.device, change])
+        self.run_cmd(['pactl', '--', 'set-sink-volume', self.device, change])
 
     def volume_down(self, delta):
-        self.run_cmd(['pactl', 'set-sink-volume', self.device, '-{}%'.format(delta)])
+        self.run_cmd(['pactl', '--', 'set-sink-volume', self.device, '-{}%'.format(delta)])
 
     def toggle_mute(self):
         self.run_cmd(['pactl', 'set-sink-mute', self.device, 'toggle'])


### PR DESCRIPTION
If the volume is preceded by a '-' pactl will raise the following error:
'pactl: invalid option -- '

We need to pass '--' right after pactl:

$ pactl -- set-sink-volume -5%

Otherwise pactl tries to parse the number as an option, which it isn't. 

reference: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=686667