### PR TITLE
bugfix: missing function

### DIFF
--- a/py3status/module.py
+++ b/py3status/module.py
@@ -185,6 +185,16 @@ class Module(Thread):
         self.allow_config_clicks = False
         self.set_updated()
 
+    def hide_errors(self):
+        """
+        hide the module in the i3bar
+        """
+        for method in self.methods.values():
+            method['last_output'] = {}
+
+        self.allow_config_clicks = False
+        self.set_updated()
+
     def start_module(self):
         """
         Start the module running.


### PR DESCRIPTION
I think this must have been lost to a `git stash` at some point.

When we dismiss an errored module