### PR TITLE
cmus, moc: fix screenshots

### DIFF
--- a/py3status/modules/cmus.py
+++ b/py3status/modules/cmus.py
@@ -14,9 +14,9 @@ Configuration parameters:
     button_stop: mouse button to stop the playback (default 3)
     cache_timeout: refresh interval for this module (default 5)
     format: display format for this module
-        (default '[\?if=is_started [\?if=is_playing > ][\?if=is_paused \|\| ]
+        *(default '[\?if=is_started [\?if=is_playing > ][\?if=is_paused \|\| ]
         [\?if=is_stopped .. ][[{artist}][\?soft  - ][{title}]
-        |\?show cmus: waiting for user input]]')
+        |\?show cmus: waiting for user input]]')*
     sleep_timeout: sleep interval for this module will be used when cmus is not
         running. this allows aggressive timing in cache_timeout where one might
         want to refresh cmus every 0 second along with time placeholders...
@@ -28,7 +28,6 @@ Control placeholders:
     is_playing: a boolean based on cmus status
     is_started: a boolean based on cmus status
     is_stopped: a boolean based on cmus status
-    ----------
     continue: a boolean based on data status
     play_library: a boolean based on data status
     play_sorted: a boolean based on data status
@@ -43,7 +42,6 @@ Control placeholders:
 Format placeholders:
     {durationtime} length time in [HH:]MM:SS, eg 02:51
     {positiontime} elapsed time in [HH:]MM:SS, eg 00:17
-    ----------
     {aaa_mode} shuffle songs between artist, album, or all. eg album
     {albumartist} album artist
     {album} album name
@@ -78,13 +76,13 @@ SAMPLE OUTPUT
 {'color': '#00FF00', 'full_text': '> Music For Programming - Big War'}
 
 paused
-{'color: '#FFFF00', 'full_text': '|| Music For Programming - Big War'}
+{'color': '#FFFF00', 'full_text': '|| Music For Programming - Big War'}
 
 stopped
-{'color: '#FF0000', 'full_text': '.. Music For Programming - Big War'}
+{'color': '#FF0000', 'full_text': '.. Music For Programming - Big War'}
 
 waiting
-{'color: '#FF0000', 'full_text': '.. cmus: waiting for user input'}
+{'color': '#FF0000', 'full_text': '.. cmus: waiting for user input'}
 """
 
 from __future__ import division

--- a/py3status/modules/moc.py
+++ b/py3status/modules/moc.py
@@ -30,7 +30,6 @@ Control placeholders:
 Format placeholders:
     {totaltime} total time in seconds, eg 72:02
     {currenttime} elapsed time in [HH:]MM:SS, eg 00:32
-    ----------
     {album} album name
     {artist} artist name
     {avgbitrate} audio average bitrate, eg 230kbps
@@ -63,10 +62,10 @@ SAMPLE OUTPUT
 {'color': '#00FF00', 'full_text': '> Music For Programming - Mindaugaszq'}
 
 paused
-{'color: '#FFFF00', 'full_text': '|| Music For Programming - Mindaugaszq'}
+{'color': '#FFFF00', 'full_text': '|| Music For Programming - Mindaugaszq'}
 
 stopped
-{'color: '#FF0000', 'full_text': '[] moc'}
+{'color': '#FF0000', 'full_text': '[] moc'}
 """
 
 from __future__ import division

--- a/py3status/screenshots.py
+++ b/py3status/screenshots.py
@@ -197,7 +197,11 @@ def parse_sample_data(sample_data, module_name):
                     output = ast.literal_eval(data)
                     samples[name] = output
                 except:
-                    samples[name] = 'SAMPLE DATA ERROR'
+                    samples[name] = {
+                        'color': '#990000',
+                        'background': '#FFFF00',
+                        'full_text': ' SAMPLE DATA ERROR ',
+                    }
                 name = None
                 data = ''
                 count += 1


### PR DESCRIPTION
New `cmu` and `moc` modules had errors in their screenshot data.  This also broke the documentation build.

* fix modules screenshot data

* improve screenshot building so that if this happens again the build will not die

**edit**

fixed additional docstring errors causing build warnings/formatting issues