### PR TITLE
improve logging for modules

### DIFF
--- a/py3status/py3.py
+++ b/py3status/py3.py
@@ -443,10 +443,14 @@ class Py3:
         ], 'level must be LOG_ERROR, LOG_INFO or LOG_WARNING'
 
         # nicely format logs if we can using pretty print
-        message = pformat(message)
+        if isinstance(message, (dict, list, set, tuple)):
+            message = pformat(message)
         # start on new line if multi-line output
-        if '\n' in message:
-            message = '\n' + message
+        try:
+            if '\n' in message:
+                message = '\n' + message
+        except:
+            pass
         message = 'Module `{}`: {}'.format(
             self._module.module_full_name, message)
         self._py3_wrapper.log(message, level)


### PR DESCRIPTION
fix for #1028

make `py3.log()` more like `log()`

now we just do the `pformat` on tuple, list, dict, set