### PR TITLE
documentation IX (module screenshots)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,5 @@ dist
 .cache/
 
 # sphinx build system
+doc/screenshots
 doc/_build

--- a/doc/doc-requirements.txt
+++ b/doc/doc-requirements.txt
@@ -1,0 +1,2 @@
+Pillow>=3.4.2
+fonttools

--- a/py3status/autodoc.py
+++ b/py3status/autodoc.py
@@ -2,8 +2,12 @@
 
 import ast
 import inspect
+import os.path
+import re
+
 
 from py3status.docstrings import core_module_docstrings
+from py3status.screenshots import create_screenshots, get_samples
 from py3status.py3 import Py3
 
 
@@ -36,18 +40,60 @@ def markdown_2_rst(lines):
     return out
 
 
+def file_sort(my_list):
+    """
+    Sort a list of files in a nice way.
+    eg item-10 will be after item-9
+    """
+    def alphanum_key(key):
+        """
+        Split the key into str/int parts
+        """
+        return [int(s) if s.isdigit() else s for s in re.split('([0-9]+)', key)]
+
+    my_list.sort(key=alphanum_key)
+    return my_list
+
+
+def screenshots(screenshots_data, module_name):
+    """
+    Create .rst output for any screenshots a module may have.
+    """
+    shots = screenshots_data.get(module_name)
+    if not shots:
+        return('')
+
+    out = []
+    for shot in file_sort(shots):
+        if not os.path.exists('../doc/screenshots/%s.png' % shot):
+            continue
+        out.append(
+            u'\n.. image:: screenshots/{}.png\n\n'.format(shot)
+        )
+    return u''.join(out)
+
+
 def create_module_docs():
     """
     Create documentation for modules.
     """
     data = core_module_docstrings(format='rst')
