### PR TITLE
only show text of Composite when notifying user

### DIFF
--- a/py3status/composite.py
+++ b/py3status/composite.py
@@ -77,6 +77,12 @@ class Composite:
         """
         return self._content
 
+    def text(self):
+        """
+        Return the text only component of the composite.
+        """
+        return ''.join([x.get('full_text', '') for x in self._content])
+
     def simplify(self):
         """
         Simplify the content of a Composite merging any parts that can be

--- a/py3status/py3.py
+++ b/py3status/py3.py
@@ -496,6 +496,8 @@ class Py3:
         rate_limit is the time period in seconds during which this message
         should not be repeated.
         """
+        if isinstance(msg, Composite):
+            msg = msg.text()
         # force unicode for python2 str
         if self._is_python_2 and isinstance(msg, str):
             msg = msg.decode('utf-8')


### PR DESCRIPTION
A simple fix for #1079

`Py3.notify_user()` only shows the text if it gets a Composite as input