### PR TITLE
window_title_async: use post_config_hook

### DIFF
--- a/py3status/modules/window_title_async.py
+++ b/py3status/modules/window_title_async.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 """
-Display current window title asynchronously.
+Display window title asynchronously.
 
 Uses asynchronous update via i3 IPC events.
 Provides instant title update only when it required.
@@ -37,7 +37,7 @@ class Py3status:
     format = "{title}"
     max_width = 120
 
-    def __init__(self):
+    def post_config_hook(self):
         self.title = self.empty_title
 
         # we are listening to i3 events in a separate thread
@@ -112,12 +112,10 @@ class Py3status:
         conn.main()  # run the event loop
 
     def window_title_async(self):
-        resp = {
+        return {
             'cached_until': self.py3.CACHE_FOREVER,
             'full_text': self.title,
         }
-
-        return resp
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
We convert `__init__` to `post_config_hook` here.