### PR TITLE
move thread checks out of core main loop

### DIFF
--- a/py3status/core.py
+++ b/py3status/core.py
@@ -922,7 +922,6 @@ class Py3statusWrapper:
         signal(SIGTERM, self.terminate)
 
         # initialize usage variables
-        i3status_thread = self.i3status_thread
         py3_config = self.config['py3_config']
 
         # prepare the color mappings
@@ -949,9 +948,6 @@ class Py3statusWrapper:
         # items in the bar
         output = [None] * len(py3_config['order'])
 
-        interval = self.config['interval']
-        last_sec = 0
-
         # start our output
         header = {
             'version': 1,
@@ -974,31 +970,6 @@ class Py3statusWrapper:
 
             while not self.i3bar_running:
                 time.sleep(0.1)
-
-            sec = int(time.time())
-
-            # only check everything is good each second
-            if sec > last_sec:
-                last_sec = sec
-
-                # check i3status thread
-                if not i3status_thread.is_alive():
-                    err = i3status_thread.error
-                    if not err:
-                        err = 'I3status died horribly.'
-                    self.notify_user(err)
-
-                # check events thread
-                if not self.events_thread.is_alive():
-                    # don't spam the user with i3-nagbar warnings
-                    if not hasattr(self.events_thread, 'nagged'):
-                        self.events_thread.nagged = True
-                        err = 'Events thread died, click events are disabled.'
-                        self.notify_user(err, level='warning')
-
-                # update i3status time/tztime items
-                if interval == 0 or sec % interval == 0:
-                    update_due = i3status_thread.update_times()
 
             # check if an update is needed
             if self.update_queue:

--- a/py3status/events.py
+++ b/py3status/events.py
@@ -235,15 +235,20 @@ class Events(Thread):
         Example event:
         {'y': 13, 'x': 1737, 'button': 1, 'name': 'empty', 'instance': 'first'}
         """
-        while self.py3_wrapper.running:
-            event_str = self.poller_inp.readline()
-            if not event_str:
-                continue
-            try:
-                # remove leading comma if present
-                if event_str[0] == ',':
-                    event_str = event_str[1:]
-                event = loads(event_str)
-                self.dispatch_event(event)
-            except Exception:
-                self.py3_wrapper.report_exception('Event failed')
+        try:
+            while self.py3_wrapper.running:
+                event_str = self.poller_inp.readline()
+                if not event_str:
+                    continue
+                try:
+                    # remove leading comma if present
+                    if event_str[0] == ',':
+                        event_str = event_str[1:]
+                    event = loads(event_str)
+                    self.dispatch_event(event)
+                except Exception:
+                    self.py3_wrapper.report_exception('Event failed')
+        except:
+            err = 'Events thread died, click events are disabled.'
+            self.py3_wrapper.report_exception(err, notify_user=False)
+            self.py3_wrapper.notify_user(err, level='warning')

--- a/py3status/i3status.py
+++ b/py3status/i3status.py
@@ -401,6 +401,11 @@ class I3status(Thread):
                 break
             # limit restart rate
             self.lock.wait(5)
+        if not self.py3_wrapper.lock.is_set():
+            err = self.error
+            if not err:
+                err = 'I3status died horribly.'
+            self.py3_wrapper.notify_user(err)
 
     def spawn_i3status(self):
         """


### PR DESCRIPTION
Currently we check event and i3status threads are alive in the main loop.  This moves these checks into the actual modules.  Also remove some other cruft in the loop that is no longer needed.