### PR TITLE
spaceapi: prevent 'used before assignment' error

### DIFF
--- a/py3status/modules/spaceapi.py
+++ b/py3status/modules/spaceapi.py
@@ -98,6 +98,8 @@ class Py3status:
             if 'lastchange' in data['state'].keys():
                 dt = datetime.datetime.fromtimestamp(data['state']['lastchange'])
                 lastchanged = dt.strftime(self.format_lastchanged)
+            else:
+                lastchanged = 'unknown'
 
             full_text = self.py3.safe_format(
                 self.format, {'state': state, 'lastchanged': lastchanged})


### PR DESCRIPTION
The 'lastchange' field in the 'state' object is optional according to the SpaceAPI specification. If it is not present, the lastchanged variable was never set, causing a 'used before assignment' error during formatting.