### PR TITLE
tor_rate: use post_config_hook

### DIFF
--- a/py3status/modules/tor_rate.py
+++ b/py3status/modules/tor_rate.py
@@ -70,7 +70,7 @@ class Py3status:
     rate_unit = 'B/s'
     si_units = False
 
-    def __init__(self):
+    def post_config_hook(self):
         self._auth_failure = False
         self._down = 0
         self._handler_active = False


### PR DESCRIPTION
We convert `__init__` to `post_config_hook` here.
I can't test this.