+    # get screenshot data
+    screenshots_data = {}
+    samples = get_samples()
+    for sample in samples.keys():
+        module = sample.split('-')[0]
+        if module not in screenshots_data:
+            screenshots_data[module] = []
+        screenshots_data[module].append(sample)
 
     out = []
     # details
     for module in sorted(data.keys()):
         out.append(
-            '\n{name}\n{underline}\n\n{details}\n'.format(
+            '\n{name}\n{underline}\n\n{screenshots}{details}\n'.format(
                 name=module,
+                screenshots=screenshots(screenshots_data, module),
                 underline='-' * len(module),
                 details=''.join(markdown_2_rst(data[module])).strip()
             )
@@ -208,6 +254,8 @@ def create_auto_documentation():
     """
     Create any include files needed for sphinx documentation
     """
+    create_screenshots()
+
     create_module_docs()
     create_py3_docs()
 

--- a/py3status/docstrings.py
+++ b/py3status/docstrings.py
@@ -69,7 +69,15 @@ def core_module_docstrings(include_core=True, include_user=False, config=None,
         path, module_type = paths[name]
         with open(path) as f:
             module = ast.parse(f.read())
-            docstring = ast.get_docstring(module)
+            raw_docstring = ast.get_docstring(module)
+
+            # prevent issue when no docstring exists
+            if raw_docstring is None:
+                continue
+
+            # remove any sample outputs
+            parts = re.split('^SAMPLE OUTPUT$', raw_docstring, flags=re.M)
+            docstring = parts[0]
 
             if format == 'md':
                 docstring = [

--- a/py3status/modules/battery_level.py
+++ b/py3status/modules/battery_level.py
@@ -69,6 +69,12 @@ Requires:
 
 @author shadowprince, AdamBSteele, maximbaz, 4iar, m45t3r
 @license Eclipse Public License
+
+SAMPLE OUTPUT
+{'color': '#FCE94F', 'full_text': u'\u26a1'}
+
+discharging
+{'color': '#FF0000', 'full_text': u'\u2340'}
 """
 
 from __future__ import division  # python2 compatibility

--- a/py3status/screenshots.py
+++ b/py3status/screenshots.py
@@ -1,0 +1,267 @@
+# -*- coding: utf-8 -*-
+"""
+This file is used for the generation of screenshots for py3status
+documentation.
+
+outside of pythons standard library there are the following requirements:
+
+    Pillow==3.4.2
+    fonttools
+
+PIL may work if installed but is not supported.
+"""
+
+from __future__ import division
+
+import ast
+import os
+import re
+
+from hashlib import md5
+
+from PIL import Image, ImageFont, ImageDraw
+from fontTools.ttLib import TTFont
+
+
+WIDTH = 650
+TOP_BAR_HEIGHT = 5
+BAR_HEIGHT = 24
+X_OFFSET = 5
+PADDING = 4
+
+SEP_PADDING_LEFT = 4
+SEP_PADDING_RIGHT = SEP_PADDING_LEFT + 1
+
+SEP_BORDER = 4
+
+FONT = 'DejaVuSansMono.ttf'
+
+# Pillow does poor font rendering so we are best of creating huge text and then
+# shrinking with anti-aliasing.  SCALE is how many times bigger we render the
+# test
+SCALE = 8
+
+COLOR = '#FFFFFF'
+COLOR_BG = '#000000'
+COLOR_PY3STATUS = '#FFFFFF'
+COLOR_SEP = '#666666'
+COLOR_URGENT = '#FFFFFF'
+COLOR_URGENT_BG = '#900000'
+
+FONT_SIZE = BAR_HEIGHT - (PADDING * 2)
+HEIGHT = TOP_BAR_HEIGHT + BAR_HEIGHT
+
+
+def get_color_for_name(module_name):
+    """
+    Create a custom color for a given string.
+    This allows the screenshots to each have a unique color but for that color
+    to be consistent.
+    """
+    # all screenshots of the same module should be a uniform color
+    module_name = module_name.split('-')[0]
+
+    saturation = 0.5
+    value = 243.2
+    try:
+        module_name = module_name.encode('utf-8')
+    except:
+        pass
+    hue = int(md5(module_name).hexdigest(), 16) / 16**32
+    hue *= 6
+    hue += 3.708
+    r, g, b = (
+        (value, value - value * saturation * abs(1 - hue % 2), value - value *
+         saturation) * 3)[5**int(hue) // 3 % 3::int(hue) % 2 + 1][:3]
+    return '#' + '%02x' * 3 % (int(r), int(g), int(b))
+
+
+def contains_bad_glyph(glyph_data, data):
+    """
+    Pillow only looks for glyphs in the font used so we need to make sure our
+    font has the glygh.  Although we could substitute a glyph from another font
+    eg symbola but this adds more complexity and is of limited value.
+    """
+    def check_glyph(char):
+        for cmap in glyph_data['cmap'].tables:
+            if cmap.isUnicode():
+                if char in cmap.cmap:
+                    return True
+        return False
+
+    for part in data:
+        text = part.get('full_text', '')
+        try:
+            # for python 2
+            text = text.decode('utf8')
+        except:
+            pass
+
+        for char in text:
+            if not check_glyph(ord(char)):
+                # we have not found a character in the font
+                print(u'%s (%s) missing' % (char, ord(char)))
+                return True
+    return False
+
+
+def create_screenshot(name, data, path, font, module=True):
+    """
+    Create screenshot of py3status output and save to path
+    """
+    desktop_color = get_color_for_name(name)
+
+    # if this screenshot is for a module then add modules name etc
+    if module:
+        data.append(
+            {
+                'full_text': name.split('-')[0],
+                'color': desktop_color,
+                'separator': True,
+            }
+        )
+        data.append(
+            {
+                'full_text': 'py3status',
+                'color': COLOR_PY3STATUS,
+                'separator': True,
+            }
+        )
+
+    img = Image.new('RGB', (WIDTH, HEIGHT), COLOR_BG)
+    d = ImageDraw.Draw(img)
+
+    # top bar
+    d.rectangle((0, 0, WIDTH, TOP_BAR_HEIGHT), fill=desktop_color)
+    x = X_OFFSET
+
+    # add text and separators
+    for part in reversed(data):
+        text = part.get('full_text')
+        color = part.get('color', COLOR)
+        background = part.get('background')
+        separator = part.get('separator')
+        urgent = part.get('urgent')
+
+        # urgent background
+        if urgent:
+            color = COLOR_URGENT
+            background = COLOR_URGENT_BG
+
+        size = font.getsize(text)
+
+        if background:
+            d.rectangle((WIDTH - x - (size[0] // SCALE),
+                         TOP_BAR_HEIGHT + PADDING,
+                         WIDTH - x - 1,
+                         HEIGHT - PADDING,
+                         ), fill=background)
+
+        x += size[0] // SCALE
+
+        txt = Image.new('RGB', size, background or COLOR_BG)
+        d_text = ImageDraw.Draw(txt)
+        d_text.text((0, 0), text, font=font, fill=color)
+        # resize to actual size wanted and add to image
+        txt = txt.resize((size[0] // SCALE, size[1] // SCALE), Image.ANTIALIAS)
+        img.paste(txt, (WIDTH - x, TOP_BAR_HEIGHT + PADDING))
+
+        if separator:
+            x += SEP_PADDING_RIGHT
+            d.line(((WIDTH - x, TOP_BAR_HEIGHT + PADDING),
+                    (WIDTH - x, TOP_BAR_HEIGHT + 1 + PADDING + FONT_SIZE)),
+                   fill=COLOR_SEP, width=1)
+            x += SEP_PADDING_LEFT
+
+    img.save(os.path.join(path, '%s.png' % name))
+    print(' %s.png' % name)
+
+
+def parse_sample_data(sample_data, module_name):
+    """
+    Parse sample output definitions and return a dict
+    {screenshot_name: sample_output}
+    """
+    samples = {}
+    name = None
+    data = ''
+    count = 0
+    for line in sample_data.splitlines() + ['']:
+        if line == '':
+            if data:
+                if name:
+                    name = u'%s-%s-%s' % (module_name, count, name)
+                else:
+                    name = module_name
+                try:
+                    output = ast.literal_eval(data)
+                    samples[name] = output
+                except:
+                    samples[name] = 'SAMPLE DATA ERROR'
+                name = None
+                data = ''
+                count += 1
+            continue
+        if name is None and data == '' and not line[0] in ['[', '{']:
+            name = line
+            continue
+        else:
+            data += line
+    return samples
+
+
+def get_samples():
+    '''
+    Look in all core modules and get any samples from the docstrings.
+    return a dict {screenshot_name: sample_output}
+    '''
+    samples = {}
+    module_dir = os.path.join(
+        os.path.dirname(os.path.abspath(__file__)), 'modules')
+    for file in sorted(os.listdir(module_dir)):
+        if file.endswith('.py') and file != '__init__.py':
+            module_name = file[:-3]
+            with open(os.path.join(module_dir, file), 'r') as f:
+                module = ast.parse(f.read())
+                raw_docstring = ast.get_docstring(module)
+                if raw_docstring is None:
+                    continue
+                parts = re.split('^SAMPLE OUTPUT$', raw_docstring, flags=re.M)
+                if len(parts) == 1:
+                    continue
+                sample_data = parts[1]
+                samples.update(parse_sample_data(sample_data, module_name))
+    return samples
+
+
+def create_screenshots(quiet=False):
+    """
+    create screenshots for all core modules.
+    The screenshots directory will have all .png files deleted before new shots
+    are created.
+    """
+
+    path = '../doc/screenshots'
+    # create dir if not exists
+    try:
+        os.makedirs(path)
+    except OSError:
+        pass
+
+    print('Creating screenshots...')
+    samples = get_samples()
+    font = ImageFont.truetype(FONT, FONT_SIZE * SCALE)
+    glyph_data = TTFont(font.path)
+    for name, data in sorted(samples.items()):
+        # make sure that the data is in list form
+        if not isinstance(data, list):
+            data = [data]
+
+        if contains_bad_glyph(glyph_data, data):
+            print('** %s has characters not in %s **' % (name, font.getname()[0]))
+        else:
+            create_screenshot(name, data, path, font=font)
+
+
+if __name__ == '__main__':
+    create_screenshots()


### PR DESCRIPTION
This PR adds screenshots to the new module documentation.  Thanks to @lasers for his idea and support for this feature.

Screenshots are defined in a `SAMPLE OUTPUT` section of the modules docstring.  Multiple samples can be defined.

`autodoc.py` calls the creation of the screenshots and then adds any for a module when documentation is created.

 `screenshots.py` does most of the work.  screenshots can be generated by running it directly eg `python screenshots.py`.  We use Pillow to create the images.  The reason for this is that it is available in the readthedocs build system and works well enough.  It has the limitation that it cannot do substitution for glyphs not supported by the chosen font.  As we are using `DejaVuMono` the support is generally good, so far only the 🕝 char.

I wrote some code that will substitute fonts but it was quite long and then I discovered that none of the font on the readthedocs build machine had this char either it is in Symbola which is not installed.  So now we just use `DejaVuMono` and skip any modules that use unsupported characters.

If we are happy with this code/approach I'll add some documentation about it and add some tests.

This PR updates the output of `module-info.inc` 