### PR TITLE
getjson: use py3.request() + bugfix

### DIFF
--- a/py3status/modules/getjson.py
+++ b/py3status/modules/getjson.py
@@ -52,12 +52,6 @@ Format placeholders:
 """
 
 import collections
-import json
-try:
-    # python3
-    from urllib.request import urlopen
-except:
-    from urllib2 import urlopen
 
 
 class Py3status:
@@ -97,10 +91,10 @@ class Py3status:
         """
         """
         try:
-            resp = urlopen(self.url, timeout=self.timeout)
-            status = resp.getcode() == 200
-            resp = json.loads(resp.read())
-        except Exception:
+            resp = self.py3.request(self.url, timeout=self.timeout)
+            status = resp.status_code == 200
+            resp = resp.json()
+        except self.Py3.RequestException:
             resp = None
             status = False
         return resp, status

--- a/py3status/request.py
+++ b/py3status/request.py
@@ -87,7 +87,7 @@ class HttpResponse:
                 encoding = self._response.headers.get_content_charset('utf-8')
             else:
                 encoding = self._response.headers.getparam('charset')
-            self._text = self._response.read().decode(encoding)
+            self._text = self._response.read().decode(encoding or 'utf-8')
         return self._text
 
     def json(self):


### PR DESCRIPTION
Convert `getjson` module to use `py3.request()`

There was also a bug where we might not get a charset so we now default to utf-8