### PR TITLE
color_degraded support in status mode for whatismyip module

### DIFF
--- a/py3status/modules/whatismyip.py
+++ b/py3status/modules/whatismyip.py
@@ -131,18 +131,14 @@ class Py3status:
             info['icon'] = self.icon_on
             response['cached_until'] = self.py3.time_in(self.cache_timeout)
             response['color'] = self.py3.COLOR_GOOD
+            for key, val in self.expected.items():
+                if val != info.get(key):
+                    response['color'] = self.py3.COLOR_DEGRADED
+                    break
             if self.mode == 'ip':
                 response['full_text'] = self.py3.safe_format(self.format, info)
-                for key, val in self.expected.items():
-                    if val != info.get(key):
-                        response['color'] = self.py3.COLOR_DEGRADED
-                        break
             else:
                 response['full_text'] = self.icon_on
-                for key, val in self.expected.items():
-                    if val != info.get(key):
-                        response['color'] = self.py3.COLOR_DEGRADED
-                        break
         else:
             response['full_text'] = self.icon_off
             response['color'] = self.py3.COLOR_BAD

--- a/py3status/modules/whatismyip.py
+++ b/py3status/modules/whatismyip.py
@@ -139,6 +139,10 @@ class Py3status:
                         break
             else:
                 response['full_text'] = self.icon_on
+                for key, val in self.expected.items():
+                    if val != info.get(key):
+                        response['color'] = self.py3.COLOR_DEGRADED
+                        break
         else:
             response['full_text'] = self.icon_off
             response['color'] = self.py3.COLOR_BAD


### PR DESCRIPTION
As of now status mode in whatismyip only shows either color_good or color_bad and as such ignores user "expected" dictionary, showing color_good even when there is an IP/country mismatch. This following commit fixes this and adds color_degraded support for status mode.