### PR TITLE
remove Timers and spend less time in threading

### DIFF
--- a/py3status/core.py
+++ b/py3status/core.py
@@ -12,7 +12,7 @@ from platform import python_version
 from pprint import pformat
 from signal import signal, SIGTERM, SIGUSR1, SIGTSTP, SIGCONT
 from subprocess import Popen
-from threading import Event
+from threading import Event, Thread
 from syslog import syslog, LOG_ERR, LOG_INFO, LOG_WARNING
 from traceback import extract_tb, format_tb, format_stack
 
@@ -40,6 +40,22 @@ CONFIG_SPECIAL_SECTIONS = [
     'py3_modules',
     'py3status',
 ]
+
+
+class Runner(Thread):
+    """
+    A Simple helper to run a module in a Thread so it is non-locking.
+    """
+    def __init__(self, module, py3_wrapper):
+        Thread.__init__(self)
+        self.module = module
+        self.py3_wrapper = py3_wrapper
+
+    def run(self):
+        try:
+            self.module.run()
+        except:
+            self.py3_wrapper.report_exception('Runner')
 
 
 class NoneSetting:
@@ -187,13 +203,100 @@ class Py3statusWrapper:
         self.output_modules = {}
         self.py3_modules = []
         self.py3_modules_initialized = False
-        self.queue = deque()
+        self.running = True
+        self.update_queue = deque()
         self.update_request = Event()
 
         # shared code
         common = Common(self)
         self.get_config_attribute = common.get_config_attribute
         self.report_exception = common.report_exception
+
+        # these are used to schedule module updates
+        self.timeout_update_due = deque()
+        self.timeout_queue = {}
+        self.timeout_keys = []
+        self.timeout_queue_members = set()
+
+    def timeout_queue_add_module(self, module_name, cache_time=0):
+        """
+        Add a module to the timeout_queue if it is scheduled in the future or
+        if it is due for an update imediately just trigger that.
+
+        the timeout_queue is a dict with the scheduled time as the key and the
+        value is a list of module instance names due to be updated at that
+        point. An ordered list of keys is kept to allow easy checking of when
+        updates are due.  A list is also kept of which modules are in the
+        update_queue to save having to search for modules in it unless needed.
+        """
+        if module_name in self.timeout_queue_members:
+            # we want to remove the module from the timeout_queue
+            # a module should only ever at most once in the queue
+            found = False
+            for key, value in self.timeout_queue.items():
+                if module_name in value:
+                    found = True
+                    break
+            if found:
+                value.remove(module_name)
+                if not value:
+                    del self.timeout_queue[key]
+                    self.timeout_keys.remove(key)
+                self.timeout_queue_members.remove(module_name)
+        if cache_time == 0:
+            # if cache_time is 0 we can just trigger the module update
+            self.timeout_update_due.append(
+                (self.modules[module_name], cache_time)
+            )
+            self.update_request.set()
+        else:
+            # add the module to the timeout queue
+            if cache_time not in self.timeout_keys:
+                self.timeout_queue[cache_time] = set([module_name])
+                self.timeout_keys.append(cache_time)
+                # sort keys so earliest is first
+                self.timeout_keys.sort()
+            else:
+                self.timeout_queue[cache_time].add(module_name)
+            # note that the module is in the timeout_queue
+            self.timeout_queue_members.add(module_name)
+
+    def timeout_queue_process(self):
+        """
+        Check the timeout_queue and set any due modules to update.
+        """
+        now = time.time()
+        due_timeouts = []
+        # find any due timeouts
+        for timeout in self.timeout_keys:
+            if timeout > now:
+                break
+            due_timeouts.append(timeout)
+
+        # process them
+        for timeout in due_timeouts:
+            modules = self.timeout_queue[timeout]
+            # remove from the queue
+            del self.timeout_queue[timeout]
+            self.timeout_keys.remove(timeout)
+
+            for module in modules:
+                # module no longer in queue
+                self.timeout_queue_members.remove(module)
+                # tell module to update
+                self.timeout_update_due.append((self.modules[module], timeout))
+
+        # run any modules that are due
+        while self.timeout_update_due:
+            module, timeout = self.timeout_update_due.popleft()
+            r = Runner(module, self)
+            r.start()
+
+        # we return how long till we next need to process the timeout_queue
+        try:
+            return self.timeout_keys[0] - time.time()
+        except IndexError:
+            return None
 
     def get_config(self):
         """
@@ -565,6 +668,7 @@ class Py3statusWrapper:
         """
         Set the Event lock, this will break all threads' loops.
         """
+        self.running = False
         # stop the command server
         try:
             self.commands_thread.kill()
@@ -647,7 +751,7 @@ class Py3statusWrapper:
         """
         if not isinstance(update, list):
             update = [update]
