### PR TITLE
cmus, moc: quality assurance

### DIFF
--- a/py3status/modules/cmus.py
+++ b/py3status/modules/cmus.py
@@ -17,44 +17,43 @@ Configuration parameters:
         *(default '[\?if=is_started [\?if=is_playing > ][\?if=is_paused \|\| ]
         [\?if=is_stopped .. ][[{artist}][\?soft  - ][{title}]
         |\?show cmus: waiting for user input]]')*
-    sleep_timeout: sleep interval for this module will be used when cmus is not
-        running. this allows aggressive timing in cache_timeout where one might
-        want to refresh cmus every 0 second along with time placeholders...
-        or to make cmus run once every minute as long as it's not being used.
-        (default 20)
+    sleep_timeout: sleep interval for this module. when cmus is not running,
+        this interval will be used. this allows some flexible timing where one
+        might want to refresh constantly with some placeholders... or to refresh
+        only once every minute rather than every few seconds. (default 20)
 
 Control placeholders:
-    is_paused: a boolean based on cmus status
-    is_playing: a boolean based on cmus status
-    is_started: a boolean based on cmus status
-    is_stopped: a boolean based on cmus status
-    continue: a boolean based on data status
-    play_library: a boolean based on data status
-    play_sorted: a boolean based on data status
-    repeat: a boolean based on data status
-    repeat_current: a boolean based on data status
-    replaygain: a boolean based on data status
-    replaygain_limit: a boolean based on data status
-    shuffle: a boolean based on data status
-    softvol: a boolean based on data status
-    stream: a boolean based on data status
+    {is_paused} a boolean based on cmus status
+    {is_playing} a boolean based on cmus status
+    {is_started} a boolean based on cmus status
+    {is_stopped} a boolean based on cmus status
+    {continue} a boolean based on data status
+    {play_library} a boolean based on data status
+    {play_sorted} a boolean based on data status
+    {repeat} a boolean based on data status
+    {repeat_current} a boolean based on data status
+    {replaygain} a boolean based on data status
+    {replaygain_limit} a boolean based on data status
+    {shuffle} a boolean based on data status
+    {softvol} a boolean based on data status
+    {stream} a boolean based on data status
 
 Format placeholders:
-    {durationtime} length time in [HH:]MM:SS, eg 02:51
-    {positiontime} elapsed time in [HH:]MM:SS, eg 00:17
-    {aaa_mode} shuffle songs between artist, album, or all. eg album
-    {albumartist} album artist
-    {album} album name
-    {artist} artist name
+    {aaa_mode} shuffle mode, eg artist, album, all
+    {albumartist} album artist, eg (new output here)
+    {album} album name, eg (new output here)
+    {artist} artist name, eg (new output here)
     {bitrate} audio bitrate, eg 229
     {comment} comment, eg URL
     {date} year number, eg 2015
     {duration} length time in seconds, eg 171
+    {durationtime} length time in [HH:]MM:SS, eg 02:51
     {file} file location, eg /home/user/Music...
     {position} elapsed time in seconds, eg 17
+    {positiontime} elapsed time in [HH:]MM:SS, eg 00:17
     {replaygain_preamp} replay gain preamp, eg 0.000000
-    {status} playback status, eg playing, paused, or stopped
-    {title} track title
+    {status} playback status, eg playing, paused, stopped
+    {title} track title, eg (new output here)
     {tracknumber} track number, eg 0
     {vol_left} left volume number, eg 90
     {vol_right} right volume number, eg 90

--- a/py3status/modules/moc.py
+++ b/py3status/modules/moc.py
@@ -15,33 +15,30 @@ Configuration parameters:
     format: display format for this module
         (default '\?if=is_started [\?if=is_stopped \[\] moc|
         [\?if=is_paused \|\|][\?if=is_playing >] {title}]')
-    sleep_timeout: sleep interval for this module will be used when moc is not
-        running. this allows aggressive timing in cache_timeout where one might
-        want to refresh moc every 0 second along with time placeholders...
-        or to make moc run once every minute as long as it's not being used.
-        (default 20)
+    sleep_timeout: sleep interval for this module. when moc is not running,
+        this interval will be used. this allows some flexible timing where one
+        might want to refresh constantly with some placeholders... or to refresh
+        only once every minute rather than every few seconds. (default 20)
 
 Control placeholders:
-    is_paused: a boolean based on moc status
-    is_playing: a boolean based on moc status
-    is_started: a boolean based on moc status
-    is_stopped: a boolean based on moc status
+    {is_paused} a boolean based on moc status
+    {is_playing} a boolean based on moc status
+    {is_started} a boolean based on moc status
+    {is_stopped} a boolean based on moc status
 
 Format placeholders:
-    {totaltime} total time in seconds, eg 72:02
-    {currenttime} elapsed time in [HH:]MM:SS, eg 00:32
-    {album} album name
-    {artist} artist name
+    {album} album name, eg (new output here)
+    {artist} artist name, eg (new output here)
     {avgbitrate} audio average bitrate, eg 230kbps
     {bitrate} audio bitrate, eg 230kbps
     {currentsec} elapsed time in seconds, eg 32
     {currenttime} elapsed time in [HH:]MM:SS, eg 00:32
     {file} file location, eg /home/user/Music...
     {rate} audio rate, eg 44kHz
-    {songtitle} song title
-    {state} playback state, eg PLAY, PAUSE, or STOP
+    {songtitle} song title, eg (new output here)
+    {state} playback state, eg PLAY, PAUSE, STOP
     {timeleft} time left in [HH:]MM:SS, eg 71:30
-    {title} track title (contains artist + songtitle)
+    {title} track title, eg (new output here)
     {totalsec} total time in seconds, eg 4322
     {totaltime} total time in seconds, eg 72:02
 


### PR DESCRIPTION
I had this branch ready already. I removed `moc` duplicate placeholders
```
{totalsec} total time in seconds, eg 4322
{totaltime} total time in seconds, eg 72:02
```
The rest is just fixing up formatting and phrasing things better (imho).