### PR TITLE
net_iplist: use post_config_hook

### DIFF
--- a/py3status/modules/net_iplist.py
+++ b/py3status/modules/net_iplist.py
@@ -69,7 +69,7 @@ class Py3status:
     ip_sep = ','
     remove_empty = True
 
-    def __init__(self):
+    def post_config_hook(self):
         self.iface_re = re.compile(r'\d+: (?P<iface>\w+):')
         self.ip_re = re.compile(r'\s+inet (?P<ip4>[\d\.]+)/')
         self.ip6_re = re.compile(r'\s+inet6 (?P<ip6>[\da-f:]+)/')


### PR DESCRIPTION
We convert `__init__` to `post_config_hook` here.

P.S. Do we want to use this...
```
    def post_config_hook(self):
         self.iface_re = re.compile(r'\d+: (?P<iface>\w+):')
         self.ip_re = re.compile(r'\s+inet (?P<ip4>[\d\.]+)/')
         self.ip6_re = re.compile(r'\s+inet6 (?P<ip6>[\da-f:]+)/')
```
...or...
```
# Outside
RE_IFACE = re.compile(r'\d+: (?P<iface>\w+):')
RE_IP = re.compile(r'\s+inet (?P<ip4>[\d\.]+)/')
RE_IP6 = re.compile(r'\s+inet6 (?P<ip6>[\da-f:]+)/')

class Py3status:
"""
"""
```
Same same but different. We want same thing for all modules that needs it.