### PR TITLE
coin_balance: use post_config_hook

### DIFF
--- a/py3status/modules/coin_balance.py
+++ b/py3status/modules/coin_balance.py
@@ -125,7 +125,7 @@ class Py3status:
     protocol = 'http'
     username = None
 
-    def __init__(self):
+    def post_config_hook(self):
         self._active_coins = []
         self._config = None
         self._credential_cache = {}


### PR DESCRIPTION
We convert `__init__` to `post_config_hook` here.
I can't test this.