### PR TITLE
py3-cmd: add exit if no command

### DIFF
--- a/py3status/command.py
+++ b/py3status/command.py
@@ -290,6 +290,8 @@ def send_command():
 
     if options.command:
         msg = json.dumps(vars(options))
+    else:
+        sys.exit(1)
 
     msg = msg.encode('utf-8')
     if len(msg) > MAX_SIZE:


### PR DESCRIPTION
Bugfix.
```
3d [chris:~] % py3-cmd                     
Traceback (most recent call last):         
  File "/usr/bin/py3-cmd", line 11, in <module>                                       
    sys.exit(send_command())               
  File "/home/chris/src/py3status/py3status/command.py", line 294, in send_command 
    msg = msg.encode('utf-8')
UnboundLocalError: local variable 'msg' referenced before assignment
```