### PR TITLE
rate_counter: new module from scratch

### DIFF
--- a/py3status/modules/rate_counter.py
+++ b/py3status/modules/rate_counter.py
@@ -127,8 +127,11 @@ class Py3status:
     def _reset_timer(self):
         if not self.running:
             self.saved_time = 0.0
-            with open(self.config_file, 'w') as f:
-                f.write('0')
+            try:
+                with open(self.config_file, 'w') as f:
+                    f.write('0')
+            except:
+                pass
 
     def _start_timer(self):
         if not self.running:
@@ -148,8 +151,11 @@ class Py3status:
 
     def kill(self):
         self._stop_timer()
-        with open(self.config_file, 'w') as f:
-            f.write(str(self.saved_time))
+        try:
+            with open(self.config_file, 'w') as f:
+                f.write(str(self.saved_time))
+        except:
+            pass
 
     def rate_counter(self):
         cached_until = self.py3.CACHE_FOREVER

--- a/py3status/modules/rate_counter.py
+++ b/py3status/modules/rate_counter.py
@@ -18,6 +18,7 @@ Format placeholders:
     {days} The number of whole days in running timer
     {hours} The remaining number of whole hours in running timer
     {minutes} The remaining number of whole minutes in running timer
+    {rate} The user inputted hourly rate
     {seconds} The remaining number of seconds in running timer
     {subtotal} The subtotal cost (time * rate)
     {tax} The tax cost, based on the subtotal cost
@@ -172,6 +173,7 @@ class Py3status:
                     'days': days,
                     'hours': hours,
                     'minutes': minutes,
+                    'rate': self.rate,
                     'seconds': seconds,
                     'subtotal': subtotal,
                     'tax': total - subtotal,

--- a/py3status/modules/rate_counter.py
+++ b/py3status/modules/rate_counter.py
@@ -9,8 +9,8 @@ Configuration parameters:
     config_file: specify a file to save time between sessions
         (default '~/.config/py3status/rate_counter.save')
     format: display format for this module
