### PR TITLE
backlight: better xbacklight detection

### DIFF
--- a/py3status/modules/backlight.py
+++ b/py3status/modules/backlight.py
@@ -80,7 +80,14 @@ class Py3status:
         if self.device is None:
             raise Exception(STRING_NOT_AVAILABLE)
 
-        self.xbacklight = self.py3.check_commands(['xbacklight'])
+        # check for an error code and an output
+        self.xbacklight = False
+        try:
+            if self.py3.command_output(['xbacklight', '-get']):
+                self.xbacklight = True
+        except:
+            pass
+
         if self.xbacklight and self.brightness_initial:
             self._set_backlight_level(self.brightness_initial)
 


### PR DESCRIPTION
Hi. Here's a bugfix. Just because the users can install `xbacklight`... does not mean `xbacklight` ought to be enabled internally in the module. For that, we need more than checking a command.

We need a better xbacklight detection.

When Linux distros and/or DE detects that the users are using a laptop, it can install `xbacklight` too... likely a part of laptop/other metapackage.

Having it installed does not necessarily mean that `xbacklight` are guaranteed to work out of the box... as some laptops can have native backlight support using Fn key. Some laptops can not have this feature too so the users would be left with a bad/broken module.


If you looked in the module, you can see that because you have `xbacklight` installed, it will try and get you a value from `xbacklight -get` instead of `/sys/class/backlight/???/brightness`... which can give you either nothing or an exception / error code.

The fix correctly turns off `xbacklight` so we can show the percent number natively.

Anyway... Here's how... In `post_config_hook`, we try few things.
* Is `xbacklight` installed? [y/n]
* Any error codes when running `xbacklight -get`?  [y/n] **NEW!**
* Any percent output when running `xbacklight -get`? [y/n] **NEW!**

P.S. I have more fun things for `backlight` in diff branch. Lemme know if you want it. This is just a worthy bugfix to get it working with my native backlight laptop. Thx. 👍 

EDIT: We could make do without `84: if self.py3.check_commands(['xbacklight']):`... 