### PR TITLE
deadbeef: back from the dead

### DIFF
--- a/py3status/modules/deadbeef.py
+++ b/py3status/modules/deadbeef.py
@@ -4,21 +4,23 @@ Display song currently playing in deadbeef.
 
 Configuration parameters:
     cache_timeout: refresh interval for this module (default 1)
-    delimiter: delimiter between metadata fields (default '¥å¥å¥å')
-    format: display format for this module (default '{artist} - {title}')
+    delimiter: delimiter between metadata fields (default 'ÐÉÅÐƁÊËF')
+    format: display format for this module (default '[{artist} - ][{title}]')
 
 Format placeholders:
-    {artist}        artist
-    {length}        length
-    {playback_time} playback time
-    {title}         title
-    {tracknumber}   track number
-    {year}          year
+    {artist} Name of the artist of the track.
+    {isplaying} "1" if file is currently playing, empty string otherwise.
+    {length} The length of the track formatted as hours, minutes,
+                and seconds, rounded to the nearest second.
+    {playback_time} The elapsed time formatted as [HH:]MM:SS.
+    {title} Title of the track.
+    {tracknumber} Two-digit index of specified track within the album.
+    {year} Year formatted as four digits from a time/date string.
 
 Color options:
-    color_degraded: Paused
-    color_good: Playing
-    color_bad: Not Playing
+    color_paused: Paused, defaults to color_degraded
+    color_playing: Playing, defaults to color_good
+    color_stopped: Stopped, defaults to color_bad
 
 Requires:
     deadbeef: a GTK+ audio player for GNU/Linux
@@ -32,8 +34,8 @@ import subprocess
 class Py3status:
     # available configuration parameters
     cache_timeout = 1
-    delimiter = u'¥å¥å¥å'
-    format = '{artist} - {title}'
+    delimiter = u'ÐÉÅÐƁÊËF'
+    format = '[{artist} - ][{title}]'
 
     class Meta:
         deprecated = {
@@ -43,8 +45,18 @@ class Py3status:
                     'new': 'playback_time',
                     'format_strings': ['format'],
                 },
+                {
+                    'placeholder': 'tracknum',
+                    'new': 'tracknumber',
+                    'format_strings': ['format'],
+                },
             ],
         }
+
+    def post_config_hook(self):
+        self.color_paused = self.py3.COLOR_PAUSED or self.py3.COLOR_DEGRADED
+        self.color_playing = self.py3.COLOR_PLAYING or self.py3.COLOR_GOOD
+        self.color_stopped = self.py3.COLOR_STOPPED or self.py3.COLOR_BAD
 
     def _is_running(self):
         try:
@@ -54,7 +66,7 @@ class Py3status:
             return False
 
     def deadbeef(self):
-        color = self.py3.COLOR_BAD
+        color = self.color_stopped
         artist = isplaying = length = playback_time = title = \
             tracknumber = year = ""
 
@@ -62,7 +74,7 @@ class Py3status:
             return {
                 'cached_until': self.py3.time_in(self.cache_timeout),
                 'color': color,
-                'full_text': '',
+                'full_text': ''
             }
 
         # mix metadata fields in with the delimiters
@@ -70,6 +82,12 @@ class Py3status:
             '%artist%', '%isplaying%', '%length%', '%playback_time%',
             '%title%', '%tracknumber%', '%year%'
         ])
+        # Starting deadbeef may generate lot of startup noises either with
+        # or without error codes. Running deadbeef command below may sometimes
+        # change how things behaves onscreen. We use subprocess to ignore error
+        # codes and using pgrep to control how status output and color will
+        # look... mainly to build consistency better between versions.
+
         # run command and get output
         out = subprocess.check_output(['deadbeef', '--nowplaying-tf', fmt])
         out = out.decode('utf-8')
@@ -78,21 +96,23 @@ class Py3status:
         if out != 'nothing':
             artist, isplaying, length, playback_time, title, tracknumber, \
                 year = out.split(self.delimiter)
-
+            # color
             if title:
                 if isplaying == "1":
-                    color = self.py3.COLOR_GOOD
+                    color = self.color_playing
                 else:
-                    color = self.py3.COLOR_DEGRADED
-
+                    color = self.color_paused
         # response
