### PR TITLE
reverse lock so we can wait for it

### DIFF
--- a/py3status/core.py
+++ b/py3status/core.py
@@ -384,8 +384,6 @@ class Py3statusWrapper():
         """
         Setup py3status and spawn i3status/events/modules threads.
         """
-        # set the Event lock
-        self.lock.set()
 
         # SIGTSTP will be received from i3bar indicating that all output should
         # stop and we should consider py3status suspended.  It is however
@@ -469,6 +467,7 @@ class Py3statusWrapper():
 
         # setup input events thread
         self.events_thread = Events(self)
+        self.events_thread.daemon = True
         self.events_thread.start()
         if self.config['debug']:
             self.log('events thread started')
@@ -557,7 +556,7 @@ class Py3statusWrapper():
 
     def stop(self):
         """
-        Clear the Event lock, this will break all threads' loops.
+        Set the Event lock, this will break all threads' loops.
         """
         # stop the command server
         try:
@@ -566,9 +565,9 @@ class Py3statusWrapper():
             pass
 
         try:
-            self.lock.clear()
+            self.lock.set()
             if self.config['debug']:
-                self.log('lock cleared, exiting')
+                self.log('lock set, exiting')
             # run kill() method on all py3status modules
             for module in self.modules.values():
                 module.kill()

--- a/py3status/events.py
+++ b/py3status/events.py
@@ -236,7 +236,7 @@ class Events(Thread):
         Example event:
         {'y': 13, 'x': 1737, 'button': 1, 'name': 'empty', 'instance': 'first'}
         """
-        while self.lock.is_set():
+        while not self.lock.is_set():
             event_str = self.poller_inp.readline()
             if not event_str:
                 continue

--- a/py3status/i3status.py
+++ b/py3status/i3status.py
@@ -8,7 +8,7 @@ from subprocess import PIPE
 from signal import SIGTSTP, SIGSTOP, SIGUSR1, SIG_IGN, signal
 from tempfile import NamedTemporaryFile
 from threading import Thread
-from time import time, sleep
+from time import time
 
 from py3status.profiling import profile
 from py3status.events import IOPoller
@@ -175,24 +175,24 @@ class I3status(Thread):
         Our output will be read asynchronously from 'last_output'.
         """
         Thread.__init__(self)
-        self.py3_config = py3_wrapper.config['py3_config']
         self.error = None
+        self.i3modules = {}
         self.i3status_module_names = [
             'battery', 'cpu_temperature', 'cpu_usage', 'ddate', 'disk',
             'ethernet', 'ipv6', 'load', 'path_exists', 'run_watch', 'time',
             'tztime', 'volume', 'wireless'
         ]
-        self.i3modules = {}
+        self.i3status_pipe = None
         self.json_list = None
         self.json_list_ts = None
         self.last_output = None
         self.last_refresh_ts = time()
         self.lock = py3_wrapper.lock
         self.new_update = False
+        self.py3_config = py3_wrapper.config['py3_config']
         self.py3_wrapper = py3_wrapper
         self.ready = False
         self.standalone = py3_wrapper.config['standalone']
-        self.i3status_pipe = None
         self.time_modules = []
         self.tmpfile_path = None
 
@@ -313,14 +313,14 @@ class I3status(Thread):
         # if the i3status process dies we want to restart it.
         # We give up restarting if we have died too often
         for x in range(10):
-            if not self.lock.is_set():
+            if self.lock.is_set():
                 break
             self.spawn_i3status()
             # check if we never worked properly and if so quit now
             if not self.ready:
                 break
             # limit restart rate
-            sleep(5)
+            self.lock.wait(5)
 
     def spawn_i3status(self):
         """
@@ -351,7 +351,7 @@ class I3status(Thread):
 
                 try:
                     # loop on i3status output
-                    while self.lock.is_set():
+                    while not self.lock.is_set():
                         line = self.poller_inp.readline()
                         if line:
                             # remove leading comma if present

--- a/py3status/module.py
+++ b/py3status/module.py
@@ -723,14 +723,14 @@ class Module(Thread):
         if self.timer:
             self.timer.cancel()
 
-        if self.lock.is_set():
+        if not self.lock.is_set():
             cache_time = None
             # execute each method of this module
             for meth, obj in self.methods.items():
                 my_method = self.methods[meth]
 
                 # always check the lock
-                if not self.lock.is_set():
+                if self.lock.is_set():
                     break
 
                 # respect the cache set for this method


### PR DESCRIPTION
Currently killing py3status is slow.  This is mainly due to the i3status thread that can wait up to 5 seconds to die.

by 'reversing' the lock we can wait() on it and die much quicker

making the event thread a daemon also cuts off approx 500ms

minor cleanup of `I3status.__init__()` to bribe you (I can put as separate PR) plus we lose a line of code :D

```
time timeout 5 py3status > /dev/null

# this branch
real	0m5.073s
user	0m0.349s
sys	0m0.064s

# master
real	0m10.073s
user	0m0.341s
sys	0m0.065s
```