### PR TITLE
allow - in config token

### DIFF
--- a/py3status/parse_config.py
+++ b/py3status/parse_config.py
@@ -102,7 +102,7 @@ class ConfigParser:
         '|(?P<literal>'
         r'("(?:[^"\\]|\\.)*")'  # double quoted string
         r"|('(?:[^'\\]|\\.)*')"  # single quoted string
-        '|([a-z_][a-z0-9_]*(:[a-z0-9_]+)?)'  # token
+        '|([a-z_][a-z0-9_\-]*(:[a-z0-9_]+)?)'  # token
         '|(-?\d+\.\d*)|(-?\.\d+)'  # float
         '|(-?\d+)'  # int
         ')'


### PR DESCRIPTION
for #861 

tokens must start with `a-z` or `_` following chars can be `a-z` `0-9` `_` and `-` 