### PR TITLE
exchange_rate: allow for bad json being returned

### DIFF
--- a/py3status/modules/exchange_rate.py
+++ b/py3status/modules/exchange_rate.py
@@ -52,7 +52,10 @@ class Py3status:
             result = None
         rates = []
         if result:
-            data = result.json()
+            try:
+                data = result.json()
+            except self.py3.RequestInvalidJSON:
+                data = {}
             try:
                 rates = data['query']['results']['rate']
             except (KeyError, TypeError):


### PR DESCRIPTION
fix for #1052 

Sometimes we get bad json back in a response.  Now we will just keep the old values when this happens.