### PR TITLE
bugfix prevent terminated modules from being enabled

### DIFF
--- a/py3status/module.py
+++ b/py3status/module.py
@@ -208,7 +208,7 @@ class Module(Thread):
         """
         Forces an update of the module.
         """
-        if self.disabled:
+        if self.disabled or self.terminated:
             return
         # clear cached_until for each method to allow update
         for meth in self.methods:


### PR DESCRIPTION
A module is terminated because it failed to load or raised an exception in `post_config_hook()`

However `killall -USR1 py3status` will cause the module to get started when it shouldn't.

This trivial patch fixes the issue.