### PR TITLE
keyboard_locks: add sample output

### DIFF
--- a/py3status/modules/keyboard_locks.py
+++ b/py3status/modules/keyboard_locks.py
@@ -17,6 +17,20 @@ Color options:
     color_bad: Lock off
 
 @author lasers
+
+SAMPLE OUTPUT
+[
+    {'color': '#00FF00', 'full_text': 'CAPS '},
+    {'color': '#00FF00', 'full_text': 'NUMS '},
+    {'color': '#FF0000', 'full_text': 'SCR'},
+]
+
+no_locks
+[
+    {'color': '#FF0000', 'full_text': 'CAPS '},
+    {'color': '#FF0000', 'full_text': 'NUMS '},
+    {'color': '#FF0000', 'full_text': 'SCR'},
+]
 """
 
 


### PR DESCRIPTION
We add `SAMPLE OUTPUT`. I can't generate screenshots anymore as it's not working for me now or I forget how to. Thanks. P.S. How to fix the docs? I found a simple typo. We want `freenode`. 