### PR TITLE
fix weird behavior when disabling button_up/button_down

### DIFF
--- a/py3status/modules/backlight.py
+++ b/py3status/modules/backlight.py
@@ -73,6 +73,9 @@ class Py3status:
         if not self.xbacklight:
             return None
 
+        if not self.button_up and not self.button_down:
+            return None
+
         level = self._get_backlight_level()
         button = event['button']
         if self.button_up and button == self.button_up:


### PR DESCRIPTION
When `button_up` and `button_down` are both disabled, there's now reason to give`self._set_backlight_level(level)` a call.
This just causes weird side-effects.
e.g. for me, even though I disabled both, the brightness **always** decreases no matter the direction I scroll in.
Having set `on_click 2 = ...` combined with two-finger scrolling on a touchpad makes this really awkward.