### PR TITLE
command_output allow piping of STDERR to STDOUT

### DIFF
--- a/py3status/py3.py
+++ b/py3status/py3.py
@@ -8,7 +8,7 @@ import shlex
 from fnmatch import fnmatch
 from math import log10
 from pprint import pformat
-from subprocess import Popen, PIPE
+from subprocess import Popen, PIPE, STDOUT
 from time import time
 
 from py3status import exceptions
@@ -840,18 +840,25 @@ class Py3:
             msg = 'Command `{cmd}` {error}'.format(cmd=command[0], error=e.errno)
             raise exceptions.CommandError(msg, error_code=e.errno)
 
-    def command_output(self, command, shell=False):
+    def command_output(self, command, shell=False, capture_stderr=False):
         """
         Run a command and return its output as unicode.
         The command can either be supplied as a sequence or string.
 
-        An Exception is raised if an error occurs
+        :param command: command to run can be a str or list
+        :param shell: if `True` then command is run through the shell
+        :param capture_stderr: if `True` then STDERR is piped to STDOUT
+
+        A CommandError is raised if an error occurs
         """
         # convert the command to sequence if a string
         if isinstance(command, basestring):
             command = shlex.split(command)
+
+        stderr = STDOUT if capture_stderr else PIPE
+
         try:
-            process = Popen(command, stdout=PIPE, stderr=PIPE, close_fds=True,
+            process = Popen(command, stdout=PIPE, stderr=stderr, close_fds=True,
                             universal_newlines=True, shell=shell)
         except Exception as e:
             msg = 'Command `{cmd}` {error}'.format(cmd=command[0], error=e)


### PR DESCRIPTION
Some commands provide valid output via STDERR this PR allows this to be piped to STDOUT.

This is an issue for `apt` and `dnf`