### PR TITLE
[xrandr] Add option to hide output if only one combination is available

### DIFF
--- a/py3status/modules/xrandr.py
+++ b/py3status/modules/xrandr.py
@@ -29,7 +29,8 @@ Configuration parameters:
         (default None)
     format: display format for xrandr
         (default '{output}')
-    hide_if_single_combination: hide if only one combination is available.
+    hide_if_single_combination: hide if only one combination is available,
+        has effect only if 'format' uses square brackets, like: '[{output}]'
         (default False)
     icon_clone: icon used to display a 'clone' combination
         (default '=')
@@ -404,7 +405,7 @@ class Py3status:
 
         if (len(self.available_combinations) < 2 and
                 self.hide_if_single_combination):
-            full_text = ''
+            full_text = self.py3.safe_format(self.format)
         else:
             if self.fixed_width is True:
                 output = self._center(self.displayed)

--- a/py3status/modules/xrandr.py
+++ b/py3status/modules/xrandr.py
@@ -28,7 +28,7 @@ Configuration parameters:
         when the module starts (saves you from having to configure xorg)
         (default None)
     format: display format for xrandr
-        (default '[{output}]')
+        (default '{output}')
     hide_if_single_combination: hide if only one combination is available
         (default False)
     icon_clone: icon used to display a 'clone' combination
@@ -97,7 +97,7 @@ class Py3status:
     fallback = True
     fixed_width = True
     force_on_start = None
-    format = '[{output}]'
+    format = '{output}'
     hide_if_single_combination = False
     icon_clone = '='
     icon_extend = '+'
@@ -404,7 +404,7 @@ class Py3status:
 
         if (len(self.available_combinations) < 2 and
                 self.hide_if_single_combination):
-            full_text = self.py3.safe_format(self.format)
+            full_text = self.py3.safe_format(self.format, {'output': ''})
         else:
             if self.fixed_width is True:
                 output = self._center(self.displayed)

--- a/py3status/modules/xrandr.py
+++ b/py3status/modules/xrandr.py
@@ -28,9 +28,8 @@ Configuration parameters:
         when the module starts (saves you from having to configure xorg)
         (default None)
     format: display format for xrandr
-        (default '{output}')
-    hide_if_single_combination: hide if only one combination is available,
-        has effect only if 'format' uses square brackets, like: '[{output}]'
+        (default '[{output}]')
+    hide_if_single_combination: hide if only one combination is available
         (default False)
     icon_clone: icon used to display a 'clone' combination
         (default '=')
@@ -98,7 +97,7 @@ class Py3status:
     fallback = True
     fixed_width = True
     force_on_start = None
-    format = '{output}'
+    format = '[{output}]'
     hide_if_single_combination = False
     icon_clone = '='
     icon_extend = '+'

--- a/py3status/modules/xrandr.py
+++ b/py3status/modules/xrandr.py
@@ -29,6 +29,8 @@ Configuration parameters:
         (default None)
     format: display format for xrandr
         (default '{output}')
+    hide_if_single_combination: hide if only one combination is available.
+        (default False)
     icon_clone: icon used to display a 'clone' combination
         (default '=')
     icon_extend: icon used to display a 'extend' combination
@@ -96,6 +98,7 @@ class Py3status:
     fixed_width = True
     force_on_start = None
     format = '{output}'
+    hide_if_single_combination = False
     icon_clone = '='
     icon_extend = '+'
     output_combinations = None
@@ -399,11 +402,15 @@ class Py3status:
         self._set_available_combinations()
         self._choose_what_to_display()
 
-        if self.fixed_width is True:
-            output = self._center(self.displayed)
+        if (len(self.available_combinations) < 2 and
+                self.hide_if_single_combination):
+            full_text = ''
         else:
-            output = self.displayed
-        full_text = self.py3.safe_format(self.format, {'output': output})
+            if self.fixed_width is True:
+                output = self._center(self.displayed)
+            else:
+                output = self.displayed
+            full_text = self.py3.safe_format(self.format, {'output': output})
 
         response = {
             'cached_until': self.py3.time_in(self.cache_timeout),


### PR DESCRIPTION
The idea is very simple: this module is useful to switch outputs, however when there is only one output available (my case: I'm on laptop with external screen disconnected), there is no sense to consume space on my status panel by showing this module.