### PR TITLE
Added options for format_one and format_none

### DIFF
--- a/py3status/modules/apt_updates.py
+++ b/py3status/modules/apt_updates.py
@@ -9,7 +9,13 @@ This will display a count of how many 'apt' updates are waiting to be installed.
 Configuration parameters:
     cache_timeout: How often we refresh this module in seconds (default 600)
     format: Display format to use
-        (default 'UPD[\?not_zero : {apt}]')
+        (default 'UPD: {apt}')
+    format_one: Display format to use if one update is available. If left empty,
+    default format will be used.
+        (default '')
+    format_none: Display format to use if no updates are available.
+        (default '')
+
 
 Format placeholders:
     {apt} Number of pending apt updates
@@ -34,19 +40,24 @@ class Py3status:
     # available configuration parameters
     cache_timeout = 600
     format = 'UPD[\?not_zero : {apt}]'
+    format_one = ''
+    format_none = ''
 
     def check_updates(self):
         apt_updates = self._check_apt_updates()
 
-        color = self.py3.COLOR_DEGRADED
         if apt_updates == 0:
             color = self.py3.COLOR_GOOD
-        full_text = self.py3.safe_format(
-            self.format,
-            {
-                'apt': apt_updates
-            }
-        )
+            full_text = self.py3.safe_format(
+                self.format_none, {'apt': apt_updates})
+        elif apt_updates == 1 and self.format_one:
+            color = self.py3.COLOR_DEGRADED
+            full_text = self.py3.safe_format(
+                self.format_one, {'apt': apt_updates})
+        else:
+            color = self.py3.COLOR_DEGRADED
+            full_text = self.py3.safe_format(
+                self.format, {'apt': apt_updates})
         return {
             'color': color,
             'cached_until': self.py3.time_in(self.cache_timeout),

--- a/py3status/modules/apt_updates.py
+++ b/py3status/modules/apt_updates.py
@@ -39,7 +39,7 @@ LINE_SEPARATOR = "\\n" if sys.version_info > (3, 0) else "\n"
 class Py3status:
     # available configuration parameters
     cache_timeout = 600
-    format = 'UPD[\?not_zero : {apt}]'
+    format = 'UPD: {apt}'
     format_one = ''
     format_none = ''
 


### PR DESCRIPTION
Added some more formatting, should not change results for any existing users. Removed the not_zero conditional in the default as it is now redundant.

Personally I have this in my config:
```
apt_updates{                                                                                                       
         format= "{apt} updates available"                                                                          
         format_one= "update available"                                                                             
         format_none= "system up to date"                                                                           
 }           
```
