### PR TITLE
py3 commands raise CommandError

### DIFF
--- a/py3status/exceptions.py
+++ b/py3status/exceptions.py
@@ -5,6 +5,25 @@ class Py3Exception(Exception):
     """
 
 
+class CommandError(Py3Exception):
+    """
+    An error occurred running the given command.
+
+    This exception provides some additional attributes
+
+    ``error_code``: The error code returned from the call
+
+    ``output``: Any output returned by the call
+
+    ``error``: Any error output returned by the call
+    """
+    def __init__(self, msg=None, error_code=0, output='', error=''):
+        Py3Exception.__init__(self, msg)
+        self.error_code = error_code
+        self.output = output
+        self.error = error
+
+
 class RequestException(Py3Exception):
     """
     A Py3.request() base exception.  This will catch any of the more specific
@@ -20,11 +39,11 @@ class RequestInvalidJSON(RequestException):
 
 class RequestTimeout(RequestException):
     """
-    A timeout has occured during a request made via Py3.request().
+    A timeout has occurred during a request made via Py3.request().
     """
 
 
 class RequestURLError(RequestException):
     """
-    A URL related error has occured during a request made via Py3.request().
+    A URL related error has occurred during a request made via Py3.request().
     """

--- a/py3status/modules/external_script.py
+++ b/py3status/modules/external_script.py
@@ -37,7 +37,6 @@ example
 """
 
 STRING_UNAVAILABLE = "external_script: N/A"
-STRING_ERROR = "external_script: error"
 
 
 class Py3status:
@@ -58,13 +57,10 @@ class Py3status:
             }
         try:
             output = self.py3.command_output(self.script_path, shell=True)
-            output = output.splitlines()[0]
-        except:
-            return {
-                'cached_until': self.py3.time_in(self.cache_timeout),
-                'color': self.py3.COLOR_BAD,
-                'full_text': STRING_ERROR
-            }
+        except self.py3.CommandError as e:
+            output = e.output or e.error
+
+        output = output.splitlines()[0]
 
         if self.strip_output:
             output = output.strip()


### PR DESCRIPTION
When there is an error it is hard to know what went wrong.  Also some commands use error codes to indicate things other than something actually was bad.  Anyhow we now raise a `CommandError` exception that allows access to the returncode, error, and output of a command.

I'm sort of thinking with `py3.command_run()` we should just simplify it and get it to return `True`/`False` depending on if it runs ok,  So if command has a retcode of `0` we return `True` else `False`.  I think that would make more sense for quick easy usage.