### PR TITLE
new profiling abilities

### DIFF
--- a/py3status/module.py
+++ b/py3status/module.py
@@ -49,6 +49,8 @@ class Module(Thread):
         self.new_update = False
         self.nagged = False
         self.prevent_refresh = False
+        self.profiler = py3_wrapper.profiler
+        self.profile_name = 'module %s' % module
         self.sleeping = False
         self.terminated = False
         self.testing = self.config.get('testing')
@@ -719,6 +721,13 @@ class Module(Thread):
         didn't already do so.
         We will execute the 'kill' method of the module when we terminate.
         """
+        # make local to reduce overhead
+        profiler = self.profiler
+
+        # start of interesting code
+        if profiler:
+            profiler.enable(self.profile_name)
+
         # cancel any existing timer
         if self.timer:
             self.timer.cancel()
@@ -851,6 +860,10 @@ class Module(Thread):
                 cache_time = time() + self.config['cache_timeout']
             self.cache_time = cache_time
             # new style modules can signal they want to cache forever
+            # end of interesting code
+            if profiler:
+                profiler.disable(self.profile_name)
+
             if cache_time == PY3_CACHE_FOREVER:
                 return
             # don't be hasty mate

--- a/py3status/module_test.py
+++ b/py3status/module_test.py
@@ -25,6 +25,7 @@ class MockPy3statusWrapper:
         self.output_modules = {}
         self.events_thread = self.EventThread()
         self.lock.set()
+        self.profiler = None
 
         # shared code
         common = Common(self)

--- a/py3status/profiling.py
+++ b/py3status/profiling.py
@@ -19,3 +19,122 @@ def profile(thread_run_fn):
             profiler.dump_stats("py3status-%s.profile" % thread_id)
 
     return wrapper_run
+
+
+class Profiler:
+    """
+    Helper class to aid profiling.
+    We can enable/disable profiling in specific parts of the code as required
+
+    standard cProfile output is sent to /tmp/py3status.prof
+
+    if pyprof2calltree is installed we create kcachegrind profile info
+    all files created are in a directory
+    /tmp/profile_py3status_<timestamp>_<git branch>
+
+    profiling is enabled via `py3status --profile`
+    """
+
+    filename = 'py3status-{name}.prof'
+    filename_callgrind = 'callgrind.out.py3status-{name}.prof'
+    filename_stats = 'py3status-{name}.stats'
+    dir_format = '/tmp/profile_py3status_{timestamp}_{branch}'
+
+    def __init__(self, py3_wrapper):
+        # only import stuff if we are profiling
+        import os.path
+        import subprocess
+        from datetime import datetime
+        # generate output directory name
+        # get git info if we are running in a repo
+        try:
+            cwd = os.path.dirname(os.path.realpath(__file__))
+            branch = subprocess.check_output(
+                ['git', 'symbolic-ref', '--short', 'HEAD'], cwd=cwd
+            ).decode('utf-8').strip()
+        except:
+            pass
+            branch = ''
+
+        timestamp = datetime.today().strftime('%Y-%m-%d_%H:%M')
+        self.output_dir = self.dir_format.format(
+            timestamp=timestamp, branch=branch
+        )
+
+        self.py3_wrapper = py3_wrapper
+        self.running = {}
+        self.profilers = {}
+
+    def _profiler(self, name):
+        try:
+            return self.profilers[name]
+        except KeyError:
+            pass
+        self.profilers[name] = cProfile.Profile()
+        return self.profilers[name]
+
+    def enable(self, name=''):
+        if self.running.get(name):
+            return
+        self.running[name] = True
+        self._profiler(name).enable()
+
+    def disable(self, name=''):
+        self._profiler(name).disable()
+        self.running[name] = False
+
+    def exit(self):
+        import os
+        import pstats
+        try:
+            from pyprof2calltree import convert
+        except ImportError:
+            convert = None
+
+        try:
+            os.mkdir(self.output_dir)
+        except:
+            return
+
+        stats_info = {}
+        profiles = {}
+        streams = []
+
+        for name, p in self.profilers.items():
+            if name:
+                name = name.split(' ')[0]
+            if name not in profiles:
+                profiles[name] = []
+            profiles[name].append(p)
+            if 'full' not in profiles:
+                profiles['full'] = []
+            profiles['full'].append(p)
+
+        for name, p in profiles.items():
+            if not name:
+                continue
+            filename = self.filename_stats.format(name=name)
+            filename = os.path.join(self.output_dir, filename)
+            stream = open(filename, 'w')
+            streams.append(stream)
+            stats_info[name] = pstats.Stats(*p, stream=stream)
+
+        for name, s in stats_info.items():
+            filename = self.filename.format(name=name)
+            filename = os.path.join(self.output_dir, filename)
+            # write profile data
+            s.dump_stats(filename)
+            s.strip_dirs()
+            s.sort_stats('time', 'calls')
+            # writes stats to Stats stream
+            s.print_stats()
+
+            # kcachegrind file output
+            if convert:
+                filename = self.filename_callgrind.format(name=name)
+                filename = os.path.join(self.output_dir, filename)
+                convert(s, filename)
+
+        # cleanup
+        for stream in streams:
+            stream.close()


### PR DESCRIPTION
Profiling py3status is painful we need it to be nicer for 3.7

a) we have to turn it on manually by editing a file

b) profile is swamped by sleep, poll calls which we do not generally care about

This PR adds a `Profiler` which can be enabled via the `--profile` switch.  We can now mark the code we are interested in profiling using `enable` `disable` calls.  Profile info is converted into a suiable format for `kcachegrind` if module `pyprof2calltree` is installed.

Currently the output is to fixed locations to keep things simple but this can be improved.

Having the enable/disable calls has a slight overhead when profiling is not enabled, however I think that this is acceptable as the advantages of being able to do easy profiling outweigh the cost.

I have another branch that adds a `performance_check` utility that add a standardised config etc so that we can get repeatable output to aid profiling.