### PR TITLE
Expose total disk space in diskdata module

### DIFF
--- a/py3status/modules/diskdata.py
+++ b/py3status/modules/diskdata.py
@@ -154,7 +154,7 @@ class Py3status:
                 devs.append(data[0])
 
         if total == 0:
-            return free, used, 'err'
+            return free, used, 'err', total
 
         return free, used, 100 * used / total, total
 

--- a/py3status/modules/diskdata.py
+++ b/py3status/modules/diskdata.py
@@ -27,6 +27,7 @@ Format placeholders:
     {disk} the selected disk
     {free} free space on disk in GB
     {used} used space on disk in GB
+    {total_space} total space on disk in GB
     {used_percent} used space on disk in %
     {read} reading rate
     {total} total IO rate
@@ -113,13 +114,15 @@ class Py3status:
             self.py3.threshold_get_color(total, 'total')
             self.py3.threshold_get_color(write, 'write')
 
-        if self.py3.format_contains(self.format, ['free', 'used*']):
-            free, used, used_percent = self._get_free_space(self.disk)
+        if self.py3.format_contains(self.format, ['free', 'used*', 'total_space']):
+            free, used, used_percent, total_space = self._get_free_space(self.disk)
 
             self.values['free'] = self.py3.safe_format(self.format_space, {'value': free})
             self.values['used'] = self.py3.safe_format(self.format_space, {'value': used})
             self.values['used_percent'] = self.py3.safe_format(self.format_space,
                                                                {'value': used_percent})
+            self.values['total_space'] = self.py3.safe_format(self.format_space,
+                                                              {'value': total_space})
             self.py3.threshold_get_color(free, 'free')
             self.py3.threshold_get_color(used, 'used')
 
@@ -153,7 +156,7 @@ class Py3status:
         if total == 0:
             return free, used, 'err'
 
-        return free, used, 100 * used / total
+        return free, used, 100 * used / total, total
 
     def _get_io_stats(self, disk):
         if disk and disk.startswith('/dev/'):


### PR DESCRIPTION
Currently only free, used, and used_percent are exposed. Even though you could infer the total disk space using these values, it's a bit cleaner to just expose the total disk space as well to allow for format strings such as `Disk Usage: {used}/{total_space}GB`