### PR TITLE
share code so module_test improved

### DIFF
--- a/py3status/module.py
+++ b/py3status/module.py
@@ -22,7 +22,7 @@ class Module(Thread):
     PARAMS_NEW = 'new'
     PARAMS_LEGACY = 'legacy'
 
-    def __init__(self, module, user_modules, py3_wrapper):
+    def __init__(self, module, user_modules, py3_wrapper, instance=None):
         """
         We need quite some stuff to occupy ourselves don't we ?
         """
@@ -42,7 +42,7 @@ class Module(Thread):
         self.last_output = []
         self.lock = py3_wrapper.lock
         self.methods = OrderedDict()
-        self.module_class = None
+        self.module_class = instance
         self.module_full_name = module
         self.module_inst = ''.join(module.split(' ')[1:])
         self.module_name = module.split(' ')[0]
@@ -51,6 +51,7 @@ class Module(Thread):
         self.prevent_refresh = False
         self.sleeping = False
         self.terminated = False
+        self.testing = self.config.get('testing')
         self.timer = None
         self.urgent = False
 
@@ -153,6 +154,10 @@ class Module(Thread):
         """
         Show the error in the bar
         """
+        if self.testing:
+            self._py3_wrapper.report_exception(msg)
+            raise KeyboardInterrupt
+
         if self.error_hide:
             self.hide_errors()
             return
@@ -272,10 +277,14 @@ class Module(Thread):
         for method in self.methods.values():
             data = method['last_output']
             if isinstance(data, list):
+                if self.testing:
+                    data[0]['cached_until'] = method.get('cached_until')
                 output.extend(data)
             else:
                 # if the output is not 'valid' then don't add it.
                 if data.get('full_text') or 'separator' in data:
+                    if self.testing:
+                        data['cached_until'] = method.get('cached_until')
                     output.append(data)
         # if changed store and force display update.
         if output != self.last_output:
