### PR TITLE
xrandr_rotate: use post_config_hook

### DIFF
--- a/py3status/modules/xrandr_rotate.py
+++ b/py3status/modules/xrandr_rotate.py
@@ -54,7 +54,7 @@ class Py3status:
     vertical_icon = 'V'
     vertical_rotation = 'left'
 
-    def __init__(self):
+    def post_config_hook(self):
         self.displayed = ''
 
     def _call(self, cmd):


### PR DESCRIPTION
We convert `__init__` to `post_config_hook` here.