### PR TITLE
tests: cleaner more helpful output on test failure

### DIFF
--- a/tests/test_formatter.py
+++ b/tests/test_formatter.py
@@ -8,6 +8,8 @@ import sys
 
 from pprint import pformat
 
+import pytest
+
 from py3status.composite import Composite
 from py3status.formatter import Formatter
 from py3status.py3 import NoneColor
@@ -77,6 +79,8 @@ def attr_getter_fn(attr):
 
 
 def run_formatter(test_dict):
+    __tracebackhide__ = True
+
     if test_dict.get('py3only') and python2:
         return
     if not test_dict.get('pypy', True) and is_pypy:
@@ -92,6 +96,7 @@ def run_formatter(test_dict):
     except Exception as e:
         if test_dict.get('exception') == str(e):
             return
+        print('Format\n{}\n'.format(test_dict['format']))
         raise e
 
     # simplify the composite and convert to text if possible
@@ -108,9 +113,11 @@ def run_formatter(test_dict):
     if python2 and isinstance(expected, str):
         expected = expected.decode('utf-8')
     if result != expected:
+        print('Format\n{}\n'.format(test_dict['format']))
         print('Expected\n{}'.format(pformat(expected)))
         print('Got\n{}'.format(pformat(result)))
-    assert (result == expected)
+    if result != expected:
+        pytest.fail('Results not as expected')
 
 
 def test_1():


### PR DESCRIPTION
Currently when a formatter test fails we get a backtrace of the testing functionality which is both noisy and unhelpful.  If an actual exception occurs during a test then we do see that traceback as it is important for fixing the issue.

This PR uses pytest functionality to make fails cleaner, we also print out the failing format to make the error easier to understand.

example

failing test in current master

```
_________________________________ test_inherit_show_1 __________________________________

    def test_inherit_show_1():
        run_formatter({
            'format': '\?show [[[hello]]]',
>           'expected': 'hello x'
        })

tests/test_formatter.py:1169: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

test_dict = {'expected': 'hello x', 'format': '\\?show [[[hello]]]'}

    def run_formatter(test_dict):
        if test_dict.get('py3only') and python2:
            return
        if not test_dict.get('pypy', True) and is_pypy:
            return
        if test_dict.get('attr_getter'):
            attr_getter = attr_getter_fn
        else:
            attr_getter = None
        try:
            module = Module()
            result = f.format(test_dict['format'], module, param_dict,
                              force_composite=test_dict.get('composite'), attr_getter=attr_getter)
        except Exception as e:
            if test_dict.get('exception') == str(e):
                return
            raise e
    
        # simplify the composite and convert to text if possible
        if isinstance(result, Composite):
            result.simplify()
            if (not test_dict.get('composite') and
                    len(result) == 1 and len(result[0].keys()) == 1):
                result = result[0]['full_text']
    
        if hasattr(result, 'get_content'):
            result = result.get_content()
    
        expected = test_dict.get('expected')
        if python2 and isinstance(expected, str):
            expected = expected.decode('utf-8')
        if result != expected:
            print('Expected\n{}'.format(pformat(expected)))
            print('Got\n{}'.format(pformat(result)))
>       assert (result == expected)
E       assert 'hello' == 'hello x'
E         - hello
E         + hello x
E         ?      ++

tests/test_formatter.py:113: AssertionError
--------------------------------- Captured stdout call ---------------------------------
Expected
'hello x'
Got
'hello'
```

same failing test with this branch
```
    def test_inherit_show_1():
        run_formatter({
            'format': '\?show [[[hello]]]',
>           'expected': 'hello x'
        })
E       Failed: Results not as expected

tests/test_formatter.py:1176: Failed
--------------------------------- Captured stdout call ---------------------------------
Format
\?show [[[hello]]]

Expected
'hello x'
Got
'hello'
