### PR TITLE
gpmdp: support 5+ external placeholders 

### DIFF
--- a/py3status/modules/gpmdp.py
+++ b/py3status/modules/gpmdp.py
@@ -4,32 +4,67 @@ Display song currently playing in Google Play Music Desktop Player.
 
 Configuration parameters:
     cache_timeout:  refresh interval for this module (default 5)
-    format:         specify the items and ordering of the data in the status bar.
-                    These area 1:1 match to gpmdp-remote's options
-                    (default '♫ {info}')
+    format:         display format for this module (default '♫[ {status}]')
+    state_paused:   show this when gpmdp paused playback
+        (default '[(Paused) {song_title} - {song_artist}]')
+    state_playing:  show this when gpmdp started playback
+        (default '{song_title} - {song_artist}')
 
 Format placeholders:
-    {info}            Print info about now playing song
-    {title}           Print current song title
-    {artist}          Print current song artist
-    {album}           Print current song album
-    {album_art}       Print current song album art URL
-    {time_current}    Print current song time in milliseconds
-    {time_total}      Print total song time in milliseconds
-    {status}          Print whether GPMDP is paused or playing
-    {current}         Print now playing song in "artist - song" format
+    {status}          Google Play Music Desktop Player status
 
+State placeholders:
+    {songLyrics}      Print song lyrics
+    {song_album}      Print song album
+    {song_artist}     Print song artist
+    {song_title}      Print song title
+    {time_current}    Print time (current) in milliseconds
+    {time_total}      Print time (total) in milliseconds
+
+    Placeholders are retrieved directly from keys/values in JSON playback file.
+    We found more placeholders from the file although these may not be useful for
+    some percent of users. We're keeping them here for everybody's convenience.
+
+    {playing}         Print boolean
+    {volume}          Print number
+    {shuffle}         Print value, eg NO_SHUFFLE
+    {repeat}          Print value, eg NO_REPEAT
+    {song_albumArt}   Print long URL to song album art
+    {rating_disliked} Print boolean
+    {rating_liked}    Print boolean
+
+Color options:
+    color_paused: Paused, defaults to color_degraded
+    color_playing: Playing, defaults to color_good
+    color_stopped: Not playing, defaults to color_bad
 
 Requires:
-    gpmdp: http://www.googleplaymusicdesktopplayer.com/
-    gpmdp-remote: https://github.com/iandrewt/gpmdp-remote
+    gpmdp: A beautiful cross platform Desktop Player for Google Play Music
+           See http://www.googleplaymusicdesktopplayer.com/
 
-@author Aaron Fields https://twitter.com/spirotot
+@author Aaron Fields https://twitter.com/spirotot, lasers
 @license BSD
 
 SAMPLE OUTPUT
 {'full_text': '♫ Now Playing: The Show Goes On by Lupe Fiasco'}
 """
+
+import json
+import os
+
+GPMDP = "~/.config/Google Play Music Desktop Player/json_store/playback.json"
+
+
+def flatten_dict(d, delimiter='_'):
+    def expand(key, value):
+        if isinstance(value, dict):
+            return [
+                (delimiter.join([key, k]), v)
+                for k, v in flatten_dict(value, delimiter).items()
+            ]
+        else:
+            return [(key, value)]
+    return dict([item for k, v in d.items() for item in expand(k, v)])
 
 
 class Py3status:
@@ -37,25 +72,60 @@ class Py3status:
     """
     # available configuration parameters
     cache_timeout = 5
-    format = u'♫ {info}'
+    format = u'♫[ {status}]'
+    state_paused = '[(Paused) {song_title} - {song_artist}]'
+    state_playing = '{song_title} - {song_artist}'
+
+    class Meta:
+        deprecated = {
+            'remove': [
+                {
+                    'param': 'current',
+                    'msg': 'obsolete set. use new parameters'
+                },
+                {
+                    'param': 'info',
+                    'msg': 'obsolete set. use new parameters'
+                },
+            ],
+        }
+
+    def post_config_hook(self):
+        self.color_stopped = self.py3.COLOR_STOPPED or self.py3.COLOR_BAD
+        self.color_paused = self.py3.COLOR_PAUSED or self.py3.COLOR_DEGRADED
+        self.color_playing = self.py3.COLOR_PLAYING or self.py3.COLOR_GOOD
+        self.playback_json = os.path.expanduser(GPMDP)
+
+    def _is_running(self):
+        try:
+            cmd = ['pgrep', '-f', 'Google Play Music Desktop Player']
+            self.py3.command_run(cmd)
+            return True
+        except:
+            return False
 
     def gpmdp(self):
