### PR TITLE
external_script module: add support for colors

### DIFF
--- a/py3status/modules/external_script.py
+++ b/py3status/modules/external_script.py
@@ -3,7 +3,10 @@
 Display output of a given script.
 
 Display output of any executable script set by `script_path`.
-Pay attention. The output must be one liner, or will break your i3status !
+Only the first two lines of output will be used. The first line is used
+as the displayed text. If the output has two or more lines, the second
+line is set as the text color (and should hence be a valid hex color
+code such as #FF0000 for red).
 The script should not have any parameters, but it could work.
 
 Configuration parameters:
@@ -36,6 +39,8 @@ example
 {'full_text': 'It is now: Wed Feb 22 22:24:13'}
 """
 
+import re
+
 STRING_UNAVAILABLE = "external_script: N/A"
 
 
@@ -55,20 +60,28 @@ class Py3status:
                 'color': self.py3.COLOR_BAD,
                 'full_text': STRING_UNAVAILABLE
             }
+
+        response = {}
+        response['cached_until'] = self.py3.time_in(self.cache_timeout)
         try:
             output = self.py3.command_output(self.script_path, shell=True)
+            output_lines = output.splitlines()
+            if len(output_lines) > 1:
+                output_color = output_lines[1]
+                if re.search(r'^#[0-9a-fA-F]{6}$', output_color):
+                    response['color'] = output_color
         except self.py3.CommandError as e:
             output = e.output or e.error
+            output_lines = output.splitlines()
+            response['color'] = self.py3.COLOR_BAD
 
-        output = output.splitlines()[0]
+        output_text = output_lines[0]
 
         if self.strip_output:
-            output = output.strip()
+            output_text = output_text.strip()
 
-        return {
-            'cached_until': self.py3.time_in(self.cache_timeout),
-            'full_text': self.py3.safe_format(self.format, {'output': output})
-        }
+        response['full_text'] = self.py3.safe_format(self.format, {'output': output_text})
+        return response
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Read a color code from the second line of output.

If the external script has only one line of output the behavior
is unchanged.