### PR TITLE
github: add support for GitHub Enterprise

### DIFF
--- a/py3status/modules/github.py
+++ b/py3status/modules/github.py
@@ -29,6 +29,12 @@ Configuration parameters:
         '{repo} {issues}/{pull_requests}')*
     format_notifications: Format of `{notification}` status placeholder.
         (default ' N{notifications_count}')
+    github_api_url: Change only if using Enterprise Github to something like
+        https://github.company.com/api/v3.
+        (default 'https://api.github.com')
+    github_url: Change only if using Enterprise Github to somethig like
+        https://github.company.com.
+        (default 'https://github.com/')
     notifications: Type of notifications can be `all` for all notifications or
         `repo` to only get notifications for the repo specified.  If repo is
         not provided then all notifications will be checked.
@@ -37,12 +43,6 @@ Configuration parameters:
         (default 'ultrabug/py3status')
     username: Github username, needed to check notifications.
         (default None)
-    github_api_url: Change only if using Enterprise Github to something like
-        https://github.company.com/api/v3.
-        (default 'https://api.github.com')
-    github_url: Change only if using Enterprise Github to somethig like
-        https://github.company.com.
-        (default 'https://github.com/')
 
 Format placeholders:
     {issues} Number of open issues.
@@ -84,7 +84,6 @@ except ImportError:
     import urllib.parse as urlparse
 
 
-
 class Py3status:
     auth_token = None
     button_action = 3
@@ -92,11 +91,11 @@ class Py3status:
     cache_timeout = 60
     format = None
     format_notifications = ' N{notifications_count}'
+    github_api_url = 'https://api.github.com'
+    github_url = 'https://github.com/'
     notifications = 'all'
     repo = 'ultrabug/py3status'
     username = None
-    github_api_url = 'https://api.github.com'
-    github_url = 'https://github.com/'
 
     def post_config_hook(self):
         self.first = True

--- a/py3status/modules/github.py
+++ b/py3status/modules/github.py
@@ -29,18 +29,16 @@ Configuration parameters:
         '{repo} {issues}/{pull_requests}')*
     format_notifications: Format of `{notification}` status placeholder.
         (default ' N{notifications_count}')
-    github_api_url: Change only if using Enterprise Github to something like
-        https://github.company.com/api/v3.
-        (default 'https://api.github.com')
-    github_url: Change only if using Enterprise Github to somethig like
-        https://github.company.com.
-        (default 'https://github.com/')
     notifications: Type of notifications can be `all` for all notifications or
         `repo` to only get notifications for the repo specified.  If repo is
         not provided then all notifications will be checked.
         (default 'all')
     repo: Github repo to check
         (default 'ultrabug/py3status')
+    url_api: Change only if using Enterprise Github, example https://github.domain.com/api/v3.
+        (default 'https://api.github.com')
+    url_base: Change only if using Enterprise Github, example https://github.domain.com.
+        (default 'https://github.com')
     username: Github username, needed to check notifications.
         (default None)
 
@@ -91,10 +89,10 @@ class Py3status:
     cache_timeout = 60
     format = None
     format_notifications = ' N{notifications_count}'
-    github_api_url = 'https://api.github.com'
-    github_url = 'https://github.com/'
     notifications = 'all'
     repo = 'ultrabug/py3status'
+    url_api = 'https://api.github.com'
+    url_base = 'https://github.com'
     username = None
 
     def post_config_hook(self):

--- a/py3status/modules/github.py
+++ b/py3status/modules/github.py
@@ -37,6 +37,12 @@ Configuration parameters:
         (default 'ultrabug/py3status')
     username: Github username, needed to check notifications.
         (default None)
+    github_api_url: Change only if using Enterprise Github to something like
+        https://github.company.com/api/v3.
+        (default 'https://api.github.com')
+    github_url: Change only if using Enterprise Github to somethig like
+        https://github.company.com.
+        (default 'https://github.com/')
 
 Format placeholders:
     {issues} Number of open issues.
@@ -78,9 +84,6 @@ except ImportError:
     import urllib.parse as urlparse
 
 
-GITHUB_API_URL = 'https://api.github.com'
-GITHUB_URL = 'https://github.com/'
-
 
 class Py3status:
     auth_token = None
@@ -92,6 +95,8 @@ class Py3status:
     notifications = 'all'
     repo = 'ultrabug/py3status'
     username = None
+    github_api_url = 'https://api.github.com'
+    github_url = 'https://github.com/'
 
     def post_config_hook(self):
         self.first = True
@@ -116,7 +121,7 @@ class Py3status:
         """
         if self.first:
             return '?'
-        url = GITHUB_API_URL + url + '&per_page=1'
+        url = self.github_api_url + url + '&per_page=1'
         # if we have authentication details use them as we get better
         # rate-limiting.
         if self.username and self.auth_token:
@@ -148,9 +153,9 @@ class Py3status:
         if self.first:
             return '?'
         if self.notifications == 'all' or not self.repo:
-            url = GITHUB_API_URL + '/notifications'
+            url = self.github_api_url + '/notifications'
         else:
-            url = GITHUB_API_URL + '/repos/' + self.repo + '/notifications'
+            url = self.github_api_url + '/repos/' + self.repo + '/notifications'
         url += '?per_page=100'
         try:
             info = self.py3.request(url, timeout=10,
@@ -242,14 +247,14 @@ class Py3status:
             # open github in browser
             if self._notify and self._notify != '?':
                 # open github notifications page
-                url = GITHUB_URL + 'notifications'
+                url = self.github_url + 'notifications'
             else:
                 if self.notifications == 'all' and not self.repo:
                     # open github.com if there are no unread notifications and no repo
-                    url = GITHUB_URL
+                    url = self.github_url
                 else:
                     # open repo page if there are no unread notifications
-                    url = GITHUB_URL + self.repo
+                    url = self.github_url + self.repo
             # open url in default browser
             self.py3.command_run('xdg-open {}'.format(url))
             self.py3.prevent_refresh()


### PR DESCRIPTION
Adding support for GitHub Enterprise by making the GitHub URLs configurable by the end user.