### PR TITLE
mpd_status: fix format, add depreciation stuffs

### DIFF
--- a/py3status/modules/mpd_status.py
+++ b/py3status/modules/mpd_status.py
@@ -10,6 +10,10 @@ Configuration parameters:
     hide_when_stopped: hide the status if state is stopped (default True)
     host: mpd host (default 'localhost')
     max_width: maximum status length (default 120)
+    mpd_no_auth: show this when mpd authentication failed
+        (default 'mpd: authentication failed')
+    mpd_no_conn: show this when mpd connection refused
+        (default 'mpd: connection refused')
     password: mpd password (default None)
     port: mpd port (default '6600')
     state_pause: label to display for "paused" state (default '[pause]')
@@ -104,6 +108,8 @@ class Py3status:
     hide_when_stopped = True
     host = 'localhost'
     max_width = 120
+    mpd_no_auth = 'mpd: authentication failed'
+    mpd_no_conn = 'mpd: connection refused'
     password = None
     port = '6600'
     state_pause = '[pause]'
@@ -170,10 +176,10 @@ class Py3status:
                 text = self.py3.safe_format(self.format, attr_getter=attr_getter)
 
         except socket.error:
-            text = "Failed to connect to mpd!"
+            text = self.py3.safe_format(self.mpd_no_conn)
             state = None
         except CommandError:
-            text = "Failed to authenticate to mpd!"
+            text = self.py3.safe_format(self.mpd_no_auth)
             state = None
             c.disconnect()
         else:

--- a/py3status/modules/mpd_status.py
+++ b/py3status/modules/mpd_status.py
@@ -3,20 +3,20 @@
 Display song currently playing in mpd.
 
 Configuration parameters:
-    cache_timeout: how often we refresh this module in seconds (default 2)
-    format: template string (see below)
+    cache_timeout: refresh interval for this module (default 2)
+    format: display format for this module
         (default '{state} [[[{artist}] - {title}]|[{file}]]')
     hide_when_paused: hide the status if state is paused (default False)
     hide_when_stopped: hide the status if state is stopped (default True)
     hide_when_playing: hide the status if state is playing (default False)
-    host: mpd host (default 'localhost')
-    max_width: maximum status length (default 120)
+    host: specifies a host for access to mpd (default 'localhost')
+    max_width: specifies a maximum width length (default 120)
     mpd_no_auth: show this when mpd authentication failed
         (default 'mpd: authentication failed')
     mpd_no_conn: show this when mpd connection refused
         (default 'mpd: connection refused')
-    password: mpd password (default None)
-    port: mpd port (default '6600')
+    password: specifies a password for access to mpd (default None)
+    port: specifies a port for access to mpd (default '6600')
     state_pause: show this when mpd paused playback (default '[pause]')
     state_play: show this when mpd started playback (default '[play]')
     state_stop: show this when mpd stopped playback (default '[stop]')
@@ -37,7 +37,12 @@ Format placeholders:
     playing.
 
 Requires:
-    python-mpd2: (NOT python2-mpd2)
+    python-mpd2: a Python client library for MPD
+
+__Note: python2-mpd2, not to be confused with original python-mpd2 above, is
+a fork of original python-mpd2 with enhancement features (starting with 0.5)
+which are NOT backward compatibles with original python2-mpd above.
+
 ```
 # pip install python-mpd2
 ```
