### PR TITLE
skip empty modules in group

### DIFF
--- a/py3status/modules/group.py
+++ b/py3status/modules/group.py
@@ -82,6 +82,8 @@ group disks {
 
 from time import time
 
+RETRY_TIMEOUT_NO_CONTENT = 5
+
 
 class Py3status:
     # available configuration parameters
@@ -107,6 +109,7 @@ class Py3status:
             self.cycle = 0
 
         self.active = 0
+        self.last_active = 0
         self._cycle_time = time() + self.cycle
 
         self.open = bool(self.open)
@@ -174,11 +177,14 @@ class Py3status:
             return
         return self.items[self.active]
 
-    def _next(self):
-        self.active = (self.active + 1) % len(self.items)
-
-    def _prev(self):
-        self.active = (self.active - 1) % len(self.items)
+    def _change_active(self, delta):
+        # we want to ignore any empty outputs
+        # to prevent endless cycling we limit ourselves to only going through
+        # the outputs once.
+        self.active = (self.active + delta) % len(self.items)
+        if not self._get_output() and self.last_active != self.active:
+            self._change_active(delta)
+        self.last_active = self.active
 
     def group(self):
         """
@@ -194,10 +200,17 @@ class Py3status:
 
         if self.open:
             if self.cycle and time() >= self._cycle_time:
-                self._next()
+                self._change_active(1)
                 self._cycle_time = time() + self.cycle
-            current_output = self._get_output()
             update_time = self.cycle or None
+            current_output = self._get_output()
+            # if the output is empty try and find some output
+            if not current_output:
+                self._change_active(1)
+                current_output = self._get_output()
+                # there is no output for any module retry later
+                if not current_output:
+                    update_time = RETRY_TIMEOUT_NO_CONTENT
         else:
             current_output = []
             update_time = None
@@ -244,9 +257,9 @@ class Py3status:
         # reset cycle time
         self._cycle_time = time() + self.cycle
         if self.button_next and event['button'] == self.button_next:
-            self._next()
+            self._change_active(1)
         if self.button_prev and event['button'] == self.button_prev:
-            self._prev()
+            self._change_active(-1)
         if self.button_toggle and event['button'] == self.button_toggle:
             # we only toggle if button was used
             if event.get('index') == 'button':


### PR DESCRIPTION
Fix for #779

when the `group` module shows empty modules it probably should not.  In the default mode you cannot change to the next module.  When an empty group is detected we try the 'next' module.

We make sure we are not endlessly cycling and if there is no module with output we try again every 5 seconds and switch if one has content.

Although this changes the behaviour slightly I think the improvement makes sense. 