### PR TITLE
player_control: use post_config_hook

### DIFF
--- a/py3status/modules/player_control.py
+++ b/py3status/modules/player_control.py
@@ -60,7 +60,7 @@ class Py3status:
     supported_players = 'audacious,vlc'
     volume_tick = 1
 
-    def __init__(self):
+    def post_config_hook(self):
         self.status = 'stop'
         self.icon = self.play_icon
 


### PR DESCRIPTION
Replacing `__init__` with `post_config_hook` for `player_control`.