-        (default '[\?not_zero {days} days ][\?not_zero {hours}:]
-        {minutes:02d}:{seconds:02d} / ${total:.2f}')
+        *(default '[\?not_zero {days} days ][\?not_zero {hours}:]'
+        '{minutes}:{seconds} / ${total}')*
     rate: specify the hourly pay rate to use (default 30)
     tax: specify the tax value to use, 1.02 is 2% (default 1.02)
 
@@ -55,8 +55,8 @@ class Py3status:
     button_toggle = 1
     cache_timeout = 5
     config_file = '~/.config/py3status/rate_counter.save'
-    format = '[\?not_zero {days} days ][\?not_zero {hours}:]' +\
-        '{minutes:02d}:{seconds:02d} / ${total:.2f}'
+    format = ('[\?not_zero {days} days ][\?not_zero {hours}:]'
+              '{minutes}:{seconds} / ${total}')
     rate = 30
     tax = 1.02
 
@@ -120,8 +120,8 @@ class Py3status:
         remaining_seconds = time_in_seconds % SECONDS_IN_DAY
         hours = int(remaining_seconds / SECONDS_IN_HOUR)
         remaining_seconds = remaining_seconds % SECONDS_IN_HOUR
-        minutes = int(remaining_seconds / SECONDS_IN_MIN)
-        seconds = int(remaining_seconds % SECONDS_IN_MIN)
+        minutes = '%02d' % (remaining_seconds / SECONDS_IN_MIN)
+        seconds = '%02d' % (remaining_seconds % SECONDS_IN_MIN)
         return days, hours, minutes, seconds
 
     def _reset_timer(self):
@@ -169,7 +169,7 @@ class Py3status:
 
         days, hours, minutes, seconds = self._seconds_to_time(running_time)
         subtotal = float(self.rate) * (running_time / SECONDS_IN_HOUR)
-        total = subtotal * float(self.tax)
+        total = round(subtotal * float(self.tax), 2)
 
         return {
             'cached_until': cached_until,

--- a/py3status/modules/rate_counter.py
+++ b/py3status/modules/rate_counter.py
@@ -102,6 +102,8 @@ class Py3status:
         self.running = False
         self.saved_time = 0
         self.start_time = self.current_time
+        self.color_running = self.py3.COLOR_RUNNING or self.py3.COLOR_GOOD
+        self.color_stopped = self.py3.COLOR_STOPPED or self.py3.COLOR_BAD
         try:
             # Use file to refer to the file object
             with open(self.config_file) as file:
@@ -160,20 +162,21 @@ class Py3status:
                 f.write('0')
 
     def counter(self):
-        running_time = 0.0
+        cached_until = self.py3.CACHE_FOREVER
+        color = self.color_stopped
+        running_time = self.saved_time
+
         if self.running:
-            color = self.py3.COLOR_RUNNING or self.py3.COLOR_GOOD
+            cached_until = self.py3.time_in(self.cache_timeout)
+            color = self.color_running
             running_time = self.current_time - self.start_time
-        else:
-            color = self.py3.COLOR_STOPPED or self.py3.COLOR_BAD
-            running_time = self.saved_time
 
         days, hours, minutes, seconds = self.seconds_to_dhms(running_time)
         subtotal = float(self.rate) * (running_time / SECONDS_IN_HOUR)
         total = subtotal * float(self.tax)
 
         response = {
-            'cached_until': self.py3.time_in(self.cache_timeout),
+            'cached_until': cached_until,
             'color': color,
             'full_text': self.py3.safe_format(
                 self.format,

--- a/py3status/modules/rate_counter.py
+++ b/py3status/modules/rate_counter.py
@@ -196,6 +196,8 @@ class Py3status:
             self._toggle_timer()
         elif button == self.button_reset:
             self._reset_timer()
+        else:
+            self.py3.prevent_refresh()
 
 
 if __name__ == "__main__":

--- a/py3status/modules/rate_counter.py
+++ b/py3status/modules/rate_counter.py
@@ -7,10 +7,9 @@ Configuration parameters:
     config_file: file path to store the time already spent
         and restore it the next session
         (default '~/.i3/py3status/counter-config.save')
-    format: output format string
-        (default 'Time: {days} day {hours}:{minutes:02d} Cost: {total}')
-    format_money: output format string
-        (default '{price}$')
+    format: display format for this module
+        (default '[\?not_zero {days} days ][\?not_zero {hours}:]
+        {minutes:02d}:{seconds:02d} / ${total:.2f}')
     rate: your price per hour (default 30)
     tax: tax value (1.02 = 2%) (default 1.02)
 
@@ -55,13 +54,19 @@ class Py3status:
     # available configuration parameters
     cache_timeout = 5
     config_file = '~/.i3/py3status/counter-config.save'
-    format = 'Time: {days} day {hours}:{minutes:02d} Cost: {total}'
-    format_money = '{price}$'
+    format = '[\?not_zero {days} days ][\?not_zero {hours}:]' +\
+        '{minutes:02d}:{seconds:02d} / ${total:.2f}'
     rate = 30
     tax = 1.02
 
     class Meta:
         deprecated = {
+            'remove': [
+                {
+                    'param': 'format_money',
+                    'msg': 'obsolete parameter',
+                },
+            ],
             'rename': [
                 {
                     'param': 'hour_price',
@@ -168,12 +173,7 @@ class Py3status:
         days, hours, minutes, seconds = self.seconds_to_dhms(running_time)
         subtotal = float(self.rate) * (running_time / SECONDS_IN_HOUR)
         total = subtotal * float(self.tax)
-        subtotal_cost = self.py3.safe_format(self.format_money,
-                                             {'price': '%.2f' % subtotal})
-        total_cost = self.py3.safe_format(self.format_money,
-                                          {'price': '%.2f' % total})
-        tax_cost = self.py3.safe_format(self.format_money,
-                                        {'price': '%.2f' % (total - subtotal)})
+
         response = {
             'cached_until': self.py3.time_in(self.cache_timeout),
             'color': color,

--- a/py3status/modules/rate_counter.py
+++ b/py3status/modules/rate_counter.py
@@ -7,7 +7,7 @@ Configuration parameters:
     button_toggle: mouse button to toggle the timer (default 1)
     cache_timeout: refresh interval for this module (default 5)
     config_file: specify a file to save time between sessions
-        (default '~/.i3/py3status/counter-config.save')
+        (default '~/.config/py3status/rate_counter.save')
     format: display format for this module
         (default '[\?not_zero {days} days ][\?not_zero {hours}:]
         {minutes:02d}:{seconds:02d} / ${total:.2f}')
@@ -54,7 +54,7 @@ class Py3status:
     button_reset = 3
     button_toggle = 1
     cache_timeout = 5
-    config_file = '~/.i3/py3status/counter-config.save'
+    config_file = '~/.config/py3status/rate_counter.save'
     format = '[\?not_zero {days} days ][\?not_zero {hours}:]' +\
         '{minutes:02d}:{seconds:02d} / ${total:.2f}'
     rate = 30

--- a/py3status/modules/rate_counter.py
+++ b/py3status/modules/rate_counter.py
@@ -3,6 +3,8 @@
 Display time spent and calculate the price of your service.
 
 Configuration parameters:
+    button_reset: mouse button to reset the timer (default 3)
+    button_toggle: mouse button to toggle the timer (default 1)
     cache_timeout: how often to update in seconds (default 5)
     config_file: file path to store the time already spent
         and restore it the next session
@@ -52,6 +54,8 @@ class Py3status:
     """
     """
     # available configuration parameters
+    button_reset = 3
+    button_toggle = 1
     cache_timeout = 5
     config_file = '~/.i3/py3status/counter-config.save'
     format = '[\?not_zero {days} days ][\?not_zero {hours}:]' +\
@@ -149,12 +153,6 @@ class Py3status:
         with open(self.config_file, 'w') as f:
             f.write(str(self.saved_time))
 
-    def on_click(self, event):
-        if event['button'] == 1:
-            self._toggle_timer()
-        elif event['button'] == 3:
-            self._reset()
-
     def _reset(self):
         if not self.running:
             self.saved_time = 0.0
@@ -191,6 +189,12 @@ class Py3status:
             )
         }
         return response
+
+    def on_click(self, event):
+        if event['button'] == self.button_toggle:
+            self._toggle_timer()
+        elif event['button'] == self.button_reset:
+            self._reset()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
I went at this module with a broom.

Waiting for PR #999 to be merged first. Thoughts on updating `config_file` too?

i3 switched to `~/.config/i3` long time ago. We could do...
* `~/.config/i3/py3status-rate_counter.save`
* `/tmp/py3status-rate_counter.save` (until the user puts in a config?)
* Make it `None` so the users would see `0:00` on startup... just like `pomodoro` and others. This makes things a bit more consistent across modules (ie no file writing by default).

Anyway. Let me know. This is a nice module. I made the format smaller too. Ty.
