### PR TITLE
raise exception on invalid JSON in request

### DIFF
--- a/py3status/exceptions.py
+++ b/py3status/exceptions.py
@@ -12,6 +12,12 @@ class RequestException(Py3Exception):
     """
 
 
+class RequestInvalidJSON(RequestException):
+    """
+    The request has not returned valid JSON
+    """
+
+
 class RequestTimeout(RequestException):
     """
     A timeout has occured during a request made via Py3.request().

--- a/py3status/py3.py
+++ b/py3status/py3.py
@@ -89,6 +89,7 @@ class Py3:
     # Exceptions
     Py3Exception = exceptions.Py3Exception
     RequestException = exceptions.RequestException
+    RequestInvalidJSON = exceptions.RequestInvalidJSON
     RequestTimeout = exceptions.RequestTimeout
     RequestURLError = exceptions.RequestURLError
 

--- a/py3status/request.py
+++ b/py3status/request.py
@@ -19,7 +19,9 @@ except ImportError:
     from urlparse import urlsplit, urlunsplit, parse_qsl
     IS_PYTHON_3 = False
 
-from py3status.exceptions import RequestTimeout, RequestURLError
+from py3status.exceptions import (
+    RequestTimeout, RequestURLError, RequestInvalidJSON
+)
 
 
 class HttpResponse:
@@ -97,4 +99,7 @@ class HttpResponse:
         """
         Return an object representing the return json for the request
         """
-        return json.loads(self.text)
+        try:
+            return json.loads(self.text)
+        except:
+            raise RequestInvalidJSON('Invalid JSON recieved')


### PR DESCRIPTION
if we do `py3.request(url).json()` and there is invalid JSON we get a nasty exception.

This PR make it so we now raise  `RequestInvalidJSON` so now such exceptions are easy to catch.  This is useful for example in PR #877