### PR TITLE
github: prevent unneeded updates on clicks

### DIFF
--- a/py3status/modules/github.py
+++ b/py3status/modules/github.py
@@ -16,8 +16,11 @@ Configuration parameters:
         (default None)
     button_action: Button that when clicked opens the Github notification page
         if notifications, else the project page for the repository if there is
-        one (otherwise the github home page). Setting to `0` disables.
+        one (otherwise the github home page). Setting to `None` disables.
         (default 3)
+    button_refresh: Button that when clicked refreshes module.
+        Setting to `None` disables.
+        (default 2)
     cache_timeout: How often we refresh this module in seconds
         (default 60)
     format: Format of output
@@ -70,6 +73,7 @@ GITHUB_URL = 'https://github.com/'
 class Py3status:
     auth_token = None
     button_action = 3
+    button_refresh = 2
     cache_timeout = 60
     format = None
     format_notifications = ' N{notifications_count}'
@@ -202,7 +206,8 @@ class Py3status:
 
     def on_click(self, event):
         button = event['button']
-        if self.button_action and self.button_action == button:
+        if button == self.button_action:
+            # open github in browser
             if self._notify and self._notify != '?':
                 # open github notifications page
                 url = GITHUB_URL + 'notifications'
@@ -215,6 +220,9 @@ class Py3status:
                     url = GITHUB_URL + self.repo
             # open url in default browser
             self.py3.command_run('xdg-open {}'.format(url))
+            self.py3.prevent_refresh()
+        elif button != self.button_refresh:
+            # only refresh the module if needed
             self.py3.prevent_refresh()
 
 


### PR DESCRIPTION
In #826 @lasers highlighted github doing more updates than needed.

This prevents the updates unless the `button_refresh` is clicked by default this is `2`