### PR TITLE
Faster py3-cmd

### DIFF
--- a/py3status/__init__.py
+++ b/py3status/__init__.py
@@ -1,8 +1,6 @@
 import locale
 import sys
 
-from py3status.core import Py3statusWrapper
-
 try:
     from setproctitle import setproctitle
     setproctitle('py3status')
@@ -18,6 +16,7 @@ except NameError:
 
 
 def main():
+    from py3status.core import Py3statusWrapper
     try:
         locale.setlocale(locale.LC_ALL, '')
     except locale.Error:

--- a/py3status/command.py
+++ b/py3status/command.py
@@ -2,7 +2,6 @@ import argparse
 import glob
 import json
 import os
-import platform
 import socket
 import sys
 import threading
@@ -283,6 +282,7 @@ def send_command():
         options.command = 'refresh_all'
 
     if options.version:
+        import platform
         print('py3status-command version {} (python {})'.format(
             version, platform.python_version()
         ))

--- a/setup.py
+++ b/setup.py
@@ -5,12 +5,59 @@ py3status
 import os
 import sys
 from setuptools import find_packages, setup
+from setuptools.command.develop import develop
+from setuptools.command.install import install
+from setuptools.command.easy_install import _to_ascii, ScriptWriter
 
 module_path = os.path.join(
     os.path.dirname(os.path.realpath(__file__)), 'py3status')
 sys.path.insert(0, module_path)
 from version import version  # noqa
 sys.path.remove(module_path)
+
+
+# setuptools causes scripts to run slowly see
+# https://github.com/pypa/setuptools/issues/510
+# We can make py3-cmd run much faster when installed via
+# python setup install/develop
+PY3_CMD_SCRIPT_TEXT = u"""{}
+# -*- coding: utf-8 -*-
+import re
+import sys
+
+from py3status.command import send_command
+
+if __name__ == '__main__':
+    sys.argv[0] = re.sub(r'(-script\.pyw?|\.exe)?$', '', sys.argv[0])
+    sys.exit(send_command())
+"""
+
+
+def install_py3_cmd(installer):
+    """Attempt to overwrite /bin/py3-cmd with efficient version"""
+    py_cmd = ScriptWriter.get_header()
+    script_text = PY3_CMD_SCRIPT_TEXT.format(py_cmd)
+    try:
+        installer.write_script('py3-cmd', _to_ascii(script_text), 'b')
+    except AttributeError:
+        # building wheel etc
+        pass
+
+
+class PostDevelopCommand(develop):
+    """Post-installation for develop"""
+
+    def run(self):
+        develop.run(self)
+        install_py3_cmd(self)
+
+
+class PostInstallCommand(install):
+    """Post-installation for install"""
+
+    def run(self):
+        install.run(self)
+        install_py3_cmd(self)
 
 
 # Utility function to read the README file.
@@ -35,6 +82,10 @@ setup(
     packages=find_packages(),
     include_package_data=True,
     install_requires=[],
+    cmdclass={
+        'develop': PostDevelopCommand,
+        'install': PostInstallCommand,
+    },
     entry_points={
         'console_scripts': [
             'py3status = py3status:main',


### PR DESCRIPTION
py3-cmd is slow #918 

current performance for `time py3-cmd click 2 volume_status` (median of 3 runs)

```
python 3
real    0m0.347s
user    0m0.319s
sys     0m0.023s

python 2
real    0m0.270s
user    0m0.223s
sys     0m0.045s
```

with this branch

```
Python 3
real    0m0.091s
user    0m0.074s
sys     0m0.016s

Python 2
real    0m0.056s
user    0m0.043s
sys     0m0.011s
```

We get this improvement by

* only importing `py3status.core` in `__init__.py` this means we can import from py3status much more cheaply.

* only import `platform` module if we need it

* hack `setuptools` so that we can run our command without all the overheads of importing `pkg_resources`

when installed from a wheel we do not have these issues as the command runs without the overhead.