@@ -452,22 +461,24 @@ class Module(Thread):
             - 'on_click' methods as they'll be called upon a click_event
             - 'kill' methods as they'll be called upon this thread's exit
         """
-        # user provided modules take precedence over py3status provided modules
-        if self.module_name in user_modules:
-            include_path, f_name = user_modules[self.module_name]
-            self._py3_wrapper.log(
-                'loading module "{}" from {}{}'.format(module, include_path,
-                                                       f_name))
-            class_inst = self.load_from_file(include_path + f_name)
-        # load from py3status provided modules
-        else:
-            self._py3_wrapper.log(
-                'loading module "{}" from py3status.modules.{}'.format(
-                    module, self.module_name))
-            class_inst = self.load_from_namespace(self.module_name)
+        if not self.module_class:
+            # user provided modules take precedence over py3status provided modules
+            if self.module_name in user_modules:
+                include_path, f_name = user_modules[self.module_name]
+                self._py3_wrapper.log(
+                    'loading module "{}" from {}{}'.format(module, include_path,
+                                                           f_name))
+                self.module_class = self.load_from_file(include_path + f_name)
+            # load from py3status provided modules
+            else:
+                self._py3_wrapper.log(
+                    'loading module "{}" from py3status.modules.{}'.format(
+                        module, self.module_name))
+                self.module_class = self.load_from_namespace(self.module_name)
 
+        class_inst = self.module_class
         if class_inst:
-            self.module_class = class_inst
+
             try:
                 # containers have items attribute set to a list of contained
                 # module instance names.  If there are no contained items then
@@ -823,7 +834,8 @@ class Module(Thread):
                 except Exception as e:
                     msg = 'Instance `{}`, user method `{}` failed'
                     msg = msg.format(self.module_full_name, meth)
-                    self._py3_wrapper.report_exception(msg, notify_user=False)
+                    if not self.testing:
+                        self._py3_wrapper.report_exception(msg, notify_user=False)
                     # added error
                     self.runtime_error(str(e) or e.__class__.__name__, meth)
                     cache_time = time() + getattr(self.module_class,

--- a/py3status/module_test.py
+++ b/py3status/module_test.py
@@ -1,63 +1,84 @@
-import inspect
-from time import sleep
-from py3status.py3 import Py3
+from threading import Event
+from time import sleep, time
+
+from py3status.core import Common, Module
+
+
+class MockPy3statusWrapper:
+
+    class EventThread:
+        def process_event(self, *arg, **kw):
+            pass
+
+    def __init__(self, config):
+        self.config = {
+            'py3_config': config,
+            'include_paths': [],
+            'debug': False,
+            'cache_timeout': 1,
+            'minimum_interval': 0.1,
+            'testing': True,
+            'log_file': True,
+        }
+        self.i3status_thread = None
+        self.lock = Event()
+        self.output_modules = {}
+        self.events_thread = self.EventThread()
+        self.lock.set()
+
+        # shared code
+        common = Common(self)
+        self.get_config_attribute = common.get_config_attribute
+        self.report_exception = common.report_exception
+
+    def notify_update(self, *arg, **kw):
+        pass
+
+    def notify_user(self, *arg, **kw):
+        pass
+
+    def log(self, *arg, **kw):
+        print(arg[0])
 
 
 def module_test(module_class, config=None):
-    i3s_config = {
-        'color_bad': '#FF0000',
-        'color_degraded': '#FFFF00',
-        'color_good': '#00FF00'
+
+    if not config:
+        config = {}
+
+    py3_config = {
+        'general': {
+            'color_bad': '#FF0000',
+            'color_degraded': '#FFFF00',
+            'color_good': '#00FF00',
+        },
+        'py3status': {},
+        '.module_groups': {},
+        'test_module': config
     }
+
+    mock = MockPy3statusWrapper(py3_config)
+
     module = module_class()
-    setattr(module, 'py3', Py3(i3s_config=i3s_config, py3status=module))
-    if config:
-        i3s_config.update(config)
-        for key, value in config.items():
-            setattr(module, key, value)
-    methods = []
+    m = Module('test_module', {}, mock, module)
+    m.sleeping = True
+    m.prepare_module()
 
-    for attribute_name in sorted(dir(module)):
-        # find methods that we should test.
-        attribute = getattr(module, attribute_name)
-
-        if 'method' not in repr(attribute):
-            continue
-        if attribute_name.startswith('_'):
-            continue
-        if attribute_name in ['on_click', 'kill', 'py3', 'post_config_hook']:
-            continue
-
-        # set calling parameter for method to allow legacy calling signature
-        args, vargs, kw, defaults = inspect.getargspec(attribute)
-        if len(args) == 1:
-            methods.append((attribute_name, []))
-        else:
-            methods.append((attribute_name, [[], i3s_config]))
-
-    # If we are a container then self.items must be set as a list
-    try:
-        if module.Meta.container:
-            module.items = []
-    except AttributeError:
-        pass
-
-    # run any post_config_hook
-    if hasattr(module, 'post_config_hook'):
-        module.post_config_hook()
-
-    while True:
+    while not m.error_messages:
         try:
-            for method, method_args in methods:
-                print(getattr(module, method)(*method_args))
+            for meth in m.methods:
+                m.methods[meth]['cached_until'] = time()
+            m.run()
+            output = m.get_latest()
+            for item in output:
+                if 'instance' in item:
+                    del item['instance']
+                if 'name' in item:
+                    del item['name']
+            if len(output) == 1:
+                output = output[0]
+            print(output)
             sleep(1)
         except KeyboardInterrupt:
-            break
-            if hasattr(module, 'kill'):
-                method = getattr(module, 'kill', None)
-                args, vargs, kw, defaults = inspect.getargspec(method)
-                if len(args) == 1:
-                    module.kill()
-                else:
-                    module.kill([], i3s_config)
+            m.kill()
             break

--- a/py3status/py3.py
+++ b/py3status/py3.py
@@ -95,36 +95,26 @@ class Py3:
     RequestTimeout = exceptions.RequestTimeout
     RequestURLError = exceptions.RequestURLError
 
-    def __init__(self, module=None, i3s_config=None, py3status=None):
+    def __init__(self, module=None):
         self._audio = None
         self._config_setting = {}
         self._format_placeholders = {}
         self._format_placeholders_cache = {}
-        self._i3s_config = i3s_config or {}
         self._module = module
         self._is_python_2 = sys.version_info < (3, 0)
         self._report_exception_cache = set()
         self._thresholds = None
 
-        if py3status:
-            self._py3status_module = py3status
-
-        # we are running through the whole stack.
-        # If testing then module is None.
         if module:
+            self._i3s_config = module._py3_wrapper.config['py3_config']['general']
+            self._module_full_name = module.module_full_name
             self._output_modules = module._py3_wrapper.output_modules
-            if not i3s_config:
-                i3s_config = self._module.config['py3_config']['general']
-                self._i3s_config = i3s_config
             self._py3status_module = module.module_class
-        # create formatter we only if need one but want to pass py3_wrapper so
-        # that we can do logging etc.
-        if not self._formatter:
-            if module:
-                py3_wrapper = module._py3_wrapper
-            else:
-                py3_wrapper = None
-            self.__class__._formatter = Formatter(py3_wrapper)
+            self._py3_wrapper = module._py3_wrapper
+            # create formatter we only if need one but want to pass py3_wrapper so
+            # that we can do logging etc.
+            if not self._formatter:
+                self.__class__._formatter = Formatter(module._py3_wrapper)
 
     def __getattr__(self, name):
         """
