### PR TITLE
kdeconnector: clean up _dev

### DIFF
--- a/py3status/modules/kdeconnector.py
+++ b/py3status/modules/kdeconnector.py
@@ -99,7 +99,8 @@ class Py3status:
     status_no_notif = ''
     status_notif = u' ✉'
 
-    _dev = None
+    def post_config_hook(self):
+        self._dev = None
 
     def _init_dbus(self):
         """


### PR DESCRIPTION
Define `self._dev` in `post_config_hook()` rather than in the class body