### PR TITLE
make Runner threads daemon so they die when we kill py3status

### DIFF
--- a/py3status/core.py
+++ b/py3status/core.py
@@ -48,6 +48,7 @@ class Runner(Thread):
     """
     def __init__(self, module, py3_wrapper):
         Thread.__init__(self)
+        self.daemon = True
         self.module = module
         self.py3_wrapper = py3_wrapper
 


### PR DESCRIPTION
This just allows py3status to be closed/restarted faster.