@@ -141,12 +131,9 @@ class Py3:
         try:
             return self._config_setting[name]
         except KeyError:
-            if self._module:
-                fn = self._module._py3_wrapper.get_config_attribute
-                param = fn(self._module.module_full_name, name)
-            else:
-                # running in test mode so config is not available
-                param = self._i3s_config.get(name, None)
+            fn = self._py3_wrapper.get_config_attribute
+            param = fn(self._module_full_name, name)
+
             # colors are special we want to make sure that we treat a color
             # that was explicitly set to None as a True value.  Ones that are
             # not set should be treated as None
@@ -202,8 +189,7 @@ class Py3:
         'position': list of places in i3bar, usually only one item
         'type': module type py3status/i3status
         """
-        if self._module:
-            return self._output_modules.get(module_name)
+        return self._output_modules.get(module_name)
 
     def _report_exception(self, msg, frame_skip=2):
         """
@@ -222,19 +208,18 @@ class Py3:
             return
         self._report_exception_cache.add(msg_hash)
 
-        if self._module:
-            # If we just report the error the traceback will end in the try
-            # except block that we are calling from.
-            # We want to show the traceback originating from the module that
-            # called the Py3 method so get the correct error frame and pass this
-            # along.
-            error_frame = sys._getframe(0)
-            while frame_skip:
-                error_frame = error_frame.f_back
-                frame_skip -= 1
-            self._module._py3_wrapper.report_exception(
-                msg, notify_user=False, error_frame=error_frame
-            )
+        # If we just report the error the traceback will end in the try
+        # except block that we are calling from.
+        # We want to show the traceback originating from the module that
+        # called the Py3 method so get the correct error frame and pass this
+        # along.
+        error_frame = sys._getframe(0)
+        while frame_skip:
+            error_frame = error_frame.f_back
+            frame_skip -= 1
+        self._py3_wrapper.report_exception(
+            msg, notify_user=False, error_frame=error_frame
+        )
 
     def error(self, msg, timeout=None):
         """
@@ -438,8 +423,6 @@ class Py3:
         Returns True if the event name and instance match that of the module
         checking.
         """
-        if not self._module:
-            return False
 
         return (
             event.get('name') == self._module.module_name and
@@ -455,22 +438,21 @@ class Py3:
             self.LOG_ERROR, self.LOG_INFO, self.LOG_WARNING
         ], 'level must be LOG_ERROR, LOG_INFO or LOG_WARNING'
 
