### PR TITLE
apt: use post_config_hook

### DIFF
--- a/py3status/modules/apt_updates.py
+++ b/py3status/modules/apt_updates.py
@@ -28,12 +28,17 @@ import subprocess
 import sys
 
 LINE_SEPARATOR = "\\n" if sys.version_info > (3, 0) else "\n"
+STRING_NOT_INSTALLED = 'not installed'
 
 
 class Py3status:
     # available configuration parameters
     cache_timeout = 600
     format = 'UPD[\?not_zero : {apt}]'
+
+    def post_config_hook(self):
+        if not self.py3.check_commands('apt'):
+            raise Exception(STRING_NOT_INSTALLED)
 
     def check_updates(self):
         apt_updates = self._check_apt_updates()


### PR DESCRIPTION
We make `post_config_hook` for `apt`. Performance tweak.

We prevent this module from complaining too much. `[Errno 2] No such file or directory: 'apt'`. 