-        deadbeef = self.py3.safe_format(self.format, dict(
-            artist=artist, isplaying=isplaying, length=length,
-            playback_time=playback_time, title=title,
-            tracknumber=tracknumber, year=year))
-
-        deadbeef = deadbeef.strip().strip('-').strip(':')
-
+        deadbeef = self.py3.safe_format(self.format,
+                                        dict(
+                                            artist=artist,
+                                            isplaying=isplaying,
+                                            length=length,
+                                            playback_time=playback_time,
+                                            title=title,
+                                            tracknumber=tracknumber,
+                                            year=year
+                                        ))
         return {
             'color': color,
             'cached_until': self.py3.time_in(self.cache_timeout),


### PR DESCRIPTION
As of now, Python2 and Python3 prints out differently in `master` version.

`deadbeef` does not always work correctly for some time now probably because of `u'delimiter'` change back in October and other unknown forces.

To explain more about printing out differently, we sometimes get odd `deadbeef: errors` probably because of `u'delimiter'` and other unknown forces.

Okay, enough. What other unknown forces?  This `deadbeef --nowplaying-tf _FMT` forces.

Running that command can pollute terminal with `starting deadbeef 0.7.2`.
Running that command can pollute terminal with fifty~ lines.
Running that command can pollute terminal with error codes.
Running that command can return `True` for `pgrep deadbeef` at right times.


This PR should make `deadbeef` fully usable with Python2 and Python3. 
I don't know if we should make `format_deadbeef` to allow people adding music prefix and/or suffix easily without the whole format. Thoughts?

Maybe we should include a fix for `pgrep deadbeef` at right times by enclosing the whole thing in try/except. I want to see if anybody can run into this issue first before we do that because I'm always running modules (P2+P3) in terminals with no `cache_timeout`. 😆 

~~One~~ Two placeholders renamed to stay close/true to the `FMT` formatting. 
I strip `(whitespace)`, `-`, `:`. This could use the magic formatters. 👍 

**DEADBEEF NOT RUNNING.**

```
# OLD
lasers~/src/py3status/py3status/modules git:(master) python2 deadbeef.py
{'full_text': '', 'cached_until': 1490399047.0}

lasers~/src/py3status/py3status/modules git:(master) python3 deadbeef.py
{'cached_until': 1490399058.0, 'full_text': ''}

##### DIFF ####
OK.
```
```
# NEW
lasers~/src/py3status/py3status/modules git:(deadbeef) python2 deadbeef.py
{'full_text': '', 'cached_until': 1490399120.0}

lasers~/src/py3status/py3status/modules git:(deadbeef) python3 deadbeef.py
{'cached_until': 1490399122.0, 'full_text': ''}

##### DIFF ####
OK. :-)
```


**DEADBEEF RUNNING.**
```
# OLD
lasers~/src/py3status/py3status/modules git:(master) python2 deadbeef.py
starting deadbeef 0.7.2
{'full_text': '', 'cached_until': 1490401894.0}

lasers~/src/py3status/py3status/modules git:(master) python3 deadbeef.py
starting deadbeef 0.7.2
{'cached_until': 1490399240.0, 'full_text': 'deadbeef: error', 'color': '#FF0000'}

##### DIFF ####
PYTHON3 NOT OK.
```
```
# NEW
lasers~/src/py3status/py3status/modules git:(deadbeef) python2 deadbeef.py
starting deadbeef 0.7.2
{'color': '#FFFF00', 'full_text': u'', 'cached_until': 1490399299.0}

lasers~/src/py3status/py3status/modules git:(deadbeef) python3 deadbeef.py
starting deadbeef 0.7.2
{'color': '#FFFF00', 'cached_until': 1490399302.0, 'full_text': ''}

##### DIFF ####
OK. :-)

```

**DEADBEEF PLAYING SOMETHING.**
```
# OLD
lasers~/src/py3status/py3status/modules git:(master) python2 deadbeef.py
starting deadbeef 0.7.2
{'color': '#FF0000', 'full_text': 'deadbeef: error', 'cached_until': 1490399486.0}

lasers~/src/py3status/py3status/modules git:(master) python3 deadbeef.py
starting deadbeef 0.7.2
{'cached_until': 1490399493.0, 'full_text': 'deadbeef: error', 'color': '#FF0000'}

##### DIFF ####
LOOKS OK, BUT NOT OK.
PYTHON2 PRINTS WRONG DUE TO DELIMITER.
IF WE FIX DELIMITER, PYTHON2 WILL WORK OK.
PYTHON3 WILL STILL BE BROKEN EITHER WAY.
```
```
# NEW
lasers~/src/py3status/py3status/modules git:(deadbeef) python2 deadbeef.py
starting deadbeef 0.7.2
{'color': '#00FF00', 'full_text': u'Johan Skugge & Jukka Rintam\xe4ki Brawl', 'cached_until': 1490399422.0}

lasers~/src/py3status/py3status/modules git:(deadbeef) python3 deadbeef.py
starting deadbeef 0.7.2
{'color': '#00FF00', 'cached_until': 1490399425.0, 'full_text': 'Johan Skugge & Jukka Rintamäki Brawl'}

##### DIFF ####
OK. :-)
```

Closes https://github.com/ultrabug/py3status/pull/692