### PR TITLE
Round brightness values (so that 94.96% is rendered as 95% and not as 94%)

### DIFF
--- a/py3status/modules/backlight.py
+++ b/py3status/modules/backlight.py
@@ -107,7 +107,7 @@ class Py3status:
     def _get_backlight_level(self):
         if self.xbacklight:
             level = self.py3.command_output(['xbacklight', '-get']).strip()
-            return int(float(level))
+            return round(float(level))
         for brightness_line in open("%s/brightness" % self.device, 'rb'):
             brightness = int(brightness_line)
         for brightness_max_line in open("%s/max_brightness" % self.device, 'rb'):


### PR DESCRIPTION
```
❯  xbacklight -get
100.000000

❯  xbacklight -get
94.947121
```

In these cases the module was outputting `100%` and `94%`. I want to see `95%` in the latter case 🙂