### PR TITLE
netdata: use post_config_hook

### DIFF
--- a/py3status/modules/netdata.py
+++ b/py3status/modules/netdata.py
@@ -123,14 +123,12 @@ class Py3status:
             ],
         }
 
-    def __init__(self):
-        self.old_transmitted = 0
-        self.old_received = 0
-
     def post_config_hook(self):
         """
         Get network interface.
         """
+        self.old_transmitted = 0
+        self.old_received = 0
         if self.nic is None:
             # Get default gateway directly from /proc.
             with open('/proc/net/route') as fh:


### PR DESCRIPTION
Removing `__init__`. Moving things to `post_config_hook` for `netdata`.