### PR TITLE
spotify: sanitize album/track title

### DIFF
--- a/tests/test_module_doc.py
+++ b/tests/test_module_doc.py
@@ -43,6 +43,7 @@ IGNORE_ITEM = [
     ('github', 'format'),  # dynamic
     ('kdeconnector', '_dev'),  # move to __init__ etc
     ('arch_updates', 'format'),  # dynamic
+    ('spotify', 'sanitize_words'),  # line too long for docstring parsing
 ]
 
 # Obsolete parameters will not have alphabetical order checked


### PR DESCRIPTION
A lot of spotify album/track titles have this rubbish Remastered or Stereo suffix (eg. "Ziggy Stardust - Remastered 2012 Version"), which is an absolute waste of space on the screen, looks very unaesthetic and also is very useless.

This PR introduces new config options
sanitize_titles: true/false 
sanitize_words: list of words that indicate meta data

![Preview](http://i.imgur.com/PlgMPGI.png)

