### PR TITLE
documentation X (py3status lexer)

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 import re
 
-from py3status.autodoc import create_auto_documentation
+from py3status.autodoc import create_auto_documentation, Py3statusLexer
 from py3status.version import version as py3_version
 
 # py3status documentation build configuration file, created by
@@ -172,3 +172,7 @@ def setup(sphinx):
     This will be called by sphinx.
     """
     create_auto_documentation()
+
+    # add the py3status lexer (for code blocks)
+    from sphinx.highlighting import lexers
+    lexers['py3status'] = Py3statusLexer()

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -32,7 +32,7 @@ displayed.
 
 For example you could insert and load the ``imap`` module like this:
 
-.. code-block:: none
+.. code-block:: py3status
     :caption: Example
 
     order += "disk /home"
@@ -47,7 +47,7 @@ Configuring a py3status module
 
 Your py3status modules are configured the exact same way as i3status modules, directly from your ``i3status.conf``, like this :
 
-.. code-block:: none
+.. code-block:: py3status
     :caption: Example
 
     # configure the py3status imap module
@@ -74,7 +74,7 @@ Global options:
 - ``nagbar_font``. It will be used as an argument to
     ``i3-nagbar -f``, thus setting its font.
 
-.. code-block:: none
+.. code-block:: py3status
     :caption: Example
 
     py3status {
@@ -99,7 +99,7 @@ name of the parameters.
 .. note::
     Obfuscation is only available for string parameters.
 
-.. code-block:: none
+.. code-block:: py3status
     :caption: Example
 
     # normal_parameter will be shown in log files etc as 'some value'
@@ -115,7 +115,7 @@ base64 encoded.
 
 To use an encoded string add ``:base64`` to the name of the parameter.
 
-.. code-block:: none
+.. code-block:: py3status
     :caption: Example
 
     # Example of obfuscated configuration
@@ -140,7 +140,7 @@ If a module does not specify colors but it is in a container, then the colors
 of the container will be used if they are set, before using ones defined in the
 general section.
 
-.. code-block:: none
+.. code-block:: py3status
     :caption: Example
 
     general {
@@ -173,7 +173,7 @@ defined in the config as a list of tuples. With each tuple containing a value
 and a color. The color can either be a named color eg ``good`` referring to
 ``color_good`` or a hex value.
 
-.. code-block:: none
+.. code-block:: py3status
     :caption: Example
 
     volume_status {
@@ -198,7 +198,7 @@ In the above example the logic would be
 
 Some modules may allow more than one threshold to be defined.  If all the thresholds are the same they can be defined as above but if you wish to specify them separately you can by giving a dict of lists.
 
-.. code-block:: none
+.. code-block:: py3status
     :caption: Example
 
     my_module {
@@ -226,7 +226,7 @@ through automatically or by user action (the default, on mouse scroll).
 
 This module is very powerful and allows you to save a lot of space on your bar.
 
-.. code-block:: none
+.. code-block:: py3status
     :caption: Example
 
     order += "group tz"
@@ -257,7 +257,7 @@ module also allows you to group several modules together, however in a frame
 all the modules are shown.  This allows you to have more than one module shown
 in a group.
 
-.. code-block:: none
+.. code-block:: py3status
     :caption: Example
 
     order += "group frames"
@@ -296,7 +296,7 @@ in a group.
 
 Frames can also have a toggle button to hide/show the content
 
-.. code-block:: none
+.. code-block:: py3status
     :caption: Example
 
     # A frame showing times in different cities.
@@ -341,7 +341,7 @@ As an added feature and in order to get your i3bar more responsive, every
 py3status modules and i3status modules as described in the refresh command
 below.
 
-.. code-block:: none
+.. code-block:: py3status
     :caption: Example
 
     # reload the i3 config when I left click on the i3status time module
@@ -416,7 +416,7 @@ Since version 3.3 it is possible to use the output text of a module in the
 ``on_click`` command.  To do this ``$OUTPUT`` can be used in command and it will be
 substituted by the modules text output when the command is run.
 
-.. code-block:: none
+.. code-block:: py3status
     :caption: Example
 
     # copy module output to the clipboard using xclip

--- a/py3status/autodoc.py
+++ b/py3status/autodoc.py
@@ -6,6 +6,9 @@ import os.path
 import re
 
 
+from pygments.lexer import RegexLexer
+import pygments.token as pygments_token
+
 from py3status.docstrings import core_module_docstrings
 from py3status.screenshots import create_screenshots, get_samples
 from py3status.py3 import Py3
@@ -16,6 +19,30 @@ CONSTANT_PARAMS = [
     ('log', 'level'),
     ('notify_user', 'level'),
 ]
+
+
+class Py3statusLexer(RegexLexer):
+    """
+    A simple lexer for py3status configuration files.
+    This helps make the documentation more beautiful
+    """
+    name = 'Py3status'
+    aliases = ['py3status']
+    filenames = ['*.conf']
+
+    tokens = {
+        'root': [
+            (r'#.*?$', pygments_token.Comment),
+            (r'"(?:[^"\\]|\\.)*"', pygments_token.String.Double),
+            (r"'(?:[^'\\]|\\.)*'", pygments_token.String.Single),
+            (r'([0-9]+)|([0-9]*)\.([0-9]*)', pygments_token.Number),
+            (r'True|False|None', pygments_token.Literal),
+            (r'(\+=)|=', pygments_token.Operator),
+            (r'\s+', pygments_token.Text),
+            (r'[{}\[\](),:]', pygments_token.Text,),
+            (r'\S+', pygments_token.Keyword),
+        ],
+    }
 
 
 def markdown_2_rst(lines):


### PR DESCRIPTION
config examples are boring and hard to read eg http://py3status.readthedocs.io/en/latest/configuration.html#id3

This PR adds a simple pygments lexer so that they are colorized