### PR TITLE
xsel: remove excess whitespace chars

### DIFF
--- a/py3status/modules/xsel.py
+++ b/py3status/modules/xsel.py
@@ -38,7 +38,7 @@ class Py3status:
     symmetric = True
 
     def xsel(self):
-        selection = self.py3.command_output(self.command)
+        selection = ' '.join(self.py3.command_output(self.command).split())
         if len(selection) >= self.max_size:
             if self.symmetric is True:
                 split = int(self.max_size / 2) - 1


### PR DESCRIPTION
This is a bugfix. In `xsel`, the bouncer `\n` continues to kick out the drunk line out of the bar...
*"Enough is enough."* The fix? We absolutely remove excess whitespace chars everywhere. 