### PR TITLE
mpris: raise keyboard interrupt

### DIFF
--- a/py3status/modules/mpris.py
+++ b/py3status/modules/mpris.py
@@ -518,6 +518,9 @@ class Py3status:
                                                  text,
                                                  buttons)
 
+        if self._kill:
+            raise KeyboardInterrupt
+
         if (self._data.get('error_occurred') or
                 current_player_id != self._player_details.get('id')):
             # Something went wrong or the player changed during our processing


### PR DESCRIPTION
When you ran the _mpris_ module in test mode you couldn't abort it with ^C. The exception was 
caught in the module and wasn't raise up to _module_test_.