### PR TITLE
Battery level icons now work with capacity over 100%.

### DIFF
--- a/py3status/modules/battery_level.py
+++ b/py3status/modules/battery_level.py
@@ -391,8 +391,9 @@ class Py3status:
         if self.charging:
             self.icon = self.charging_character
         else:
-            self.icon = self.blocks[int(math.ceil(self.percent_charged / 100 *
-                                                  (len(self.blocks) - 1)))]
+            self.icon = self.blocks[min(len(self.blocks) - 1,
+                                        int(math.ceil(self.percent_charged / 100 *
+                                                      (len(self.blocks) - 1))))]
 
     def _update_full_text(self):
         self.full_text = self.py3.safe_format(


### PR DESCRIPTION
This is how I fixed https://github.com/ultrabug/py3status/issues/548 on my Dell notebook where the battery level can go above 100% . Simply limits the icon character index to the string length, so the rightmost character will be also be shown for levels > 100%.