### PR TITLE
Catch ZeroDivisionError for #732

### DIFF
--- a/py3status/modules/battery_level.py
+++ b/py3status/modules/battery_level.py
@@ -359,12 +359,17 @@ class Py3status:
 
                 time_remaining_seconds = self._hms_to_seconds(active_battery[
                     "time_remaining"])
-                rate_second_per_mah = time_remaining_seconds / (
-                    active_battery["capacity"] *
-                    (active_battery["percent_charged"] / 100))
-                time_remaining_seconds += inactive_battery["capacity"] * \
-                    inactive_battery["percent_charged"] / 100 * \
-                    rate_second_per_mah
+                try:
+                    rate_second_per_mah = time_remaining_seconds / (
+                        active_battery["capacity"] *
+                        (active_battery["percent_charged"] / 100))
+                    time_remaining_seconds += inactive_battery["capacity"] * \
+                        inactive_battery["percent_charged"] / 100 * \
+                        rate_second_per_mah
+                except ZeroDivisionError:
+                    # Either active or inactive battery has 0% charge
+                    time_remaining_seconds = 0
+                    rate_second_per_mah = 0
 
                 self.time_remaining = self._seconds_to_hms(
                     time_remaining_seconds)


### PR DESCRIPTION
Quickfix for #732. Catches ZeroDivisionError which could happen if either the active or inactive battery is reporting 0% capacity.