### PR TITLE
frame: use helpers (no.2)

### DIFF
--- a/py3status/modules/frame.py
+++ b/py3status/modules/frame.py
@@ -83,7 +83,7 @@ class Py3status:
 
     def post_config_hook(self):
         self.urgent = False
-        if '{button}' not in self.format:
+        if not self.py3.format_contains(self.format, 'button'):
             self.open = True
         self.py3.register_function('urgent_function', self._urgent_function)
 


### PR DESCRIPTION
Uses `self.py3.format_contains(self.format, 'lemon')` Hassle-free PR. :lemon: I missed this.