### PR TITLE
twitch_streaming: use post_config_hook

### DIFF
--- a/py3status/modules/twitch_streaming.py
+++ b/py3status/modules/twitch_streaming.py
@@ -33,14 +33,13 @@ import requests
 
 class Py3status:
     # available configuration parameters
-    # can be customized in i3status.conf
     cache_timeout = 10
     format = "{stream_name} is live!"
     format_invalid = "{stream_name} does not exist!"
     format_offline = "{stream_name} is offline."
     stream_name = None
 
-    def __init__(self):
+    def post_config_hook(self):
         self._display_name = None
 
     def _get_display_name(self):


### PR DESCRIPTION
We convert `__init__` to `post_config_hook` here.

This changes nothing as `twitch_streaming` is currently broken, but still good to do that.
See https://github.com/ultrabug/py3status/issues/613 for more information.

Gave me chance to peek inside a bit... Things that need to be worked on...
* Code currently broken. We need new API + key stuffs here.
* `format`. Based on other modules, we may want `{format_twitch}` here.
* `format_twitch`. Based on other modules, we would want `state_` or `icon_` for invalid, offline, and any other state.
* Use `py3.requests`. 
* Default `cache_timeout = 60` as not to call Twitch every 10s (imho).