### PR TITLE
xrandr: clean docstring

### DIFF
--- a/py3status/docstrings.py
+++ b/py3status/docstrings.py
@@ -124,7 +124,7 @@ re_to_tag = re.compile('&lt;([^.]*)&gt;')
 re_to_defaults = re.compile('\*(\(default.*\))\*')
 
 # match in module docstring
-re_from_param = re.compile('^    ([a-z]\S+):($|[ \t])(.*)$')
+re_from_param = re.compile('^    ([a-z<]\S+):($|[ \t])(.*)$')
 re_from_status = re.compile('^\s+({\S+})($|[ \t])(.*)$')
 re_from_item = re.compile('^\s+-(?=\s)')
 re_from_data = re.compile('^@(author|license|source)($|[ \t])')

--- a/py3status/modules/xrandr.py
+++ b/py3status/modules/xrandr.py
@@ -42,25 +42,28 @@ Configuration parameters:
         The combinations will be rotated in the exact order as you listed them.
         When an output layout is not available any more, the configurations
         are automatically filtered out.
-        Example:
-        Assuming the default values for `icon_clone` and `icon_extend`
-        are used, and assuming you have two screens 'eDP1' and 'DP1', the
-        following setup will reduce the number of output combinations
-        from four (every possible one) down to two:
-        output_combinations = "eDP1|eDP1+DP1"
         (default None)
 
+        Example:
+            Assuming the default values for `icon_clone` and `icon_extend`
+            are used, and assuming you have two screens 'eDP1' and 'DP1', the
+            following setup will reduce the number of output combinations
+            from four (every possible one) down to two.
+            ```
+            output_combinations = "eDP1|eDP1+DP1"
+            ```
+
 Dynamic configuration parameters:
-    - <OUTPUT>_pos: apply the given position to the OUTPUT
+    <OUTPUT>_pos: apply the given position to the OUTPUT
         Example: DP1_pos = "-2560x0"
         Example: DP1_pos = "above eDP1"
         Example: DP1_pos = "below eDP1"
         Example: DP1_pos = "left-of LVDS1"
         Example: DP1_pos = "right-of eDP1"
-    - <OUTPUT>_workspaces: comma separated list of workspaces to move to
+    <OUTPUT>_workspaces: comma separated list of workspaces to move to
         the given OUTPUT when it is activated
         Example: DP1_workspaces = "1,2,3"
-    - <OUTPUT>_rotate: rotate the output as told
+    <OUTPUT>_rotate: rotate the output as told
         Example: DP1_rotate = "left"
 
 Color options:


### PR DESCRIPTION
Update xrandr docstring.

To both improve the display and for upcoming documentation work.  Fixes glitches in readthdocs output

To enable `<OUTPUT>_workspaces` etc to be recognized the re used for documentation creation now allows parameter names starting with `<`