### PR TITLE
clock module fix unicode time formatting

### DIFF
--- a/py3status/modules/clock.py
+++ b/py3status/modules/clock.py
@@ -172,6 +172,26 @@ class Py3status:
         self._cycle_time = time() + self.cycle
         self.active = 0
 
+        # set our _fmt_strftime function depending on python version
+        if self.py3.is_python_2():
+            self._fmt_strftime = self._fmt_strftime_py2
+        else:
+            self._fmt_strftime = self._fmt_strftime_py3
+
+    @staticmethod
+    def _fmt_strftime_py2(fmt, t):
+        """
+        strftime for python 2
+        """
+        return t.strftime(fmt.encode('utf-8'))
+
+    @staticmethod
+    def _fmt_strftime_py3(fmt, t):
+        """
+        strftime for python 3
+        """
+        return t.strftime(fmt)
+
     def _get_timezone(self, tz):
         """
         Find and return the time zone if possible
@@ -264,14 +284,12 @@ class Py3status:
                         timezone=timezone,
                         timezone_unclear=timezone_unclear,
                     ))
+
                 if self.py3.is_composite(format_time):
                     for item in format_time:
-                        item['full_text'] = t.strftime(item['full_text'])
+                        item['full_text'] = self._fmt_strftime(item['full_text'], t)
                 else:
-                    if self.py3.is_python_2():
-                        format_time = t.strftime(format_time.encode('utf-8'))
-                    else:
-                        format_time = t.strftime(format_time)
+                    format_time = self._fmt_strftime(format_time, t)
                 times[name] = format_time
 
         # work out when we need to update


### PR DESCRIPTION
#988 found an error in the clock module strftime formatting.  This PR fixes the issue by ensuring we have none unicode strings in python2.

The fix is big due to restructuring the code.  It might be worth moving the code into Py3 at some point if other modules need this functionality.