### PR TITLE
Fix usage of cower in arch_updates module

### DIFF
--- a/py3status/modules/arch_updates.py
+++ b/py3status/modules/arch_updates.py
@@ -114,7 +114,7 @@ class Py3status:
 
         pending_updates = b""
         try:
-            pending_updates = str(subprocess.check_output(["cower", "-bu"]))
+            pending_updates = str(subprocess.check_output(["cower", "-u"]))
         except subprocess.CalledProcessError as cp_error:
             pending_updates = cp_error.output
         except:


### PR DESCRIPTION
There is no `-b` flag, using it leads to zero results.