### PR TITLE
fix HttpResponse for when an http error ocurrs

### DIFF
--- a/py3status/request.py
+++ b/py3status/request.py
@@ -63,6 +63,11 @@ class HttpResponse:
             elif isinstance(e, HTTPError):
                 self._status_code = e.code
                 self._error_message = reason
+                # we return an HttpResponse but have no response
+                # so create some 'fake' response data.
+                self._text = ''
+                self._json = None
+                self._headers = []
             else:
                 # unknown exception, so just raise it
                 raise RequestURLError(reason)
@@ -100,13 +105,21 @@ class HttpResponse:
         Return an object representing the return json for the request
         """
         try:
-            return json.loads(self.text)
-        except:
-            raise RequestInvalidJSON('Invalid JSON received')
+            return self._json
+        except AttributeError:
+            try:
+                self._json = json.loads(self.text)
+                return self._json
+            except:
+                raise RequestInvalidJSON('Invalid JSON received')
 
     @property
     def headers(self):
         """
         Get the headers from the response.
         """
-        return self._response.headers
+        try:
+            return self._headers
+        except AttributeError:
+            self._headers = self._response.headers
+            return self._headers


### PR DESCRIPTION
Revisiting the issue of #1052 

Rather than just fixing `exchange_rate` module to not fail, I dug further and found the root cause.

When we do `Py3.request()` we have 3 outcomes.

1. Everything is good we get our `HttpResponse` with all the `.json()` etc

2. We get a timeout or similar and a `RequestException` of some type is raised

3. We have a http error and return a `HttpResponse` with the `status_code` set

In the 3rd option the returned `HttpResponse` fails if attributes `text`, `headers` are queried or the `.json()` method.  This PR allows these to now function as expected. 