### PR TITLE
fix new air quality module

### DIFF
--- a/py3status/modules/air_quality.py
+++ b/py3status/modules/air_quality.py
@@ -38,7 +38,7 @@ Color options:
 Example:
 
 ```
-aqicn {
+air_quality {
     token = 'demo'
     city = 'shanghai'
 
@@ -157,7 +157,7 @@ class Py3status:
             self.py3, color_key
         )
 
-    def aqicn(self):
+    def air_quality(self):
         data = self._call_api()
 
         return {

--- a/py3status/modules/aqicn.py
+++ b/py3status/modules/aqicn.py
@@ -94,7 +94,7 @@ def get_in(coll, path, default=None):
 
 
 class Py3status:
-    cache_timeout = 900
+    cache_timeout = 3600
     city = 'shanghai'
 
     format = 'aqicn: {aqicn}'
@@ -129,6 +129,8 @@ class Py3status:
     def _key(self, data):
         if data.get('status') == 'ok':
             aqi = get_in(data, ['data', 'aqi'], -1)
+            if type(aqi) is not int:
+                return 'unknown'
 
             for start, end, key in AQI:
                 if aqi >= start and aqi <= end:

--- a/py3status/modules/aqicn.py
+++ b/py3status/modules/aqicn.py
@@ -1,27 +1,39 @@
 # -*- coding: utf-8 -*-
 """
-# TODO: fill this docstring
-Single line summary
+Air quality plugin
 
-Longer description of the module.  This should help users understand the
-modules purpose.
+Plugin show data fetched form aqicn.org public API
 
 Configuration parameters:
-    parameter: Explanation of this parameter (default <value>)
-    parameter_other: This parameter has a longer explanation that continues
-        onto a second line so it is indented.
-        (default <value>)
+    cache_timeout: timeout for refresh data from api (default 900)
+    city: city or id of city
+        for search for Your city use curl, for example (sarching for stations in Kraków):
+        `curl http://api.waqi.info/search/?token=YOUR_TOKEN&keyword=kraków`
+        best option is choice uid instead city name: city = '@8691'
+        (default 'shanghai')
+    format: format string used for text in bar (default 'aqicn: {aqicn}')
+    good: (default 'Good')
+    hazardous: (default 'Hazardous')
+    moderate: (default 'Moderate')
+    token: token from http://aqicn.org (default 'demo')
+    unhealty: (default 'Unhealty')
+    unhealty_sensitive: (default 'Kinda Unhealty')
+    unknown: (default 'Unknown')
+    very_unhealty: (default 'Very Unhealthy')
 
 Format placeholders:
-    {info} Description of the placeholder
+    {aqicn} air quality (text, configurable by options)
+    {aqi} air quality
+    {pm25} paramers from `iaqi` array
 
 Color options:
-    color_meaning: what this signifies, defaults to color_good
-    color_meaning2: what this signifies
-
-Requires:
-    program: Information about the program
-    python_lib: Information on the library
+    color_good: for good aqi
+    color_hazardous: for hazardous aqi
+    color_moderate: for moderate aqi
+    color_unhealty: for unhealty aqi
+    color_unhealty_sensitive: for unhealty for sensitive persons aqi
+    color_unknown: for unknow
+    color_very_unhealty: for very uhealty
 
 Example:
 
