### PR TITLE
vnstat: use updated command

### DIFF
--- a/py3status/modules/vnstat.py
+++ b/py3status/modules/vnstat.py
@@ -91,7 +91,7 @@ class Py3status:
     def vntstat(self):
         def filter_stat():
             # Get statistics in list of lists of words
-            out = self.py3.command_output(["vnstat", "--dumpdb"]).splitlines()
+            out = self.py3.command_output(["vnstat", "--exportdb"]).splitlines()
             for x in out:
                 if x.startswith("{};0;".format(self.statistics_type)):
                     return x


### PR DESCRIPTION
`vnstat` deprecated `--dumpdb` many years ago in favor of `--exportdb`. Being nice and all, `vnstat` continues to support the old command. Debian stable does not have `--dumpdb` in their man page either. I think we should use the updated command. 