### PR TITLE
Fix net_iplist to work with master

### DIFF
--- a/py3status/modules/net_iplist.py
+++ b/py3status/modules/net_iplist.py
@@ -75,8 +75,8 @@ class Py3status:
 
     def post_config_hook(self):
         self.iface_re = re.compile(r'\d+: (?P<iface>\w+):')
-        self.ip_re = re.compile(r'\s+inet (?P<ip4>[\d\.]+)/')
-        self.ip6_re = re.compile(r'\s+inet6 (?P<ip6>[\da-f:]+)/')
+        self.ip_re = re.compile(r'\s+inet (?P<ip4>[\d\.]+)(?:/| )')
+        self.ip6_re = re.compile(r'\s+inet6 (?P<ip6>[\da-f:]+)(?:/| )')
 
     def ip_list(self):
         response = {

--- a/py3status/modules/net_iplist.py
+++ b/py3status/modules/net_iplist.py
@@ -108,12 +108,14 @@ class Py3status:
         if not connection:
             response['full_text'] = self.py3.safe_format(self.format_no_ip,
                                                          {'format_iface':
-                                                             self.iface_sep.join(iface_list)})
+                                                             self.py3.composite_join(
+                                                                 self.iface_sep, iface_list)})
             response['color'] = self.py3.COLOR_BAD
         else:
             response['full_text'] = self.py3.safe_format(self.format,
                                                          {'format_iface':
-                                                             self.iface_sep.join(iface_list)})
+                                                             self.py3.composite_join(
+                                                                 self.iface_sep, iface_list)})
             response['color'] = self.py3.COLOR_GOOD
 
         return response


### PR DESCRIPTION
This fixes `net_iplist` by using the new `composite_join`. Previously, it would do a `str.join` but that doesn't work with composites.

Additionally, the regexp has been improved so that it can display ip addresses of peered interfaces (such as VPNs) too.

EDIT: this is similar to #901 I think.