### PR TITLE
xrandr: use post_config_hook

### DIFF
--- a/py3status/modules/xrandr.py
+++ b/py3status/modules/xrandr.py
@@ -133,8 +133,9 @@ class Py3status:
             ],
         }
 
-    def __init__(self):
+    def post_config_hook(self):
         """
+        Initialization
         """
         self.active_comb = None
         self.active_layout = None


### PR DESCRIPTION
We convert `__init__` to `post_config_hook` here.