### PR TITLE
dropbox: add safeformat for all statuses

### DIFF
--- a/py3status/modules/dropboxd_status.py
+++ b/py3status/modules/dropboxd_status.py
@@ -84,16 +84,19 @@ class Py3status:
                 'full_text': STRING_ERROR
             }
 
+        _format = ''
         if status == "Dropbox isn't running!":
             color = self.py3.COLOR_BAD
-            status = self.status_off
+            _format = self.status_off
         elif status == "Up to date":
             color = self.py3.COLOR_GOOD
-            status = self.status_on
+            _format = self.status_on
         else:
             color = self.py3.COLOR_DEGRADED
             if self.status_busy is not None:
-                status = self.status_busy
+                _format = self.status_busy
+
+        status = self.py3.safe_format(_format, {'status': status})
 
         return {
             'cached_until': self.py3.time_in(self.cache_timeout),


### PR DESCRIPTION
This adds safeformat for all statuses. Now we can customize this. 🚀

Couple of new default formats. We now pass `status` result straight to the return instead of using predefined strings which will return the same thing (if unset).

Why? More clean this way. Allow us to do things a bit easier with something like `format_on = '[\?color=#fcf {status}]'` instead of `format = '[\?color=#fcf Up to Date]'`.

Because `format_off` comes with `Dropbox` prefix, we use `Not started` here. I avoid `isn't running` as we're already using that in many modules. This will clear up the confusion (if any) between exception `dropbox` module and perfectly okay running `dropbox` module.

Thanks for looking. No rush. 🚀 🚤 🐎 🐰 ⏩ 