@@ -29,13 +41,22 @@ Example:
 aqicn {
     token = 'demo'
     city = 'shanghai'
+
+    format = 'shanghai: {aqicn}'
+
+    color_good = '#009966'
+    color_hazardous = '#7E0023'
+    color_moderate = '#FFDE33'
+    color_unhealty = '#CC0033'
+    color_unhealty_sensitive = '#FF9933'
+    color_unknown = '#FFFFFF'
+    color_very_unhealty = '#660099'
 }
 ```
 
 @author beetleman
 @license BSD
 """
-import functools
 
 try:
     # python 3
@@ -73,28 +94,18 @@ def get_in(coll, path, default=None):
 
 
 class Py3status:
-    good = 'Good'
-    moderate = 'Moderate'
-    unhealty_sensitive = 'Kinda Unhealty'
-    unhealty = 'Unhealty'
-    very_unhelty = 'Very Unhealthy'
-    hazardous = 'Hazardous'
-    unknown = 'Unknown'
-
-    color_good = '#009966'
-    color_moderate = '#FFDE33'
-    color_unhealty_sensitive = '#FF9933'
-    color_unhealty = '#CC0033'
-    color_very_unhelty = '#660099'
-    color_hazardous = '#7E0023'
-    color_unknown = '#FFFFFF'
-
-    token = 'demo'
+    cache_timeout = 900
     city = 'shanghai'
 
-    cache_timeout = 900
-
     format = 'aqicn: {aqicn}'
+    good = 'Good'
+    hazardous = 'Hazardous'
+    moderate = 'Moderate'
+    token = 'demo'
+    unhealty = 'Unhealty'
+    unhealty_sensitive = 'Kinda Unhealty'
+    unknown = 'Unknown'
+    very_unhealty = 'Very Unhealthy'
 
     def _call_api(self):
         kwargs = {
@@ -148,12 +159,11 @@ class Py3status:
 
     def aqicn(self):
         data = self._call_api()
-        key = self._key(data)
 
         return {
-           'cached_until': self.py3.time_in(self.cache_timeout),
-           'full_text': self._full_text(data),
-           'color': self._color(data)
+            'cached_until': self.py3.time_in(self.cache_timeout),
+            'full_text': self._full_text(data),
+            'color': self._color(data)
         }
 
 

--- a/py3status/modules/aqicn.py
+++ b/py3status/modules/aqicn.py
@@ -1,0 +1,152 @@
+# -*- coding: utf-8 -*-
+"""
+# TODO: fill this docstring
+Single line summary
+
+Longer description of the module.  This should help users understand the
+modules purpose.
+
+Configuration parameters:
+    parameter: Explanation of this parameter (default <value>)
+    parameter_other: This parameter has a longer explanation that continues
+        onto a second line so it is indented.
+        (default <value>)
+
+Format placeholders:
+    {info} Description of the placeholder
+
+Color options:
+    color_meaning: what this signifies, defaults to color_good
+    color_meaning2: what this signifies
+
+Requires:
+    program: Information about the program
+    python_lib: Information on the library
+
+Example:
+
+```
+aqicn {
+    token = 'demo'
+    city = 'shanghai'
+}
+```
+
+@author beetleman
+@license BSD
+"""
+import functools
+
+try:
+    # python 3
+    from urllib.error import URLError
+    from urllib.request import urlopen, Request
+    from urllib.parse import urlencode
+except ImportError:
+    # python 2
+    from utllib2 import urlencode
+    from urllib2 import URLError
+    from urllib2 import urlopen, Request
+
+import json
+
+
+AQI = (
+    (0, 50, 'good'),
+    (51, 100, 'moderate'),
+    (101, 150, 'unhealty_sensitive'),
+    (151, 200, 'unhealty'),
+    (201, 300, 'very_unhealty'),
+    (300, None, 'hazardous')
+)
+
+
+BASE_URL = 'http://api.waqi.info'
+
+
+class Py3status:
+    good = 'Good'
+    moderate = 'Moderate'
+    unhealty_sensitive = 'Kinda Unhealty'
+    unhealty = 'Unhealty'
+    very_unhelty = 'Very Unhealthy'
+    hazardous = 'Hazardous'
+    unknown = 'Unknown'
+
+    color_good = '#009966'
+    color_moderate = '#FFDE33'
+    color_unhealty_sensitive = '#FF9933'
+    color_unhealty = '#CC0033'
+    color_very_unhelty = '#660099'
+    color_hazardous = '#7E0023'
+    color_unknown = '#FFFFFF'
+
+    token = 'demo'
+    city = 'shanghai'
+
+    cache_timeout = 900
+
+    format = 'aqicn: {aqicn}'
+
+    def _call_api(self):
+        kwargs = {
+            'token': self.token
+        }
+        url_part = 'feed/{}'.format(self.city)
+
+        url = '{base_url}/{url_part}/?{query}'.format(
+            base_url=BASE_URL,
+            url_part=url_part,
+            query=urlencode(kwargs)
+        )
+
+        req = Request(url)
+        try:
+            resp = urlopen(req)
+            return json.loads(resp.read().decode('utf8'))
+        except URLError:
+            return {}
+
+    def _key(self, data):
+        if data.get('status') == 'ok':
+            try:
+                aqi = int(data['data']['aqi'])
+            except:
+                return None
+
+            for start, end, key in AQI:
+                if aqi >= start and aqi <= end:
+                    return key
+
+        return None
+
+    def _full_text(self, key):
+       aqicn = getattr(self, key, self.unknown)
+       return self.format.format(aqicn=aqicn)
+
+    def _color(self, key):
+        color_key_default = 'color_{}'.format(key)
+        color_key = color_key_default.upper()
+        return getattr(
+            self.py3, color_key
+        ) or getattr(
+            self, color_key_default, self.color_unknown
+        )
+
+    def aqicn(self):
+       data = self._call_api()
+       key = self._key(data)
+
+       return {
+           'cached_until': self.py3.time_in(self.cache_timeout),
+           'full_text': self._full_text(key),
+           'color': self._color(key)
+       }
+
+
+if __name__ == "__main__":
+    """
+    Run module in test mode.
+    """
+    from py3status.module_test import module_test
+    module_test(Py3status)

--- a/py3status/modules/aqicn.py
+++ b/py3status/modules/aqicn.py
@@ -65,7 +65,7 @@ try:
     from urllib.parse import urlencode
 except ImportError:
     # python 2
-    from utllib2 import urlencode
+    from urllib import urlencode
     from urllib2 import URLError
     from urllib2 import urlopen, Request
 
@@ -153,8 +153,6 @@ class Py3status:
         color_key = color_key_default.upper()
         return getattr(
             self.py3, color_key
-        ) or getattr(
-            self, color_key_default, self.color_unknown
         )
 
     def aqicn(self):


### PR DESCRIPTION
Courtesy of @beetleman. https://github.com/ultrabug/py3status/pull/746

This covers all remarks.
Style in compliance with other modules.

* ~~TODO: Replace `oldthing` w/ `py3.request` L130~~
* ~~TODO: Decide on using `{icon}` or `{category}`~~
&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;~~and~~
* ~~TODO: Decide on using `icon_*` or `category_*`~~
I decided on `{category}` and `category_*`. Fight me irl.

To make this more well around, we would have to add things that allows users to override things for i8ln... or they could do that in their own copy of  customized `air_quality` module.
* `aqi_policies = ''` -- Override custom policies
* `aqi_categories = ''` -- Override custom categories
* `aqi_colors = ''` -- Override custom colors
* `aqi_url = ''` -- Override URL

Please take a look. Many thanks.