### PR TITLE
window_title_async: fix workspace glitch

### DIFF
--- a/py3status/modules/window_title_async.py
+++ b/py3status/modules/window_title_async.py
@@ -90,8 +90,12 @@ class Py3status:
                 self.title = get_title(conn)
                 self.py3.update()
 
-        def clear_title(*args):
-            self.title = self.empty_title
+        def clear_title(conn, e):
+            f = conn.get_tree().find_focused()
+            if f.window_class:
+                self.title = f.name
+            else:
+                self.title = self.empty_title
             self.py3.update()
 
         conn = i3ipc.Connection()


### PR DESCRIPTION
Hi. This module could use a bit of rewritten... to get rid of `max_width` in favor of the formatter and maybe some other minor things to clear up the confusion. For now, we closes https://github.com/ultrabug/py3status/issues/747