### PR TITLE
show urgent on closed containers

### DIFF
--- a/py3status/module.py
+++ b/py3status/module.py
@@ -352,6 +352,7 @@ class Module(Thread):
 
         # update all components
         color = response.get('color')
+        urgent = response.get('urgent')
         for index, item in enumerate(response['composite']):
             # validate the response
             if 'full_text' not in item:
@@ -381,6 +382,9 @@ class Module(Thread):
             # Remove any none color from our output
             if hasattr(item.get('color'), 'none_setting'):
                 del item['color']
+            # if urgent we want to set this to all parts
+            if urgent and 'urgent' not in item:
+                item['urgent'] = urgent
 
     def _params_type(self, method_name, instance):
         """

--- a/py3status/modules/frame.py
+++ b/py3status/modules/frame.py
@@ -82,8 +82,13 @@ class Py3status:
         container = True
 
     def post_config_hook(self):
+        self.urgent = False
         if '{button}' not in self.format:
             self.open = True
+        self.py3.register_function('urgent_function', self._urgent_function)
+
+    def _urgent_function(self, module_list):
+        self.urgent = True
 
     def frame(self):
 
@@ -106,10 +111,13 @@ class Py3status:
                     if self.format_separator:
                         out += [{'full_text': self.format_separator}]
                 output += out
+            urgent = False
 
             # Remove last separator
             if self.format_separator:
                 output = output[:-1]
+        else:
+            urgent = self.urgent
 
         if self.py3.format_contains(self.format, 'button'):
             if self.open:
@@ -126,10 +134,15 @@ class Py3status:
             'button': button,
         }
         output = self.py3.build_composite(self.format, composites=composites)
-        return {
+        response = {
             'cached_until': self.py3.CACHE_FOREVER,
             'composite': output,
         }
+
+        if urgent:
+            response['urgent'] = urgent
+
+        return response
 
     def on_click(self, event):
         """
@@ -138,6 +151,7 @@ class Py3status:
         if event['button'] == self.button_toggle:
             # we only toggle if button was used
             if event.get('index') == 'button' and self.py3.is_my_event(event):
+                self.urgent = False
                 self.open = not self.open
 
 

--- a/py3status/modules/group.py
+++ b/py3status/modules/group.py
@@ -110,6 +110,7 @@ class Py3status:
 
         self.active = 0
         self.last_active = 0
+        self.urgent = False
         self._cycle_time = time() + self.cycle
 
         self.open = bool(self.open)
@@ -142,6 +143,7 @@ class Py3status:
         for module in module_list:
             if module in self.items:
                 self.active = self.items.index(module)
+                self.urgent = True
 
     def _get_output(self):
         if not self.fixed_width:
@@ -199,6 +201,7 @@ class Py3status:
             }
 
         if self.open:
+            urgent = False
             if self.cycle and time() >= self._cycle_time:
                 self._change_active(1)
                 self._cycle_time = time() + self.cycle
@@ -212,6 +215,7 @@ class Py3status:
                 if not current_output:
                     update_time = RETRY_TIMEOUT_NO_CONTENT
         else:
+            urgent = self.urgent
             current_output = []
             update_time = None
 
@@ -238,6 +242,9 @@ class Py3status:
             'cached_until': cached_until,
             'composite': output
         }
+
+        if urgent:
+            response['urgent'] = urgent
         return response
 
     def on_click(self, event):
@@ -263,6 +270,7 @@ class Py3status:
         if self.button_toggle and event['button'] == self.button_toggle:
             # we only toggle if button was used
             if event.get('index') == 'button':
+                self.urgent = False
                 self.open = not self.open
 
 


### PR DESCRIPTION
This is a fix for #750 

There are lots of options but this one feels the simplest and least user invasive.

When a container is closed (so we don't see the urgent module) we just make the 'closed' container urgent.  In practical terms this means that the button will show as urgent.  The user can the decide if they wish to open the container.

This prevents the need for multiple options for what behaviour we want.  This feel a sensible default.

Currently we do not care if the module stops being urgent.  This is quite simple but requires `Module.urgent` to be exposed to modules which it is not currently.  This would trivial but then makes this PR overly complex.