### PR TITLE
documentation VIII (integration)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,7 @@ dist
 
 # sphinx build system
 doc/_build
+modules-info.inc
+py3-constants-info.inc
+py3-exceptions-info.inc
+py3-methods-info.inc

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -2,6 +2,7 @@
 # -*- coding: utf-8 -*-
 import re
 
+from py3status.autodoc import create_auto_documentation
 from py3status.version import version as py3_version
 
 # py3status documentation build configuration file, created by
@@ -164,3 +165,10 @@ version_info = [s for s in re.split('([0-9]+)', py3_version) if s.isdigit()][:2]
 version = '.'.join(version_info)
 # The full version, including alpha/beta/rc tags.
 release = py3_version
+
+
+def setup(sphinx):
+    """
+    This will be called by sphinx.
+    """
+    create_auto_documentation()

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -3,6 +3,7 @@
 Using modules
 =============
 
+py3status comes with a large range of :ref:`modules`.
 Modules in py3status are configured using your usual ``i3status.conf``.
 
 py3status tries to find the config in the following locations:
@@ -17,14 +18,6 @@ py3status tries to find the config in the following locations:
 
 You can also specify the config location using ``py3status -c <path to config
 file>`` in your i3 configuration file.
-
-Available modules
------------------
-
-py3status comes with a large range of modules.
-
-`List of available modules and their configuration details
-<https://github.com/ultrabug/py3status/blob/master/py3status/modules/README.md>`_
 
 
 Loading a py3status module and ordering modules output
@@ -226,8 +219,7 @@ Some modules may allow more than one threshold to be defined.  If all the thresh
 Grouping Modules
 ----------------
 
-The `group
-<https://github.com/ultrabug/py3status/blob/master/py3status/modules/README.md#group>`_
+The :ref:`module_group`
 module allows you to group several modules together.  Only one of the
 modules are displayed at a time.  The displayed module can either be cycled
 through automatically or by user action (the default, on mouse scroll).
@@ -260,8 +252,7 @@ This module is very powerful and allows you to save a lot of space on your bar.
         }
     }
 
-The `frame
-<https://github.com/ultrabug/py3status/blob/master/py3status/modules/README.md#frame>`_
+The :ref:`module_frame`
 module also allows you to group several modules together, however in a frame
 all the modules are shown.  This allows you to have more than one module shown
 in a group.
@@ -389,7 +380,7 @@ below.
     }
 
     # run thunar when I left click on the / disk info module
-    disk / {
+    disk "/" {
         format = "/ %free"
         on_click 1 = "exec thunar /"
     }

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -9,3 +9,10 @@ Welcome to py3status's documentation!
 .. toctree::
    :maxdepth: 2
    :caption: Contents:
+
+   intro
+   modules
+   configuration
+   writing_modules
+   py3
+   contributing

--- a/doc/intro.rst
+++ b/doc/intro.rst
@@ -1,8 +1,6 @@
 Introduction
 ============
 
-.. image:: screenshots/main.png
-
 Using py3status, you can take control of your i3bar easily by:
 
 * using one of the available :ref:`modules` shipped with py3status
@@ -111,9 +109,9 @@ To get more details about all available modules and their configuration, use:
 
     $ py3status modules details
 
-All modules shipped with py3status are present as the Python source files in the `py3status/modules <../py3status/modules>`_ directory.
+All modules shipped with py3status are present as the Python source files in
+the ``py3status/modules`` directory.
 
-Most of them are **configurable directly from your current i3status.conf**, check them out to see all the configurable variables.
 
 Options
 ^^^^^^^

--- a/doc/modules.rst
+++ b/doc/modules.rst
@@ -1,0 +1,8 @@
+.. _modules:
+
+Modules
+=======
+
+py3status comes with a large selection of modules ready to use.  For information on configurating see :ref:`using_modules`
+
+.. include:: modules-info.inc

--- a/doc/py3.rst
+++ b/doc/py3.rst
@@ -1,0 +1,25 @@
+
+.. _py3:
+
+py3 module helper
+=================
+
+Py3 is a special helper object that gets injected into py3status modules,
+providing extra functionality. A module can access it via the ``self.py3``
+instance attribute of its py3status class.
+
+Constants
+---------
+
+.. include:: py3-constants-info.inc
+
+Exceptions
+----------
+
+.. include:: py3-exceptions-info.inc
+
+Methods
+-------
+
+.. include:: py3-methods-info.inc
+

--- a/doc/writing_modules.rst
+++ b/doc/writing_modules.rst
@@ -87,7 +87,7 @@ self.py3
 
 This is a special object that gets injected into py3status
 modules. It helps provide functionality for the module, such as the
-``CACHE_FOREVER`` constant. Read more here: ref:`py3`.
+``CACHE_FOREVER`` constant. Read more about the :ref:`py3`.
 
 
 Example 2: Configuration parameters
@@ -184,7 +184,8 @@ The ``__init__()`` method is called when our class is instantiated.
 .. note::
     __init__ is called before any config parameters have been set.
 
-We use the ``safe_format()`` method of ``py3`` for formatting. Read more here: :ref:`py3`.
+We use the ``safe_format()`` method of ``py3`` for formatting. Read more about
+the :ref:`py3`.
 
 Example 4: Status string placeholders
 -------------------------------------

--- a/py3status/autodoc.py
+++ b/py3status/autodoc.py
@@ -45,6 +45,7 @@ def create_module_docs():
     out = []
     # details
     for module in sorted(data.keys()):
+        out.append('\n.. _module_%s:\n' % module)  # reference for linking
         out.append(
             '\n{name}\n{underline}\n\n{details}\n'.format(
                 name=module,

--- a/py3status/modules/graphite.py
+++ b/py3status/modules/graphite.py
@@ -40,19 +40,27 @@ Configuration parameters:
         (default True)
 
 Dynamic format placeholders:
-        The "format" parameter placeholders are dynamically based on the data points
-        names returned by the "targets" query to graphite.
+        The "format" parameter placeholders are dynamically based on the data
+        points names returned by the "targets" query to graphite.
 
-    For example if your target is "carbon.agents.localhost-a.memUsage", you'd get
-    a JSON result like this:
-        {"target": "carbon.agents.localhost-a.memUsage", "datapoints": [[19693568.0, 1463663040]]}
+    For example if your target is `"carbon.agents.localhost-a.memUsage"`,
+    you'd get a JSON result like this:
+
+        ```
+        {
+            "target": "carbon.agents.localhost-a.memUsage",
+            "datapoints": [[19693568.0, 1463663040]]
+        }
+        ```
 
     So the placeholder you could use on your "format" config is:
-        format = "{carbon.agents.localhost-a.memUsage}"
+        `format = "{carbon.agents.localhost-a.memUsage}"`
 
     TIP: use aliases !
+        ```
         targets = "alias(carbon.agents.localhost-a.memUsage, 'local_memuse')"
         format = "local carbon mem usage: {local_memuse} bytes"
+        ```
 
 Color options:
     color_bad: threshold_bad has been exceeded


### PR DESCRIPTION
This PR brings the documentation together so we can view the content http://py3status.readthedocs.io/en/documentation-part-8

* We call `autodoc.create_auto_documentation()` from `doc/conf.py`

* Fixing some of the links and allowing references to individual modules

* Minor text cleanups and additions

* update `.gitignore` for auto-generated files

* Clean up the `graphite` docstring slightly as it was causing a sphinx indentation warning

Once this is merged then I think we are ready to start using this as the new source of py3status documentation.