### PR TITLE
Make headers available via py3.request() and update github module

### DIFF
--- a/py3status/modules/github.py
+++ b/py3status/modules/github.py
@@ -72,6 +72,12 @@ notification
 {'full_text': 'py3status 34/24 N3', 'urgent': True}
 """
 
+try:
+    import urlparse
+except ImportError:
+    import urllib.parse as urlparse
+
+
 GITHUB_API_URL = 'https://api.github.com'
 GITHUB_URL = 'https://github.com/'
 
@@ -152,18 +158,14 @@ class Py3status:
         except (self.py3.RequestException):
             return
         if info.status_code == 200:
-            links = info._response.headers.get('Link', '').split(', ')
+            links = info.headers.get('Link')
+
             if not links:
                 return len(info.json())
 
             last_page = 1
-            for link in links:
+            for link in links.split(','):
                 if 'rel="last"' in link:
-                    import sys
-                    if sys.version_info[0] == 2:
-                        import urlparse
-                    else:
-                        import urllib.parse as urlparse
                     last_url = link[link.find('<') + 1:link.find('>')]
                     parsed = urlparse.urlparse(last_url)
                     last_page = int(urlparse.parse_qs(parsed.query)['page'][0])

--- a/py3status/py3.py
+++ b/py3status/py3.py
@@ -972,7 +972,7 @@ class Py3:
         :returns: HttpResponse
         """
 
-        # The aim of this function is to be a lmited lightweight replacement
+        # The aim of this function is to be a limited lightweight replacement
         # for the requests library but using only pythons standard libs.
 
         # IMPORTANT NOTICE

--- a/py3status/request.py
+++ b/py3status/request.py
@@ -103,3 +103,10 @@ class HttpResponse:
             return json.loads(self.text)
         except:
             raise RequestInvalidJSON('Invalid JSON recieved')
+
+    @property
+    def headers(self):
+        """
+        Get the headers from the response.
+        """
+        return self._response.headers


### PR DESCRIPTION
Allows modules to access headers from `py3.request()`.

Updates `github` module to use them.

Cleaned up the import of `urlparse`

Fixed logical bug where we would always check for links  `''.split(', ') == ['']`

Fixed typo in `Py3.request()` comment