-        def _run_cmd(cmd):
-            return self.py3.command_output(['gpmdp-remote', cmd]).strip()
+        if not self._is_running():
+            return {
+                'cached_until': self.py3.time_in(self.cache_timeout),
+                'full_text': self.py3.safe_format(self.format),
+                'color': self.color_stopped
+            }
+        data = []
+        with open(self.playback_json, 'r') as f:
+            data = json.load(f, object_hook=flatten_dict)
 
-        full_text = ''
-        if _run_cmd('status') == 'Playing':
-            cmds = ['info', 'title', 'artist', 'album', 'status', 'current',
-                    'time_total', 'time_current', 'album_art']
-            data = {}
-            for cmd in cmds:
-                if self.py3.format_contains(self.format, '{0}'.format(cmd)):
-                    data[cmd] = _run_cmd(cmd)
-            full_text = self.py3.safe_format(self.format, data)
+        if data['playing']:
+            color = self.color_playing
+            status = self.py3.safe_format(self.state_playing, data)
+        else:
+            color = self.color_paused
+            status = self.py3.safe_format(self.state_paused, data)
 
         return {
             'cached_until': self.py3.time_in(self.cache_timeout),
-            'full_text': full_text
+            'full_text': self.py3.safe_format(self.format, {'status': status}),
+            'color': color,
         }
 
 

--- a/tests/test_module_doc.py
+++ b/tests/test_module_doc.py
@@ -35,6 +35,7 @@ IGNORE_ILLEGAL_CONFIG_OPTIONS = [
 # Ignored items will not have their default values checked or be included for
 # alphabetical order purposes
 IGNORE_ITEM = [
+    ('gpmdp', 'format'),  # line too long for docstring parsing
     ('netdata', 'format'),  # line too long for docstring parsing
     ('i3block', 'cache_timeout'),  # can be overriden by interval so undefined
     ('screenshot', 'save_path'),  # home dir issue


### PR DESCRIPTION
This is for `3.6`. I have questions for gpmdp.

Do we want `state_pause` and `state_play` or to combat everything in the `format`? I asked because of consistency. It's short enough to fit in the `format`, but other media players uses `state_` options.

Do we want to rename placeholders so it looks nice or we leave them new "as-is"? The placeholders in this PR is flattened names.... We get them ourselves now.  👍 

Placeholder `{status}`, `{info}` and `{current}` are from `gpmdp-remote`
`{info}` and `{current}` is almost same. Maybe `{status}` too. Very silly.
I remove them. Can use two `state_`* or one `format` instead.
```
gpmdp-remote status  # Playing
gpmdp-remote info    # Now Playing: I Stay Determined by Dagames
gpmdp-remote current # Dagames - I Stay Determined
```
I remove hard dependency `gpmdp-remote` too. Whoo! 🎵 🎶 🎼 

<details>
<summary>[+] functions for status, current, and info</summary>

```
 gpmdp_status () {
     gpmdp_status=$(awk -F ': |,' '/playing/ {printf $2}' "$json_file")

     if [[ "$gpmdp_status" == *"true"* ]]; then
         printf "%s\n" "Playing"
     elif [[ "$gpmdp_status" == *"false"* ]]; then
         printf "%s\n" "Paused"
     fi
 }
```
```
 gpmdp_info () {
     if [ "$(gpmdp_status)" == "Playing" ]; then
         printf "%s\n" "Now Playing: $(title) by $(artist)"
     elif [ "$(gpmdp_status)" == "Paused" ]; then
         printf "%s\n" "Paused: $(title) by $(artist)"
     fi
 }
```
```
 current () {
     printf "%s\n" "$(artist) - $(title)"
 }
```
</details>