-        if self._module:
-            # nicely format logs if we can using pretty print
-            message = pformat(message)
-            # start on new line if multi-line output
-            if '\n' in message:
-                message = '\n' + message
-            message = 'Module `{}`: {}'.format(
-                self._module.module_full_name, message)
-            self._module._py3_wrapper.log(message, level)
+        # nicely format logs if we can using pretty print
+        message = pformat(message)
+        # start on new line if multi-line output
+        if '\n' in message:
+            message = '\n' + message
+        message = 'Module `{}`: {}'.format(
+            self._module.module_full_name, message)
+        self._py3_wrapper.log(message, level)
 
     def update(self, module_name=None):
         """
         Update a module.  If module_name is supplied the module of that
         name is updated.  Otherwise the module calling is updated.
         """
-        if not module_name and self._module:
+        if not module_name:
             return self._module.force_update()
         else:
             module_info = self._get_module_info(module_name)
@@ -491,8 +473,8 @@ class Py3:
         """
         Trigger an event on a named module.
         """
-        if module_name and self._module:
-            self._module._py3_wrapper.events_thread.process_event(
+        if module_name:
+            self._py3_wrapper.events_thread.process_event(
                 module_name, event)
 
     def prevent_refresh(self):
@@ -501,8 +483,7 @@ class Py3:
         request that the module is not refreshed after the event. By default
         the module is updated after the on_click event has been processed.
         """
-        if self._module:
-            self._module.prevent_refresh = True
+        self._module.prevent_refresh = True
 
     def notify_user(self, msg, level='info', rate_limit=5):
         """
@@ -511,13 +492,12 @@ class Py3:
         rate_limit is the time period in seconds during which this message
         should not be repeated.
         """
-        if self._module:
-            # force unicode for python2 str
-            if self._is_python_2 and isinstance(msg, str):
-                msg = msg.decode('utf-8')
-            module_name = self._module.module_full_name
-            self._module._py3_wrapper.notify_user(
-                msg, level=level, rate_limit=rate_limit, module_name=module_name)
+        # force unicode for python2 str
+        if self._is_python_2 and isinstance(msg, str):
+            msg = msg.decode('utf-8')
+        module_name = self._module.module_full_name
+        self._py3_wrapper.notify_user(
+            msg, level=level, rate_limit=rate_limit, module_name=module_name)
 
     def register_function(self, function_name, function):
         """
@@ -551,9 +531,8 @@ class Py3:
 
                 This function should only be used by containers.
         """
-        if self._module:
-            my_info = self._get_module_info(self._module.module_full_name)
-            my_info[function_name] = function
+        my_info = self._get_module_info(self._module.module_full_name)
+        my_info[function_name] = function
 
     def time_in(self, seconds=None, sync_to=None, offset=0):
         """


### PR DESCRIPTION
#806 called attention to problems with `module_test` not using the same code paths as when `py3status` is running. This is due to changes regarding getting config settings and the formatter updates. This causes issues

master (color missing and Composite causing confusion)
```
$ python modules/dpms.py
{'color': None, 'full_text': <Composite [{'full_text': u'DPMS'}]>, 'cached_until': 1500839733.0}
```

this branch (output as we send to i3bar - excluding cached_until which is added for user debugging)
```
$ python modules/dpms.py
{'color': '#00FF00', 'full_text': u'DPMS', 'cached_until': 1500839670.0}
```

Although it looks large there are few changes to how the code works.

__core.py__

We create a new class `Common` which holds common code `report_exception()` and `get_config_attribute()` so that the code can be accessed without `Py3statusWrapper`

Long term I'd like to improve on this so we have better separation between different parts of `Py3status Wrapper` eg cli parsing, running modules etc so we can use it for both running a single module and running all in the config.

__module.py__

This now can either take a module name (as currently) or an actual instance (testing).

A few extra bits to add `cached_until` into test output and to handle errors correctly for testing eg show full traceback on errors and to stop testing when this happens.

__py3.py__

Since we now have module for all uses we can clean up some of this code and make it more universal.

__module_test.py__

Rewrite to use new ability to run module correctly rather than mirroring finding methods etc.

__Longer term__

I'd like to replace the `MockPy3statusWrapper` with a common `Py3StatusWrapper` that supports both testing and running as normal and also allow us to do `py3status --test <module_name/path>` or similar