### PR TITLE
Fix py3-cmd link in docs

### DIFF
--- a/doc/intro.rst
+++ b/doc/intro.rst
@@ -152,4 +152,4 @@ Note that this will also send a SIGUSR1 signal to i3status.
 .. note::
 
     Since version 3.6 py3status can be controlled via the
-    :ref:`py3status-command` which is **recommended**.
+    :ref:`py3-cmd` which is **recommended**.


### PR DESCRIPTION
When we renamed `py3-cmd` we missed this reference in the documentation.