### PR TITLE
wifi: fix AttributeError bug

### DIFF
--- a/py3status/modules/wifi.py
+++ b/py3status/modules/wifi.py
@@ -75,6 +75,22 @@ class Py3status:
     use_sudo = False
 
     def post_config_hook(self):
+        self._max_bitrate = 0
+        self._ssid = ''
+        # Try and guess the wifi interface
+        cmd = ['iw', 'dev']
+        if self.use_sudo:
+            cmd.insert(0, 'sudo')
+        try:
+            iw = self.py3.command_output(cmd)
+            devices = re.findall('Interface\s*([^\s]+)', iw)
+            if not devices or 'wlan0' in devices:
+                self.device = 'wlan0'
+            else:
+                self.device = devices[0]
+        except:
+            pass
+
         # DEPRECATION WARNING
         format_down = getattr(self, 'format_down', None)
         format_up = getattr(self, 'format_up', None)
@@ -90,22 +106,6 @@ class Py3status:
             msg = 'DEPRECATION WARNING: you are using old style configuration '
             msg += 'parameters you should update to use the new format.'
             self.py3.log(msg)
-
-        self._ssid = None
-        self._max_bitrate = 0
-        # Try and guess the wifi interface
-        cmd = ['iw', 'dev']
-        if self.use_sudo:
-            cmd.insert(0, 'sudo')
-        try:
-            iw = self.py3.command_output(cmd)
-            devices = re.findall('Interface\s*([^\s]+)', iw)
-            if not devices or 'wlan0' in devices:
-                self.device = 'wlan0'
-            else:
-                self.device = devices[0]
-        except:
-            pass
 
     def wifi(self):
         """


### PR DESCRIPTION
Quick bugfix for my netbook. Confirmed working okay.
```
2017-04-11 05:49:45 INFO ========
2017-04-11 05:49:45 INFO Starting py3status version 3.6rc1 python 2.7.13
2017-04-11 05:49:45 INFO i3status spawned using config file /tmp/py3status_qHIvRD
2017-04-11 05:49:45 INFO loading module "wifi" from /home/chris/src/py3status/py3status/modules/wifi.py
2017-04-11 05:49:45 INFO starting module wifi
2017-04-11 05:49:45 WARNING Instance `wifi`, user method `wifi` failed (AttributeError) wifi.py line 173.
2017-04-11 05:49:45 INFO Traceback
AttributeError: Py3status instance has no attribute '_ssid'
  File "/usr/lib/python2.7/site-packages/py3status-3.6rc1-py2.7.egg/py3status/module.py", line 709, in run
    response = method()
  File "/home/chris/src/py3status/py3status/modules/wifi.py", line 173, in wifi
    if self._ssid != ssid:
```
