### PR TITLE
set pypy version - fix build tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ python:
   - "3.4"
   - "3.5"
   - "3.6"
-  - "pypy"
+  - "pypy-5.4.1"
 
 install:
   - travis_retry pip install tox


### PR DESCRIPTION
Travis is now using `trusty` rather than `precise` for builds which broke pypy.

This sets a pypy version.  Which fixes things.  We should look into what pypy versions we want to/cn support via travis