### PR TITLE
icinga2: fix attributeerror exception, use post_config_hook

### DIFF
--- a/py3status/modules/icinga2.py
+++ b/py3status/modules/icinga2.py
@@ -45,7 +45,6 @@ class Py3status:
 
     def get_status(self):
         response = {
-            'color': self.color,
             'cached_until': self.py3.time_in(self.cache_timeout),
             'full_text': self.py3.safe_format(
                 self.format,

--- a/py3status/modules/icinga2.py
+++ b/py3status/modules/icinga2.py
@@ -27,6 +27,7 @@ Configuration parameters:
 import requests
 
 STATUS_NAMES = {0: 'OK', 1: 'WARNING', 2: 'CRITICAL', 3: 'UNKNOWN'}
+STRING_NOT_CONFIGURED = 'not configured'
 
 
 class Py3status:
@@ -42,6 +43,10 @@ class Py3status:
     status = 0
     url_parameters = "?service_state={service_state}&format=json"
     user = ''
+
+    def post_config_hook(self):
+        if not self.base_url:
+            raise Exception(STRING_NOT_CONFIGURED)
 
     def get_status(self):
         response = {


### PR DESCRIPTION
```
'Py3status' object has no attribute 'color' (AttributeError) module.py line 747.
Traceback
AttributeError: 'Py3status' object has no attribute 'color'
  File "/home/chris/src/py3status/py3status/module.py", line 747, in run
    response = method()
  File "icinga2.py", line 48, in get_status
    'color': self.color,
```
I'm guessing 2555bd62ba054a39ced272d7d1d65e3dfa12ff9d broke this module last year right on this month. Removed the orphaned `self.color`.

Now we get the annoying `stuffs are not working without the configurations`. I added `not configured` in the `post_config_hook`. See how it could be broken for some time, I go ahead and clean up everything.