### PR TITLE
Better module doctest failures

### DIFF
--- a/tests/test_module_doc.py
+++ b/tests/test_module_doc.py
@@ -219,7 +219,7 @@ def get_module_attributes(path):
     return attributes
 
 
-def _gen_diff(source, target):
+def _gen_diff(source, target, source_label='Source', target_label='Target'):
     # Create a unique object for determining if the list is missing an entry
     blank = object()
 
@@ -230,12 +230,22 @@ def _gen_diff(source, target):
 
     # Determine the length of the longest item in the list
     max_elem_len = max([len(str(elem)) for elem in source])
-    format_str = '    %%%ds %%s %%s' % max_elem_len
+    padding = '    '
+    format_str = padding + ('%%%ds %%s %%s' % max_elem_len)
 
-    out = []
+    # Set up initial output contents
+    middle_orig = '  '
+    out = [
+        format_str % (source_label, middle_orig, target_label),
+
+        # Length of dashes is enough for the longest element on both sides,
+        # plus the size of the middle symbol(s), plus two spaces for separation
+        padding + ('-' * (2 * max_elem_len + len(middle_orig) + 2))
+    ]
+
     for (have, want) in zip(source, target):
         # Determine the mark
-        middle = '  '
+        middle = middle_orig
 
         # The current version is missing this line
         if have == blank:

--- a/tests/test_module_doc.py
+++ b/tests/test_module_doc.py
@@ -220,17 +220,39 @@ def get_module_attributes(path):
 
 
 def _gen_diff(source, target):
+    # Create a unique object for determining if the list is missing an entry
+    blank = object()
+
+    # Make both lists the same length
     max_len = max(len(source), len(target))
     for lst in (source, target):
-        lst.extend(['' for i in range(max_len - len(lst))])
+        lst.extend([blank for i in range(max_len - len(lst))])
 
-    max_elem_len = max([len(elem) for elem in source])
+    # Determine the length of the longest item in the list
+    max_elem_len = max([len(str(elem)) for elem in source])
     format_str = '    %%%ds %%s %%s' % max_elem_len
 
     out = []
     for (have, want) in zip(source, target):
-        middle = '!!' if (have != want) else '  '
-        out.append(format_str % (have, middle, want))
+        # Determine the mark
+        middle = '  '
+
+        # The current version is missing this line
+        if have == blank:
+            middle = '<<'
+            have = ''
+
+        # The target version is missing this line
+        elif want == blank:
+            middle = '>>'
+            want = ''
+
+        # Both lines exist, but are different
+        elif have != want:
+            middle = '!!'
+
+        # Place the diff into the output
+        out.append(format_str % (str(have), middle, str(want)))
 
     return '\n'.join(out) + '\n'
 


### PR DESCRIPTION
Hey all!

While working on #930, I ran into the linter pretty consistently. The most annoying issue to deal with was alphabetical ordering for parameters, as the error message in the linter would not indicate clearly which items were out of place. This becomes a bigger issue the more options you have!

I decided to take a crack at improving it! Below are my changes. I added a simple `diff` method to signal differences between two lists of items. This improves the linter output significantly:

_Module source_:
```python
...
    cache_timeout = 10
    fallback = True
    force_on_start = None
    fixed_width = True
    format = '{output}'
    icon_clone = '=' 
    icon_extend = '+' 
    hide_if_single_combination = False
    output_combinations = None
...
```

_Before_:
```
Attributes not in alphabetical order, should be
['cache_timeout', 'fallback', 'fixed_width', 'force_on_start', 'format', 'hide_if_single_combination', 'icon_clone', 'icon_extend', 'output_combinations']
```

_After_:
```
Attributes not in alphabetical order, should be
                        Source    Target
    --------------------------------------------------------
                 cache_timeout    cache_timeout
                      fallback    fallback
                force_on_start !! fixed_width
                   fixed_width !! force_on_start
                        format    format
                    icon_clone !! hide_if_single_combination
                   icon_extend !! icon_clone
    hide_if_single_combination !! icon_extend
           output_combinations    output_combinations
```

Something which is not shown is that the diff engine can handle different length lists, where two 'arrows' (either `>>` or `<<`) go from the side which has the line to the side which does not.

As long as the lists have items which can be compared for equality and have a string representation, the simple diff method can be used.

Let me know what you think!