### PR TITLE
fix for clock module due to returned composite

### DIFF
--- a/py3status/modules/clock.py
+++ b/py3status/modules/clock.py
@@ -264,10 +264,15 @@ class Py3status:
                         timezone=timezone,
                         timezone_unclear=timezone_unclear,
                     ))
-                if self.py3.is_python_2():
-                    format_time = t.strftime(format_time.encode('utf-8'))
+                self.py3.log(format_time)
+                if self.py3.is_composite(format_time):
+                    for item in format_time:
+                        item['full_text'] = t.strftime(item['full_text'])
                 else:
-                    format_time = t.strftime(format_time)
+                    if self.py3.is_python_2():
+                        format_time = t.strftime(format_time.encode('utf-8'))
+                    else:
+                        format_time = t.strftime(format_time)
                 times[name] = format_time
 
         # work out when we need to update


### PR DESCRIPTION
@lasers found a bug that came to light with the formatter changes.

This is due to a composite being returned rather than a string.  This is a bug in clock that the formatter changes triggered.