### PR TITLE
bitcoin_price: use post_config_hook

### DIFF
--- a/py3status/modules/bitcoin_price.py
+++ b/py3status/modules/bitcoin_price.py
@@ -76,7 +76,7 @@ class Py3status:
             ],
         }
 
-    def __init__(self):
+    def post_config_hook(self):
         """
         Initialize last_price, set the currency mapping
         and the url containing the data.


### PR DESCRIPTION
We convert `__init__` to `post_config_hook` here.

How did we miss this earlier when working on the format? *smh*