### PR TITLE
pingdom: fix keyerror exception

### DIFF
--- a/py3status/modules/pingdom.py
+++ b/py3status/modules/pingdom.py
@@ -44,7 +44,10 @@ class Py3status:
     request_timeout = 15
 
     def pingdom_checks(self):
-        response = {'cached_until': self.py3.time_in(self.cache_timeout)}
+        response = {
+            'cached_until': self.py3.time_in(self.cache_timeout),
+            'full_text': ''
+        }
         pingdom = None
 
         # parse some configuration parameters


### PR DESCRIPTION
Bugfix.
```
2017-09-02 10:05:37 WARNING Instance `pingdom _anon_module_47`, user method `pingdom_checks` failed (KeyError) module.py line 774.
2017-09-02 10:05:37 INFO Traceback
KeyError: 'missing "full_text" key in response'
  File "/home/chris/src/py3status/py3status/module.py", line 774, in run
    raise KeyError(err)
```