### PR TITLE
backlight fixes

### DIFF
--- a/py3status/modules/backlight.py
+++ b/py3status/modules/backlight.py
@@ -4,7 +4,7 @@ Adjust screen backlight brightness.
 
 Configuration parameters:
     brightness_delta: Change the brightness by this step.
-        (default 5)
+        (default 8)
     brightness_initial: Set brightness to this value on start.
         (default None)
     brightness_minimal: Don't go below this brightness to avoid black screen
@@ -50,7 +50,7 @@ class Py3status:
     """
     """
     # available configuration parameters
-    brightness_delta = 5
+    brightness_delta = 8
     brightness_initial = None
     brightness_minimal = 1
     button_down = 5
@@ -75,20 +75,24 @@ class Py3status:
 
         level = self._get_backlight_level()
         button = event['button']
-        if self.button_up and button == self.button_up:
+        if button == self.button_up:
             level += self.brightness_delta
             if level > 100:
                 level = 100
-        elif self.button_down and button == self.button_down:
+            self._set_backlight_level(level)
+        elif button == self.button_down:
             level -= self.brightness_delta
             if level < self.brightness_minimal:
                 level = self.brightness_minimal
-        self._set_backlight_level(level)
+            self._set_backlight_level(level)
 
     def _set_backlight_level(self, level):
-        self.py3.command_run(['xbacklight', '-set', str(level)])
+        self.py3.command_run(['xbacklight', '-time', '0', '-set', str(level)])
 
     def _get_backlight_level(self):
+        if self.xbacklight:
+            level = self.py3.command_output(['xbacklight', '-get']).strip()
+            return int(float(level))
         for brightness_line in open("%s/brightness" % self.device_path, 'rb'):
             brightness = int(brightness_line)
         for brightness_max_line in open("%s/max_brightness" % self.device_path, 'rb'):


### PR DESCRIPTION
This is in response to PR #796 by @Tadly

It does 5 things

1. only calls `_set_backlight_level()` when needed rather than on every event.

2. if we have `xbacklight` installed we use it to get the brightness rather than `/sys/class/backlight`.  THe reason for this is that we can be looking at the wrong device eg `intel_backlight` rather than `acpi_video0` which causes problems.

3. The `brightness_delta` changed from `5` to `8` the reason for this is that some displays only have 15 brightness levels and so misbehave when the delta is 5

4. slightly simplifies the button checks, as there is no need to check for `self.button_up` if it is `None`/`0` then it will not have the value `event['button']`

5. calls `xbacklight -set` with option `-time 0` this causes the update to be immediate and makes the module much more responsive.

It might change the output slightly but this is probably the correct behaviour.