### PR TITLE
arch_updates: add format 

### DIFF
--- a/tests/test_module_doc.py
+++ b/tests/test_module_doc.py
@@ -41,6 +41,7 @@ IGNORE_ITEM = [
     ('group', 'format'),  # dynamic depending on click_mode
     ('github', 'format'),  # dynamic
     ('kdeconnector', '_dev'),  # move to __init__ etc
+    ('arch_updates', 'format'),  # line too long for docstring parsing
 ]
 
 # Obsolete parameters will not have alphabetical order checked

--- a/tests/test_module_doc.py
+++ b/tests/test_module_doc.py
@@ -41,7 +41,6 @@ IGNORE_ITEM = [
     ('group', 'format'),  # dynamic depending on click_mode
     ('github', 'format'),  # dynamic
     ('kdeconnector', '_dev'),  # move to __init__ etc
-    ('arch_updates', 'format'),  # dynamic
 ]
 
 # Obsolete parameters will not have alphabetical order checked


### PR DESCRIPTION
This adds format: string to print (default '{updates}')

Fixes my first issue w/ `arch_updates` juggling between three strings.

If we add formatter features someday #752, we could update someday using something like... `[\?if=pacman&if=aur /{aur}]`. May need something opposite of `if`... maybe `\?not`?

`format = [\?if=pacman&not=aur PAC: {pacman}][\?not=pacman&if=aur AUR: {aur}][\?if=pacman&if=aur UPD:  {pacman}/{aur}]`. I dunno. Rough idea.

Ongoing efforts to FORMAT ALL THE THINGS! (meme). #98