### PR TITLE
vpn_status: use post_config_hook

### DIFF
--- a/py3status/modules/vpn_status.py
+++ b/py3status/modules/vpn_status.py
@@ -42,7 +42,7 @@ class Py3status:
     format = "VPN: {name}"
     pidfile = '/sys/class/net/vpn0/dev_id'
 
-    def __init__(self):
+    def post_config_hook(self):
         self.thread_started = False
         self.active = []
 


### PR DESCRIPTION
We convert `__init__` to `post_config_hook` here.
I can't test this.