### PR TITLE
Docs: add new screenshot directive

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -2,7 +2,11 @@
 # -*- coding: utf-8 -*-
 import re
 
-from py3status.autodoc import create_auto_documentation, Py3statusLexer
+from py3status.autodoc import (
+    create_auto_documentation,
+    Py3statusLexer,
+    ScreenshotDirective
+)
 from py3status.version import version as py3_version
 
 # py3status documentation build configuration file, created by
@@ -176,3 +180,6 @@ def setup(sphinx):
     # add the py3status lexer (for code blocks)
     from sphinx.highlighting import lexers
     lexers['py3status'] = Py3statusLexer()
+
+    # enable screenshot directive for dynamic screenshots
+    sphinx.add_directive('screenshot', ScreenshotDirective)


### PR DESCRIPTION
To allow screenshots to be embedded in the documentation, this PR adds a `screenshot` directive to sphinx.  This will be useful for documenting formatting.

```
.. screenshot::

        {'color': '#00FF00', 'full_text': 'Example output'}
```

The changes to `screenshots.py` are to allow single images to be created, but don't really change how things are done.  There is a bit of nastiness around caching `font` and `glyph_data` as that helps performance.