### PR TITLE
ensure normal click behaviour

### DIFF
--- a/py3status/module.py
+++ b/py3status/module.py
@@ -772,7 +772,10 @@ class Module(Thread):
                     if self.config['debug']:
                         self._py3_wrapper.log(
                             'method {} returned {} '.format(meth, result))
+                    # module working correctly so ensure module works as
+                    # expected
                     self.allow_config_clicks = True
+                    self.error_messages = None
                 except ModuleErrorException as e:
                     # module has indicated that it has an error
                     self.runtime_error(e.msg, meth)


### PR DESCRIPTION
If a module errors and then starts working correctly we still catch some clicks and behave like we are in error eg button 3 hides the module.  This PR fixes this so things behave as expected.