### PR TITLE
better module error handeling prevent reappearance when dismissed

### DIFF
--- a/py3status/module.py
+++ b/py3status/module.py
@@ -193,6 +193,7 @@ class Module(Thread):
             method['last_output'] = {}
 
         self.allow_config_clicks = False
+        self.error_hide = True
         self.set_updated()
 
     def start_module(self):
@@ -776,6 +777,7 @@ class Module(Thread):
                     # expected
                     self.allow_config_clicks = True
                     self.error_messages = None
+                    self.error_hide = False
                 except ModuleErrorException as e:
                     # module has indicated that it has an error
                     self.runtime_error(e.msg, meth)


### PR DESCRIPTION
With a module error if it was dismissed by a user and then an error occurred again the error would be re-shown.  With this PR the error will not show.

However if the module starts sending 'good' output and then an error happens the error will be shown.  This feels the right approach and is wanted (and tested) in #722