### PR TITLE
Only show first line of error in i3bar

### DIFF
--- a/py3status/module.py
+++ b/py3status/module.py
@@ -156,6 +156,10 @@ class Module(Thread):
         if self.error_hide:
             self.hide_errors()
             return
+
+        # only show first line of error
+        msg = msg.splitlines()[0]
+
         errors = [
             self.module_nice_name,
             u'{}: {}'.format(self.module_nice_name, msg),


### PR DESCRIPTION
If a runtime error is more than one line it displays incorrectly in i3bar.  This fixes the issue by only showing the first line.