### PR TITLE
static_string: hello, world!

### DIFF
--- a/py3status/modules/static_string.py
+++ b/py3status/modules/static_string.py
@@ -3,12 +3,12 @@
 Display static text.
 
 Configuration parameters:
-    format: text that should be printed (default '')
+    format: display format for this module (default 'Hello, world!')
 
 @author frimdo ztracenastopa@centrum.cz
 
 SAMPLE OUTPUT
-{'full_text': 'Hello world!'}
+{'full_text': 'Hello, world!'}
 """
 
 
@@ -16,22 +16,18 @@ class Py3status:
     """
     """
     # available configuration parameters
-    format = ''
+    format = 'Hello, world!'
 
     def static_string(self):
-        response = {
+        return {
             'cached_until': self.py3.CACHE_FOREVER,
             'full_text': self.py3.safe_format(self.format),
         }
-        return response
 
 
 if __name__ == "__main__":
     """
     Run module in test mode.
     """
-    config = {
-        'format': 'Hello World!'
-    }
     from py3status.module_test import module_test
-    module_test(Py3status, config=config)
+    module_test(Py3status)


### PR DESCRIPTION
* For terminals, we can put `hello, world!` in the `format` instead of using `test` config.
* This module can be used to test something... or to have a work-in-progress module being sandwiched by two of this modules... to make sure we added the module correctly and that it's printing things correctly.... and checking padding issues... and et cetera...

* When one sometimes want to try something using `static_string` and run it from terminal, one would get `test` config every time instead of the expected result. This simply removes a minor annoyance.

* If that's not a good enough, well... We, and the users, could just add `static_string {}` and see the result right away... without having to put something in the `format`.
* If that's still not good enough... Man, you're tough... I don't know... What about fewer lines? 👍 