### PR TITLE
i3blocks: fix parameters so all documented

### DIFF
--- a/py3status/modules/i3block.py
+++ b/py3status/modules/i3block.py
@@ -100,6 +100,7 @@ RESPONSE_FIELDS = [
 
 class Py3status:
 
+    cache_timeout = None
     command = None
     format = '{output}'
     instance = ''
@@ -108,7 +109,7 @@ class Py3status:
 
     def post_config_hook(self):
         # set interval.  If cache_timeout is used it takes precedence
-        if hasattr(self, 'cache_timeout'):
+        if self.cache_timeout:
             self.interval = self.cache_timeout
         self.interval = getattr(self, 'interval', None)
         # implement i3block interval rules


### PR DESCRIPTION
By adding `cache_timeout` to the parameters, helps with cleaner testing and helps generally for documentation purposes.