### PR TITLE
dpms: add safeformat for all statuses

### DIFF
--- a/py3status/modules/dpms.py
+++ b/py3status/modules/dpms.py
@@ -67,11 +67,13 @@ class Py3status:
         Display a colorful state of DPMS.
         """
         if 'DPMS is Enabled' in self.py3.command_output('xset -q'):
-            icon = self.icon_on
+            _format = self.icon_on
             color = self.color_on
         else:
-            icon = self.icon_off
+            _format = self.icon_off
             color = self.color_off
+
+        icon = self.py3.safe_format(_format)
 
         return {
             'cached_until': self.py3.time_in(self.cache_timeout),


### PR DESCRIPTION
This adds safeformat for all statuses (on/off). Now we can customize this. 📺

I looked at the history commits for this `dpms`. It was pretty awful. I was noob and made several commits before I learned about using `--amend`... Sorry for all the noises, all the emails, etc... Thanks to my friend @tobes for putting up with that and always helping out with things.

Hi. About this module... I believe it turns out that we should stick with `format_on`, `format_off` in first place and pass everything in `safe_format`...

Several months earlier, we didn't do that. We turned this into `{icon}` and `icon_*` because we don't want `format_*` for non-format strings and we didn't bother to `safeformat` things. That would have been easier in first place. I think it is best that we format all the things. Meme? 


Here, I fix everything. We turn back with the depreciation. We can use formatter stuffs now if we want to. To change colors, we use`color_bad`, `color_good` or use `[\?color]` + other neat formatter stuffs... will give everybody the results they want. Cheers.

I acknowledge `format` may be more than enough for `dpms`. Just looking for things that are not formatted then I can put them through `safeformat`. This way, we can get lot of `formatter` stuffs finished for all modules and should work everywhere. Neat, huh?

Thanks for looking. No rush. Sorry about being awful with git. Remember, I am stoopid. 😑

P.S. plz no judgement. I like `noises`. I like `'` over `"`. I like some `things`. Thx.
```
# Tested okay.
dpms {
        format_on = '\?color=#ff9999 DPMS'
        format_off = '\?color=#99ff99 DPMS'
}
```