### PR TITLE
[whatismyip] Add 'expected' param

### DIFF
--- a/py3status/modules/whatismyip.py
+++ b/py3status/modules/whatismyip.py
@@ -6,7 +6,8 @@ Configuration parameters:
     cache_timeout: how often we refresh this module in seconds (default 30)
     expected: define expected values for format placeholders,
               and use `color_degraded` to show the output of this module
-              if any of them does not match the actual value
+              if any of them does not match the actual value.
+              This should be a dict eg {'country': 'France'}
               (default None)
     format: available placeholders are {ip} and {country},
             as well as any other key in JSON fetched from `url_geo`

--- a/py3status/modules/whatismyip.py
+++ b/py3status/modules/whatismyip.py
@@ -7,7 +7,7 @@ Configuration parameters:
     expected: define expected values for format placeholders,
               and use `color_degraded` to show the output of this module
               if any of them does not match the actual value
-              (default {})
+              (default None)
     format: available placeholders are {ip} and {country},
             as well as any other key in JSON fetched from `url_geo`
             (default '{ip}')
@@ -52,7 +52,7 @@ class Py3status:
     """
     # available configuration parameters
     cache_timeout = 30
-    expected = {}
+    expected = None
     format = '{ip}'
     format_offline = u'■'
     format_online = u'●'
@@ -73,6 +73,9 @@ class Py3status:
         }
 
     def post_config_hook(self):
+        if self.expected is None:
+            self.expected = {}
+
         # Backwards compatibility
         self.substitutions = {}
         if self.url_geo == URL_GEO_NEW_DEFAULT:

--- a/py3status/modules/whatismyip.py
+++ b/py3status/modules/whatismyip.py
@@ -4,6 +4,9 @@ Display public IP address and online status.
 
 Configuration parameters:
     cache_timeout: how often we refresh this module in seconds (default 30)
+    expected: if defined, use `color_degraded` if the output of this module
+              doesn't match the expected string (use for IP mismatch, etc.)
+              (default None)
     format: available placeholders are {ip} and {country},
             as well as any other key in JSON fetched from `url_geo`
             (default '{ip}')
@@ -24,6 +27,7 @@ Format placeholders:
 
 Color options:
     color_bad: Offline
+    color_degraded: Output is unexpected (IP/country mismatch, etc.)
     color_good: Online
 
 @author ultrabug
@@ -47,6 +51,7 @@ class Py3status:
     """
     # available configuration parameters
     cache_timeout = 30
+    expected = None
     format = '{ip}'
     format_offline = u'■'
     format_online = u'●'
@@ -113,6 +118,8 @@ class Py3status:
             response['color'] = self.py3.COLOR_GOOD
             if self.mode == 'ip':
                 response['full_text'] = self.py3.safe_format(self.format, info)
+                if self.expected is not None and self.expected != response['full_text']:
+                    response['color'] = self.py3.COLOR_DEGRADED
             else:
                 response['full_text'] = self.format_online
         else:


### PR DESCRIPTION
I was running this locally for quite a while, and I must say it is very useful feature.

With it I don't have to visually compare all the time if my IP / country changed or not, I can use py3status to do this for me and colors to quickly bring the mismatch to my attention.

Unless, this somehow can be done with magical `format`? 😉 