### PR TITLE
bugfix: py3.request() parameters

### DIFF
--- a/py3status/request.py
+++ b/py3status/request.py
@@ -38,7 +38,8 @@ class HttpResponse:
             # Make sure the querystring params are correctly encoded
             url_params = parse_qsl(parts[3])
             if params:
-                url_params = url_params.update(params)
+                for key, value in params.items():
+                    url_params.append((key, value))
             parts[3] = urlencode(url_params)
             # rebuild the url
             url = urlunsplit(parts)


### PR DESCRIPTION
So `parse_qsl()` returns a list of tuples not a dict.  Therefore we need to append params as tuples.