-        self.queue.extend(update)
+        self.update_queue.extend(update)
 
         # if all our py3status modules are not ready to receive updates then we
         # don't want to get them to update.
@@ -680,7 +784,7 @@ class Py3statusWrapper:
                     container_module['module'].force_update()
 
         # we need to update the output
-        if self.queue:
+        if self.update_queue:
             self.update_request.set()
 
     def log(self, msg, level='info'):
@@ -852,9 +956,13 @@ class Py3statusWrapper:
         update_due = None
         # main loop
         while True:
-            # wait untill an update is requested
-            self.update_request.wait(timeout=update_due)
-            update_due = None
+            # process the timeout_queue and get interval till next update due
+            update_due = self.timeout_queue_process()
+
+            # wait until an update is requested
+            if self.update_request.wait(timeout=update_due):
+                # event was set so clear it
+                self.update_request.clear()
 
             while not self.i3bar_running:
                 time.sleep(0.1)
@@ -885,9 +993,9 @@ class Py3statusWrapper:
                     update_due = i3status_thread.update_times()
 
             # check if an update is needed
-            if self.queue:
-                while (len(self.queue)):
-                    module_name = self.queue.popleft()
+            if self.update_queue:
+                while (len(self.update_queue)):
+                    module_name = self.update_queue.popleft()
                     module = self.output_modules[module_name]
                     for index in module['position']:
                         # store the output as json
@@ -898,12 +1006,6 @@ class Py3statusWrapper:
                 out = ','.join([x for x in output if x])
                 # dump the line to stdout
                 print_line(',[{}]'.format(out))
-
-            # we've done our work here so we can clear the request
-            self.update_request.clear()
-            # just in case check if we have an update and request if needed
-            if self.queue:
-                self.update_request.set()
 
     def handle_cli_command(self, config):
         """Handle a command from the CLI.

--- a/py3status/events.py
+++ b/py3status/events.py
@@ -63,7 +63,6 @@ class Events(Thread):
         self.config = py3_wrapper.config
         self.error = None
         self.py3_config = py3_wrapper.config['py3_config']
-        self.lock = py3_wrapper.lock
         self.modules = py3_wrapper.modules
         self.on_click = self.py3_config['on_click']
         self.output_modules = py3_wrapper.output_modules
@@ -236,7 +235,7 @@ class Events(Thread):
         Example event:
         {'y': 13, 'x': 1737, 'button': 1, 'name': 'empty', 'instance': 'first'}
         """
-        while not self.lock.is_set():
+        while self.py3_wrapper.running:
             event_str = self.poller_inp.readline()
             if not event_str:
                 continue

--- a/py3status/i3status.py
+++ b/py3status/i3status.py
@@ -324,7 +324,7 @@ class I3status(Thread):
         # if the i3status process dies we want to restart it.
         # We give up restarting if we have died too often
         for x in range(10):
-            if self.lock.is_set():
+            if not self.py3_wrapper.running:
                 break
             self.spawn_i3status()
             # check if we never worked properly and if so quit now
@@ -362,7 +362,7 @@ class I3status(Thread):
 
                 try:
                     # loop on i3status output
-                    while not self.lock.is_set():
+                    while self.py3_wrapper.running:
                         line = self.poller_inp.readline()
                         if line:
                             # remove leading comma if present

--- a/py3status/module.py
+++ b/py3status/module.py
@@ -2,7 +2,6 @@ import os
 import imp
 import inspect
 
-from threading import Thread, Timer
 from collections import OrderedDict
 from time import time
 
@@ -12,7 +11,7 @@ from py3status.profiling import profile
 from py3status.formatter import Formatter
 
 
