### PR TITLE
formatter allow some commands to be inherited

### DIFF
--- a/py3status/formatter.py
+++ b/py3status/formatter.py
@@ -291,6 +291,7 @@ class BlockConfig:
     """
 
     REGEX_COLOR = re.compile('#[0-9A-F]{6}')
+    INHERITABLE = ['color', 'not_zero', 'show']
 
     # defaults
     _if = None
@@ -300,6 +301,14 @@ class BlockConfig:
     not_zero = False
     show = False
     soft = False
+
+    def __init__(self, parent):
+        # inherit any commands from the parent block
+        # inheritable commands are in self.INHERITABLE
+        if parent:
+            parent_commands = parent.commands
+            for attr in self.INHERITABLE:
+                setattr(self, attr, getattr(parent_commands, attr))
 
     def update_commands(self, commands_str):
         """
@@ -350,7 +359,7 @@ class Block:
     def __init__(self, parent, base_block=None, py3_wrapper=None):
 
         self.base_block = base_block
-        self.commands = BlockConfig()
+        self.commands = BlockConfig(parent)
         self.content = []
         self.next_block = None
         self.parent = parent
@@ -528,15 +537,13 @@ class Block:
         max_length = self.commands.max_length
         min_length = self.commands.min_length
 
-        if max_length or min_length or color:
+        if max_length or min_length:
             for item in out:
                 if max_length is not None:
                     item['full_text'] = item['full_text'][:max_length]
                     max_length -= len(item['full_text'])
                 if min_length:
                     min_length -= len(item['full_text'])
-                if color and 'color' not in item:
-                    item['color'] = color
             if min_length > 0:
                 out[0]['full_text'] = u' ' * min_length + out[0]['full_text']
                 min_length = 0

--- a/tests/test_formatter.py
+++ b/tests/test_formatter.py
@@ -1142,6 +1142,48 @@ def test_zero_format_4():
     })
 
 
+def test_inherit_not_zero_1():
+    run_formatter({
+        'format': '\?not_zero [{zero}]',
+        'expected': ''
+    })
+
+
+def test_inherit_not_zero_2():
+    run_formatter({
+        'format': '[\?not_zero [{zero}]]',
+        'expected': ''
+    })
+
+
+def test_inherit_not_zero_3():
+    run_formatter({
+        'format': '[\?not_zero [[[{zero}]]]]',
+        'expected': ''
+    })
+
+
+def test_inherit_show_1():
+    run_formatter({
+        'format': '\?show [[[hello]]]',
+        'expected': 'hello'
+    })
+
+
+def test_inherit_color_1():
+    run_formatter({
+        'format': '\?color=#F0F [[[{number}]]]',
+        'expected': [{'color': u'#FF00FF', 'full_text': u'42'}]
+    })
+
+
+def test_inherit_color_2():
+    run_formatter({
+        'format': '\?color=#F0F [[\?color=good [{number}]]]',
+        'expected': [{'color': u'#00FF00', 'full_text': u'42'}]
+    })
+
+
 if __name__ == '__main__':
     # run tests
     import sys


### PR DESCRIPTION
This PR enables `not_zero` and `show` formatter commands to be inherited.  Previously `color` ended up propagating.

This means we can now write a format like `\?not_zero Output:[ X {x}][ Y {y}]` rather than `Output:[\?not_zero  X {x}][\?not_zero  Y {y}]` which should help us simplify formats a bit

eg uptime `'up [\?if=weeks {weeks} weeks ][\?if=days {days} days ][\?if=hours {hours} hours ][\?if=minutes {minutes} minutes ]'`  == `'\?not_zero up [ {weeks} weeks][ {days} days][ {hours} hours][ {minutes} minutes] '`

Due to the inheritance changes, color now uses the same code rather than it's old method.

Some tests added for luck