@@ -54,7 +59,7 @@ Examples of `format`
 {state} \[{time}\] [{title}|{file}] → [{next_title}|{next_file}]
 ```
 
-@author shadowprince, zopieux
+@author shadowprince, zopieux, tobes, lasers
 @license Eclipse Public License
 
 SAMPLE OUTPUT
@@ -139,7 +144,7 @@ class Py3status:
             return self.state_stop
         return '?'
 
-    def current_track(self):
+    def mpd_status(self):
         try:
             state = None
             c = MPDClient()

--- a/py3status/modules/mpd_status.py
+++ b/py3status/modules/mpd_status.py
@@ -188,20 +188,18 @@ class Py3status:
         if len(text) > self.max_width:
             text = u'{}...'.format(text[:self.max_width - 3])
 
-        response = {
+        if state == 'play':
+            color = self.color_play
+        elif state == 'pause':
+            color = self.color_pause
+        else:
+            color = self.color_stop
+
+        return {
             'cached_until': self.py3.time_in(self.cache_timeout),
             'full_text': text,
+            'color': color
         }
-
-        if state:
-            if state == 'play':
-                response['color'] = self.color_play
-            elif state == 'pause':
-                response['color'] = self.color_pause
-            elif state == 'stop':
-                response['color'] = self.color_stop
-
-        return response
 
 
 if __name__ == "__main__":

--- a/py3status/modules/mpd_status.py
+++ b/py3status/modules/mpd_status.py
@@ -8,6 +8,7 @@ Configuration parameters:
         (default '{state} [[[{artist}] - {title}]|[{file}]]')
     hide_when_paused: hide the status if state is paused (default False)
     hide_when_stopped: hide the status if state is stopped (default True)
+    hide_when_playing: hide the status if state is playing (default False)
     host: mpd host (default 'localhost')
     max_width: maximum status length (default 120)
     mpd_no_auth: show this when mpd authentication failed
@@ -105,6 +106,7 @@ class Py3status:
     cache_timeout = 2
     format = '{state} [[[{artist}] - {title}]|[{file}]]'
     hide_when_paused = False
+    hide_when_playing = False
     hide_when_stopped = True
     host = 'localhost'
     max_width = 120
@@ -151,6 +153,7 @@ class Py3status:
             state = status.get('state')
 
             if ((state == 'pause' and self.hide_when_paused) or
+                    (state == 'play' and self.hide_when_playing) or
                     (state == 'stop' and self.hide_when_stopped)):
                 text = ''
 

--- a/py3status/modules/mpd_status.py
+++ b/py3status/modules/mpd_status.py
@@ -17,9 +17,9 @@ Configuration parameters:
     state_stop: label to display for "stopped" state (default '[stop]')
 
 Color options:
-    color_pause: Paused, default color_degraded
-    color_play: Playing, default color_good
-    color_stop: Stopped, default color_bad
+    color_pause: Paused, defaults to color_degraded
+    color_play: Playing, defaults to color_good
+    color_stop: Stopped, defaults to color_bad
 
 Format placeholders:
     {state} state (paused, playing. stopped) can be defined via `state_..`
@@ -117,6 +117,11 @@ class Py3status:
             self.format = re.sub('%([a-z]+)%', r'{\1}', self.format)
             self.py3.log('Old % style format DEPRECATED use { style format')
 
+        # Assign colors
+        self.color_pause = self.py3.COLOR_PAUSE or self.py3.COLOR_DEGRADED
+        self.color_play = self.py3.COLOR_PLAY or self.py3.COLOR_GOOD
+        self.color_stop = self.py3.COLOR_STOP or self.py3.COLOR_BAD
+
     def _state_character(self, state):
         if state == 'play':
             return self.state_play
@@ -184,12 +189,11 @@ class Py3status:
 
         if state:
             if state == 'play':
-                response['color'] = self.py3.COLOR_PLAY or self.py3.COLOR_GOOD
+                response['color'] = self.color_play
             elif state == 'pause':
-                response['color'] = (self.py3.COLOR_PAUSE or
-                                     self.py3.COLOR_DEGRADED)
+                response['color'] = self.color_pause
             elif state == 'stop':
-                response['color'] = self.py3.COLOR_STOP or self.py3.COLOR_BAD
+                response['color'] = self.color_stop
 
         return response
 

--- a/py3status/modules/mpd_status.py
+++ b/py3status/modules/mpd_status.py
@@ -6,9 +6,9 @@ Configuration parameters:
     cache_timeout: refresh interval for this module (default 2)
     format: display format for this module
         (default '{state} [[[{artist}] - {title}]|[{file}]]')
-    hide_when_paused: hide the status if state is paused (default False)
-    hide_when_stopped: hide the status if state is stopped (default True)
-    hide_when_playing: hide the status if state is playing (default False)
+    hide_when_pause: hide status when mpd paused playback (default False)
+    hide_when_play: hide status when mpd started playback (default False)
+    hide_when_stop: hide status when mpd stopped playback (default True)
     host: specifies a host for access to mpd (default 'localhost')
     max_width: specifies a maximum width length (default 120)
     mpd_no_auth: show this when mpd authentication failed
@@ -110,9 +110,9 @@ class Py3status:
     # available configuration parameters
     cache_timeout = 2
     format = '{state} [[[{artist}] - {title}]|[{file}]]'
-    hide_when_paused = False
-    hide_when_playing = False
-    hide_when_stopped = True
+    hide_when_pause = False
+    hide_when_play = False
+    hide_when_stop = True
     host = 'localhost'
     max_width = 120
     mpd_no_auth = 'mpd: authentication failed'
@@ -122,6 +122,22 @@ class Py3status:
     state_pause = '[pause]'
     state_play = '[play]'
     state_stop = '[stop]'
+
+    class Meta:
+        deprecated = {
+            'rename': [
+                {
+                    'param': 'hide_when_when_paused',
+                    'new': 'hide_when_pause',
+                    'msg': 'obsolete parameter use `hide_when_pause`',
+                },
+                {
+                    'param': 'hide_when_when_stopped',
+                    'new': 'hide_when_stop',
+                    'msg': 'obsolete parameter use `hide_when_stop`',
+                },
+            ],
+        }
 
     def post_config_hook(self):
         # Convert from %placeholder% to {placeholder}
@@ -157,9 +173,9 @@ class Py3status:
             next_song = int(status.get('nextsong', 0))
             state = status.get('state')
 
-            if ((state == 'pause' and self.hide_when_paused) or
-                    (state == 'play' and self.hide_when_playing) or
-                    (state == 'stop' and self.hide_when_stopped)):
+            if ((state == 'pause' and self.hide_when_pause) or
+                    (state == 'play' and self.hide_when_play) or
+                    (state == 'stop' and self.hide_when_stop)):
                 text = ''
 
             else:


### PR DESCRIPTION
If `mpd` daemon isn't running, we get dull text. See complaint(s). https://github.com/ultrabug/py3status/issues/636

To hide dull text off, we enable/start daemon (systemd) for good or we add mpd to our list of apps to run on autostart/startx/others (user). Now we can ignore `mpd_status` in the config instead.

I introduce `mpd_no_conn` to allow users to specify string when mpd isn't running.
I introduce `mpd_no_auth` to allow users to specify string when mpd auth failed.

~~I depreciate `hide_when_paused = True` // Instead, use `state_pause = ""`.~~
~~I depreciate `hide_when_stopped = True` // Instead, use `state_stop = ""`.~~
I rename `hide_when_paused = False` // Instead, use `hide_pause = False`.
I rename `hide_when_stopped = True` // Instead, use `hide_stop = True`.
-------------------------------------------------- // I add new `hide_play = False`

The new option is just there to make a full circle. 🔴

I fill up docs. Is very good.
I fill up authors. Is very good too.

I add this now because of recently merged `mpd safe_format`. Here my old PR: https://github.com/ultrabug/py3status/pull/638

EDIT: ~~Hold for now. I think I need to consider things again later since I'm so hellbent on using `state_stop = ""` to hide status. It is just an "icon".~~

This should be good now (after I remove the comments.)