-class Module(Thread):
+class Module:
     """
     This class represents a user module (imported file).
     It is responsible for executing it every given interval and
@@ -26,8 +25,6 @@ class Module(Thread):
         """
         We need quite some stuff to occupy ourselves don't we ?
         """
-        Thread.__init__(self)
-
         self.allow_config_clicks = True
         self.allow_urgent = None
         self.cache_time = None
@@ -40,7 +37,6 @@ class Module(Thread):
         self.has_kill = False
         self.i3status_thread = py3_wrapper.i3status_thread
         self.last_output = []
-        self.lock = py3_wrapper.lock
         self.methods = OrderedDict()
         self.module_class = instance
         self.module_full_name = module
@@ -52,7 +48,6 @@ class Module(Thread):
         self.sleeping = False
         self.terminated = False
         self.testing = self.config.get('testing')
-        self.timer = None
         self.urgent = False
 
         # create a nice name for the module that matches what the module is
@@ -221,7 +216,7 @@ class Module(Thread):
         if not (self.disabled or self.terminated):
             # Start the module and call its output method(s)
             self._py3_wrapper.log('starting module %s' % self.module_full_name)
-            self.start()
+            self._py3_wrapper.timeout_queue_add_module(self.module_full_name)
 
     def force_update(self):
         """
@@ -234,18 +229,13 @@ class Module(Thread):
             self.methods[meth]['cached_until'] = time()
             if self.config['debug']:
                 self._py3_wrapper.log('clearing cache for method {}'.format(meth))
-        # cancel any existing timer
-        if self.timer:
-            self.timer.cancel()
-        # get the thread to update itself
-        self.timer = Timer(0, self.run)
-        self.timer.start()
+        # set module to update
+        self._py3_wrapper.timeout_queue_add_module(
+            self.module_full_name, 0
+        )
 
     def sleep(self):
         self.sleeping = True
-        # cancel any existing timer
-        if self.timer:
-            self.timer.cancel()
 
     def disable_module(self):
         # hide message
@@ -266,9 +256,9 @@ class Module(Thread):
         if self.cache_time == PY3_CACHE_FOREVER:
             return
         # restart
-        delay = max(self.cache_time - time(), 0)
-        self.timer = Timer(delay, self.run)
-        self.timer.start()
+        self._py3_wrapper.timeout_queue_add_module(
+            self.module_full_name, self.cache_time
+        )
 
     def set_updated(self):
         """
@@ -719,18 +709,14 @@ class Module(Thread):
         didn't already do so.
         We will execute the 'kill' method of the module when we terminate.
         """
-        # cancel any existing timer
-        if self.timer:
-            self.timer.cancel()
-
-        if not self.lock.is_set():
+        if self._py3_wrapper.running:
             cache_time = None
             # execute each method of this module
             for meth, obj in self.methods.items():
                 my_method = self.methods[meth]
 
-                # always check the lock
-                if self.lock.is_set():
+                # always check py3status is running
+                if not self._py3_wrapper.running:
                     break
 
                 # respect the cache set for this method
@@ -854,17 +840,15 @@ class Module(Thread):
             if cache_time == PY3_CACHE_FOREVER:
                 return
             # don't be hasty mate
-            # set timer to do update next time one is needed
-            if not self.sleeping:
-                delay = max(cache_time - time(),
-                            self.config['minimum_interval'])
-                self.timer = Timer(delay, self.run)
-                self.timer.start()
+            # set timeout to do update next time one is needed
+            if not cache_time:
+                cache_time = time() + self.config['minimum_interval']
+
+            self._py3_wrapper.timeout_queue_add_module(
+                self.module_full_name, cache_time
+            )
 
     def kill(self):
-        # stop timer if exists
-        if self.timer:
-            self.timer.cancel()
         # check and execute the 'kill' method if present
         if self.has_kill:
             try:


### PR DESCRIPTION
This PR reduces the amount of time we spend in threading module by ~50%,  we do increase the work done in core by ~40% but this is a small increase compared to the saved time.

Overall it is about a ~15% saving

on my 10 minute test based on pprofile line profiling.

**master**

py3status module updates: 1595
total cpu time: 1,285,655
threading: 411,426
core time: 86,658

**branch**

py3status module updates: 1622
total cpu time: 1,109,407
threading: 208,338
core time: 123,383


* `Py3StatusWrapper.queue` renamed to `Py3StatusWrapper.update_queue` for readability

* `Module` no longer a `Thread`

* remove the `Timers` in `module.py`

* replace `Py3StatusWrapper.lock` with `Py3StatusWrapper.running` where possible to reduce overhead.

* We now run modules using a simple `Runner` thread when updates needed.

* We store when each module is due for an update and create a `Runner` as needed

Although we are still creating a `Runner` thread every time we get module output we end up with fewer threads running.  In future we can probably make better use of these by reusing them but for now it keeps things simple and we get our big saving.