### PR TITLE
pomodoro: use post_config_hook

### DIFF
--- a/py3status/modules/pomodoro.py
+++ b/py3status/modules/pomodoro.py
@@ -122,7 +122,7 @@ class Py3status:
     timer_long_break = 15 * 60
     timer_pomodoro = 25 * 60
 
-    def __init__(self):
+    def post_config_hook(self):
         self._initialized = False
 
     def _init(self):


### PR DESCRIPTION
Replacing `__init__` with `post_config_hook` for `pomodoro`.

I'd like to merge my format-friendly pomodoro PR someday. Slightly more informative too.