### PR TITLE
py3: add multiple format_contains

### DIFF
--- a/py3status/modules/diskdata.py
+++ b/py3status/modules/diskdata.py
@@ -89,9 +89,7 @@ class Py3status:
     def space_and_io(self):
         self.values = {'disk': self.disk if self.disk else 'all'}
 
-        if (self.py3.format_contains(self.format, 'read') or
-                self.py3.format_contains(self.format, 'write') or
-                self.py3.format_contains(self.format, 'total')):
+        if self.py3.format_contains(self.format, ['read', 'write', 'total']):
             # time from previous check
             ios = self._get_io_stats(self.disk)
             timedelta = time() - self.last_time
@@ -115,8 +113,7 @@ class Py3status:
             self.py3.threshold_get_color(total, 'total')
             self.py3.threshold_get_color(write, 'write')
 
-        if (self.py3.format_contains(self.format, 'free') or
-                self.py3.format_contains(self.format, 'used*')):
+        if self.py3.format_contains(self.format, ['free', 'used*']):
             free, used, used_percent = self._get_free_space(self.disk)
 
             self.values['free'] = self.py3.safe_format(self.format_space, {'value': free})

--- a/py3status/modules/github.py
+++ b/py3status/modules/github.py
@@ -201,8 +201,7 @@ class Py3status:
             self._pulls = self._github_count(url) or self._pulls
         status['pull_requests'] = self._pulls
         # notifications
-        if (self.py3.format_contains(self.format, 'notifications') or
-                self.py3.format_contains(self.format, 'notifications_count')):
+        if self.py3.format_contains(self.format, 'notifications*'):
             count = self._notifications()
             # if we don't have a notification count, then use the last value
             # that we did have.

--- a/py3status/py3.py
+++ b/py3status/py3.py
@@ -589,11 +589,12 @@ class Py3:
 
         return requested + offset
 
-    def format_contains(self, format_string, name):
+    def format_contains(self, format_string, names):
         """
-        Determines if ``format_string`` contains placeholder ``name``
+        Determines if ``format_string`` contains a placeholder string ``names``
+        or a list of placeholders ``names``.
 
-        ``name`` is tested against placeholders using fnmatch so the following
+        ``names`` is tested against placeholders using fnmatch so the following
         patterns can be used:
 
         .. code-block:: none
@@ -608,10 +609,14 @@ class Py3:
         will fail if the format string contains placeholder formatting
         eg ``'{placeholder:.2f}'``
         """
-
         # We cache things to prevent parsing the format_string more than needed
+        if isinstance(names, list):
+            key = str(names)
+        else:
+            key = names
+            names = [names]
         try:
-            return self._format_placeholders_cache[format_string][name]
+            return self._format_placeholders_cache[format_string][key]
         except KeyError:
             pass
 
@@ -621,15 +626,16 @@ class Py3:
         else:
             placeholders = self._format_placeholders[format_string]
 
-        result = False
-        for placeholder in placeholders:
-            if fnmatch(placeholder, name):
-                result = True
-                break
         if format_string not in self._format_placeholders_cache:
             self._format_placeholders_cache[format_string] = {}
-        self._format_placeholders_cache[format_string][name] = result
-        return result
+
+        for name in names:
+            for placeholder in placeholders:
+                if fnmatch(placeholder, name):
+                    self._format_placeholders_cache[format_string][key] = True
+                    return True
+        self._format_placeholders_cache[format_string][key] = False
+        return False
 
     def get_placeholders_list(self, format_string, match=None):
         """


### PR DESCRIPTION
We can stuff many things in a sack of `py3.contains_format` along with `any`/`all` option.