### PR TITLE
check_tcp: merge formats

### DIFF
--- a/py3status/modules/check_tcp.py
+++ b/py3status/modules/check_tcp.py
@@ -4,18 +4,22 @@ Display status of a TCP port on a given host.
 
 Configuration parameters:
     cache_timeout: refresh interval for this module (default 10)
-    format: display format for this module (default '{host}:{port} {state}')
-    host: name of host to check for (default 'localhost')
-    icon_off: show this when unavailable (default 'DOWN')
-    icon_on: show this when available (default 'UP')
-    port: number of port to check for (default 22)
+    format: display format for this module
+        (default '{host}:{port} [\?if=is_open UP|DOWN]')
+    host: specify host name to use (default 'localhost')
+    port: specify port number to use (default 22)
+
+Control placeholders:
+    is_open: a boolean based on TCP port status
+    is_closed: a boolean based on TCP port status
 
 Format placeholders:
-    {state} port state
+    {host} TCP host name
+    {port} TCP port number
 
 Color options:
-    color_down: Closed, default to color_bad
-    color_up: Open, default to color_good
+    color_down: Port closed, defaults to color_bad
+    color_up: Port open, defaults to color_good
 
 @author obb, Moritz Lüdecke
 
@@ -25,7 +29,12 @@ SAMPLE OUTPUT
 down
 {'color': '#FF0000', 'full_text': u'localhost:22 DOWN'}
 """
+
 import socket
+
+DEFAULT_FORMAT = '{host}:{port} [\?if=is_open UP|DOWN]'
+TRUE = ' '
+FALSE = ''
 
 
 class Py3status:
@@ -33,30 +42,62 @@ class Py3status:
     """
     # available configuration parameters
     cache_timeout = 10
-    format = '{host}:{port} {state}'
+    format = DEFAULT_FORMAT
     host = 'localhost'
-    icon_off = 'DOWN'
-    icon_on = 'UP'
     port = 22
 
     def post_config_hook(self):
-        self.color_on = self.py3.COLOR_UP or self.py3.COLOR_GOOD
         self.color_off = self.py3.COLOR_DOWN or self.py3.COLOR_BAD
+        self.color_on = self.py3.COLOR_UP or self.py3.COLOR_GOOD
+
+        # DEPRECATION WARNING
+        if self.format != DEFAULT_FORMAT:
+            return
+
+        icon_off = getattr(self, 'icon_off', None)
+        icon_on = getattr(self, 'icon_on', None)
+
+        if self.py3.format_contains(self.format, 'state'):
+            new = u'[\?if=is_open {}|{}]'.format(
+                icon_on or 'UP',
+                icon_off or 'DOWN',
+            )
+            self.format = self.format.replace('{state}', new)
+        else:
+            self.format = u'{{host}}:{{port}} [\?if=is_open {}|{}]'.format(
+                icon_on or 'UP',
+                icon_off or 'DOWN',
+            )
+        msg = 'DEPRECATION WARNING: you are using old style configuration '
+        msg += 'parameters you should update to use the new format.'
+        self.py3.log(msg)
 
     def check_tcp(self):
         sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         result = sock.connect_ex((self.host, self.port))
 
+        is_closed = is_open = None
+
         if result:
             color = self.color_off
-            state = self.icon_off
+            is_closed = True
         else:
             color = self.color_on
-            state = self.icon_on
+            is_open = True
 
-        return {'cached_until': self.py3.time_in(self.cache_timeout),
-                'full_text': self.py3.safe_format(self.format, {'state': state}),
-                'color': color}
+        # TEMPORARY SOLUTION
+        is_open = TRUE if is_open else FALSE
+        is_closed = TRUE if is_closed else FALSE
+
+        return {
+            'cached_until': self.py3.time_in(self.cache_timeout),
+            'color': color,
+            'full_text': self.py3.safe_format(self.format,
+                                              dict(
+                                                  is_open=is_open,
+                                                  is_closed=is_closed,
+                                              ))
+        }
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This merges three things.
```
-    format: (default '{host}:{port} {state}')
-    icon_off: (default 'DOWN')
-    icon_on: (default 'UP')
```
```
+    format: (default '{host}:{port} [\?if=is_open UP|DOWN]'
```