### PR TITLE
netdata: replace notification with placeholder

### DIFF
--- a/py3status/modules/netdata.py
+++ b/py3status/modules/netdata.py
@@ -5,14 +5,15 @@ Display network speed and bandwidth usage.
 Configuration parameters:
     cache_timeout: refresh interval for this module (default 2)
     format: display format for this module
-        *(default '[\?color=down LAN(Kb): {down}↓ {up}↑]
-         [\?color=total T(Mb): {download}↓ {upload}↑ {total}↕]')*
+        *(default '{nic} [\?color=down LAN(Kb): {down}↓ {up}↑]
+        [\?color=total T(Mb): {download}↓ {upload}↑ {total}↕]')*
     nic: network interface to use (default None)
     thresholds: color thresholds to use
         *(default {'down': [(0, 'bad'), (30, 'degraded'), (60, 'good')],
         'total': [(0, 'good'), (400, 'degraded'), (700, 'bad')]})*
 
 Format placeholders:
+    {nic}      network interface
     {down}     number of download speed
     {up}       number of upload speed
     {download} number of download usage
@@ -51,7 +52,7 @@ class Py3status:
     """
     # available configuration parameters
     cache_timeout = 2
-    format = u'[\?color=down LAN(Kb): {down}↓ {up}↑] ' + \
+    format = u'{nic} [\?color=down LAN(Kb): {down}↓ {up}↑] ' + \
         u'[\?color=total T(Mb): {download}↓ {upload}↑ {total}↕]'
     nic = None
     thresholds = {
@@ -133,9 +134,6 @@ class Py3status:
                         break
             if self.nic is None:
                 self.nic = 'lo'
-                self.py3.notify_user(
-                    'netdata: cannot find a nic to use. selected nic: lo instead.'
-                )
             self.py3.log('selected nic: %s' % self.nic)
 
     def netdata(self):
@@ -164,7 +162,8 @@ class Py3status:
                                                      'up': up,
                                                      'download': download,
                                                      'upload': upload,
-                                                     'total': total})
+                                                     'total': total,
+                                                     'nic': self.nic})
         return {
             'cached_until': self.py3.time_in(self.cache_timeout),
             'full_text': netdata


### PR DESCRIPTION
This removes annoying notification about not finding `nic`.

I don't use netdata but when I'm testing this module, I sometimes run into this annoying notification for many different reasons such as...
* Moving computer/laptop around
* Unplugging cords
* Not running `nm-applet` on startup
* Use `Disconnect` in `nm-applet`
* Whatever the reason may be...

This is quite annoying so I think we should remove the notification part. I'm not sure what stance we would like to take for the _New!_ `nic` placeholder so I included it in the `format` because all other placeholders are in the format too.... with `degraded` color.

Maybe we go with `bad` instead? One thing to point out. The alignment looks slightly off between `\?color=` versus `color threshold`.

`samecolor samecolor` OK.
`samecolor differentcolor` SLIGHTLY OFF.

I don't know if it's already possible, but if we don't like this new feature, we could try something like... `[\?color=degraded&if=nic&is=lo NIC: {nic}]` to get yellow `NIC: lo` appear only when it is `lo`, otherwise... nothing. Idk. 

EDIT: I removed `NIC: ` and use ~~`333`~~. No color for `nic`.