### PR TITLE
github: use post_config_hook

### DIFF
--- a/py3status/modules/github.py
+++ b/py3status/modules/github.py
@@ -77,7 +77,7 @@ class Py3status:
     repo = 'ultrabug/py3status'
     username = None
 
-    def __init__(self):
+    def post_config_hook(self):
         self.first = True
         self.notification_warning = False
         self.repo_warning = False


### PR DESCRIPTION
We convert `__init__` to `post_config_hook` here.

Doing all those little PRs feels like an annoyance, but I guess we want little things at a time.
Easier to test/merge. Sorry about massive emails.

P.S. Replace `?` with `None` to work with... `[{issues}][\?soft=/][{pull_requests}]` or something of that equivalent so we don't have to see `py3status ?/?` sometimes. It just can show up when it's ready with the information.