### PR TITLE
prevent modules being updated when no on_click()

### DIFF
--- a/py3status/events.py
+++ b/py3status/events.py
@@ -174,7 +174,7 @@ class Events(Thread):
             # unless the on_click event called py3.prevent_refresh()
             if not module.prevent_refresh:
                 self.py3_wrapper.refresh_modules(module_name)
-            default_event = False
+                default_event = False
 
         if default_event:
             # default button 2 action is to clear this method's cache

--- a/py3status/module.py
+++ b/py3status/module.py
@@ -666,6 +666,9 @@ class Module(Thread):
                     click_method(self.i3status_thread.json_list,
                                  self.config['py3_config']['general'], event)
                 self.set_updated()
+            else:
+                # nothing has happened so no need for refresh
+                self.prevent_refresh = True
         except Exception:
             msg = 'on_click event in `{}` failed'.format(self.module_full_name)
             self._py3_wrapper.report_exception(msg)


### PR DESCRIPTION
With the updates around showing module errors.  We now always call `Module.click_event()` so that it can handle displayed errors etc.  Because of this the module would be refreshed even if there was no need.

This PR prevents refresh if module's `on_click()` or the error click handling is not done.

Thanks to @lasers for finding this bug in #826