### PR TITLE
mpris: dbus signal fix

### DIFF
--- a/py3status/modules/mpris.py
+++ b/py3status/modules/mpris.py
@@ -377,6 +377,13 @@ class Py3status:
             status = data.get('PlaybackStatus')
             if status:
                 player = self._mpris_players[player_id]
+ 
+                # Note: Workaround.
+                # Since all players get noted if playback status has been
+                # changed we have to check if we are the choosen one
+                if status != player['_dbus_player'].PlaybackStatus:
+                    return
+
                 player['status'] = status
                 player['_state_priority'] = WORKING_STATES.index(status)
             self._set_player()

--- a/py3status/modules/mpris.py
+++ b/py3status/modules/mpris.py
@@ -398,16 +398,18 @@ class Py3status:
                     p['name'] = self._mpris_names[p['identity']]
                     p['full_name'] = u'{} {}'.format(p['name'], p['index'])
 
-        status = player.PlaybackStatus
-        state_priority = WORKING_STATES.index(status)
         identity = player.Identity
+        name = self._mpris_names.get(identity)
+        if name not in self.player_priority and '*' not in self.player_priority:
+            return False
 
         if identity not in self._mpris_name_index:
             self._mpris_name_index[identity] = 0
 
+        status = player.PlaybackStatus
+        state_priority = WORKING_STATES.index(status)
         index = self._mpris_name_index[identity]
         self._mpris_name_index[identity] += 1
-        name = self._mpris_names.get(identity)
         subscription = player.PropertiesChanged.connect(self._player_monitor(player_id))
 
         self._mpris_players[player_id] = {

--- a/py3status/modules/mpris.py
+++ b/py3status/modules/mpris.py
@@ -424,8 +424,7 @@ class Py3status:
         state_priority = WORKING_STATES.index(status)
         index = self._mpris_name_index[identity]
         self._mpris_name_index[identity] += 1
-        subscription = player.PropertiesChanged.connect(
-                self._player_monitor(player_id))
+        subscription = player.PropertiesChanged.connect(self._player_monitor(player_id))
 
         self._mpris_players[player_id] = {
             '_dbus_player': player,

--- a/py3status/modules/mpris.py
+++ b/py3status/modules/mpris.py
@@ -376,23 +376,22 @@ class Py3status:
             """
             data = args[1]
             status = data.get('PlaybackStatus')
-            if not status:
-                return
+            if status:
+                player = self._mpris_players[player_id]
 
-            player = self._mpris_players[player_id]
+                # Note: Workaround. Since all players get noted if playback status
+                #       has been changed we have to check if we are the choosen one
+                try:
+                    dbus_status = player['_dbus_player'].PlaybackStatus
+                except GError:
+                    # Prevent errors when calling methods of deleted dbus objects
+                    return
+                if status != dbus_status:
+                    # FIXME: WE DON'T RECOGNIZE ANY TITLE CHANGE
+                    return
 
-            # Note: Workaround. Since all players get noted if playback status
-            #       has been changed we have to check if we are the choosen one
-            try:
-                dbus_status = player['_dbus_player'].PlaybackStatus
-            except GError:
-                # Prevent errors when calling methods of deleted dbus objects
-                return
-            if status != dbus_status:
-                return
-
-            player['status'] = status
-            player['_state_priority'] = WORKING_STATES.index(status)
+                player['status'] = status
+                player['_state_priority'] = WORKING_STATES.index(status)
             self._set_player()
         return player_on_change
 

--- a/py3status/modules/mpris.py
+++ b/py3status/modules/mpris.py
@@ -413,7 +413,8 @@ class Py3status:
 
         identity = player.Identity
         name = self._mpris_names.get(identity)
-        if name not in self.player_priority and '*' not in self.player_priority:
+        if self.player_priority != [] and name not in self.player_priority \
+                and '*' not in self.player_priority:
             return False
 
         if identity not in self._mpris_name_index:
@@ -423,7 +424,8 @@ class Py3status:
         state_priority = WORKING_STATES.index(status)
         index = self._mpris_name_index[identity]
         self._mpris_name_index[identity] += 1
-        subscription = player.PropertiesChanged.connect(self._player_monitor(player_id))
+        subscription = player.PropertiesChanged.connect(
+                self._player_monitor(player_id))
 
         self._mpris_players[player_id] = {
             '_dbus_player': player,


### PR DESCRIPTION
There is a bug with the dbus signals. We get callbacks for all running players if only one player change the playback state.

To catch the false signals I check the playback state with the dbus method additionally. Let me know if you've an better idea.