### PR TITLE
wifi: fix sudoers entry

### DIFF
--- a/py3status/modules/wifi.py
+++ b/py3status/modules/wifi.py
@@ -18,8 +18,8 @@ Configuration parameters:
     signal_bad: Bad signal strength in percent (default 29)
     signal_degraded: Degraded signal strength in percent (default 49)
     use_sudo: Use sudo to run iw, make sure iw requires some root rights
-        without a password by adding a sudoers entry.
-        Example: "<username> ALL=(ALL) NOPASSWD: /usr/bin/iw dev wl* link"
+        without a password by adding a sudoers entry, eg...
+        '<user> ALL=(ALL) NOPASSWD:/usr/bin/iw dev,/usr/bin/iw dev [a-z]* link'
         (default False)
 
 Format placeholders:


### PR DESCRIPTION
**POST_CONFIG_HOOK**
We avoid `sudo` and/or `iw dev` to avoid potential issues, password, privilege permission, error codes, missing binaries, etc. Idk. Eww, tacky. We use `/sys/class/net` instead.... looking for first available ifaces starting with `w`.

I don't believe the `wifi` in master branch detects ifaces correctly. It either skip them entirely... or just use the assigned `wlan0` right away due to stupid default `self.device = "wlan0"` setting so I'm guessing that works for years... until people switched to `wlp3s0` or something. We now assign it `None`.

I'm not even sure if it went through `if-else` in `post_config_hook` because it was hard to test things without working color comparison (for terminal) and without working `post_config_hook` (for terminal too). I had `wlp3s0`. Thanks. :-)