### PR TITLE
formatter not zero fix for displayed values

### DIFF
--- a/py3status/formatter.py
+++ b/py3status/formatter.py
@@ -222,13 +222,7 @@ class Placeholder:
         return the correct value for the placeholder
         """
         try:
-            value = get_params(self.key)
-            if block.commands.not_zero:
-                valid = value not in ['', None, False, '0', '0.0', 0, 0.0]
-            else:
-                # '', None, and False are ignored
-                # numbers like 0 and 0.0 are not.
-                valid = not (value in ['', None] or value is False)
+            value = value_ = get_params(self.key)
             if self.format.startswith(':'):
                 # if a parameter has been set to be formatted as a numeric
                 # type then we see if we can coerce it to be.  This allows
@@ -243,11 +237,19 @@ class Placeholder:
                         value = int(float(value))
                     output = u'{%s%s}' % (self.key, self.format)
                     value = output.format(**{self.key: value})
+                    value_ = float(value)
                 except ValueError:
                     pass
             elif self.format.startswith('!'):
                 output = u'{%s%s}' % (self.key, self.format)
-                value = output.format(**{self.key: value})
+                value = value_ = output.format(**{self.key: value})
+
+            if block.commands.not_zero:
+                valid = value_ not in ['', None, False, '0', '0.0', 0, 0.0]
+            else:
+                # '', None, and False are ignored
+                # numbers like 0 and 0.0 are not.
+                valid = not (value_ in ['', None] or value_ is False)
             enough = False
         except:
             # Exception raised when we don't have the param

--- a/tests/test_formatter.py
+++ b/tests/test_formatter.py
@@ -33,6 +33,7 @@ param_dict = {
     'zero': 0,
     'zero_str': '0',
     'zero_float': 0.0,
+    'zero_almost': 0.0001,
     'str_int': '123',
     'str_float': '123.456',
     'str_nan': "I'm not a number",
@@ -1120,6 +1121,25 @@ def test_module_true_value():
 
 def test_module_false_value():
     run_formatter({'format': '{module_false}', 'expected': ''})
+
+
+def test_zero_format_1():
+    run_formatter({'format': '[\?not_zero {zero_almost}]', 'expected': '0.0001'})
+
+
+def test_zero_format_2():
+    run_formatter({'format': '[\?not_zero {zero_almost:d}]', 'expected': ''})
+
+
+def test_zero_format_3():
+    run_formatter({'format': '[\?not_zero {zero_almost:.3f}]', 'expected': ''})
+
+
+def test_zero_format_4():
+    run_formatter({
+        'format': '[\?not_zero {zero_almost:.4f}]',
+        'expected': '0.0001'
+    })
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
@maximbaz found an issue around values that get rounded to zero not being treated as zero in some situations. eg #964

Moving the zero check till after the value has been formatted fixes the issue.

Tests added to prevent regressions