### PR TITLE
volume_status: (pactl) get device number instead of assuming device 0

### DIFF
--- a/py3status/modules/volume_status.py
+++ b/py3status/modules/volume_status.py
@@ -163,8 +163,10 @@ class PamixerBackend(AudioBackend):
 
 class PactlBackend(AudioBackend):
     def setup(self, parent):
+        # get available device number if not specified
         if self.device is None:
-            self.device = "0"
+            self.device = check_output(
+                ['pactl', 'list', 'short', 'sinks']).decode('utf-8').split()[0]
         self.max_volume = parent.max_volume
         self.re_volume = re.compile(
             r'Sink \#{}.*?Mute: (\w{{2,3}}).*?Volume:.*?(\d{{1,3}})\%'.format(self.device),


### PR DESCRIPTION
Device is not always `0`. It can be `1`. Dunno about `[2-9]`. Fixes https://github.com/ultrabug/py3status/issues/921.