### PR TITLE
use wait() instead of sleep() in main loop

### DIFF
--- a/py3status/core.py
+++ b/py3status/core.py
@@ -163,7 +163,7 @@ class Common:
             self.py3_wrapper.notify_user(msg, level=level)
 
 
-class Py3statusWrapper():
+class Py3statusWrapper:
     """
     This is the py3status wrapper.
     """
@@ -182,6 +182,7 @@ class Py3statusWrapper():
         self.py3_modules = []
         self.py3_modules_initialized = False
         self.queue = deque()
+        self.update_request = Event()
 
     def get_config(self):
         """
@@ -673,6 +674,10 @@ class Py3statusWrapper():
                     # we don't know so just update.
                     container_module['module'].force_update()
 
+        # we need to update the output
+        if self.queue:
+            self.update_request.set()
+
     def log(self, msg, level='info'):
         """
         log this information to syslog or user provided logfile.
@@ -839,12 +844,12 @@ class Py3statusWrapper():
         print_line(dumps(header))
         print_line('[[]')
 
+        update_due = None
         # main loop
         while True:
-            # sleep a bit to avoid killing the CPU
-            # by doing this at the begining rather than the end
-            # of the loop we ensure a smoother first render of the i3bar
-            time.sleep(0.1)
+            # wait untill an update is requested
+            self.update_request.wait(timeout=update_due)
+            update_due = None
 
             while not self.i3bar_running:
                 time.sleep(0.1)
@@ -872,7 +877,7 @@ class Py3statusWrapper():
 
                 # update i3status time/tztime items
                 if interval == 0 or sec % interval == 0:
-                    i3status_thread.update_times()
+                    update_due = i3status_thread.update_times()
 
             # check if an update is needed
             if self.queue:
@@ -888,6 +893,12 @@ class Py3statusWrapper():
                 out = ','.join([x for x in output if x])
                 # dump the line to stdout
                 print_line(',[{}]'.format(out))
+
+            # we've done our work here so we can clear the request
+            self.update_request.clear()
+            # just in case check if we have an update and request if needed
+            if self.queue:
+                self.update_request.set()
 
     def handle_cli_command(self, config):
         """Handle a command from the CLI.

--- a/py3status/i3status.py
+++ b/py3status/i3status.py
@@ -195,19 +195,29 @@ class I3status(Thread):
         self.i3status_pipe = None
         self.time_modules = []
         self.tmpfile_path = None
+        self.update_due = 0
 
     def update_times(self):
         """
         Update time for any i3status time/tztime items.
+        Returns the time till next update needed.
         """
-        updated = []
-        for module in self.i3modules.values():
-            if module.is_time_module:
-                if module.update_time_value():
-                    updated.append(module.module_name)
-        if updated:
-            # trigger the update so new time is shown
-            self.py3_wrapper.notify_update(updated)
+        now = time()
+        if now > self.update_due:
+            updated = []
+            for module in self.i3modules.values():
+                if module.is_time_module:
+                    if module.update_time_value():
+                        updated.append(module.module_name)
+            if updated:
+                # trigger the update so new time is shown
+                self.py3_wrapper.notify_update(updated)
+                # time we next need to do an update
+            self.update_due = int(now) + 1
+
+        # return time till next update wanted
+        # currently once a second
+        return 1 - (now % 1)
 
     def valid_config_param(self, param_name, cleanup=False):
         """
@@ -238,7 +248,8 @@ class I3status(Thread):
                                                            self.py3_wrapper)
             if self.i3modules[conf_name].update_from_item(item):
                 updates.append(conf_name)
-        self.py3_wrapper.notify_update(updates)
+        if updates:
+            self.py3_wrapper.notify_update(updates)
 
     def update_json_list(self):
         """


### PR DESCRIPTION
use `wait()` with a timeout rather than `sleep()`

this reduce the amount of overhead and also makes us more responsive as we do the updates exactly when they are needed.

i3status is special so it needs to tell us when it wants to update the times which we still do in the main loop.

i3status stuff can be much improved but we get a nice benefit here and keep the PR easy to review.  later we can do that cleanup.

the test is rather crude we just run py3status for 10 mins but it shows we save cycles

```
time timeout 600 py3status > /dev/null

# branch
real	10m5.061s
user	0m0.800s
sys	0m0.125s

# master
real	10m5.056s
user	0m1.151s
sys	0m0.232s
```