### PR TITLE
Clear clipboard onclick and optional log (xsel)

### DIFF
--- a/py3status/modules/xsel.py
+++ b/py3status/modules/xsel.py
@@ -22,9 +22,6 @@ Requires:
 @author Sublim3 umbsublime@gamil.com
 @license BSD
 
-SAMPLE OUTPUT
-{'full_text': 'selected text'}
-
 Example:
 xsel {
   max_size = 50
@@ -32,6 +29,9 @@ xsel {
   on_click 1 = "exec xsel --clear --clipboard"
   log_file = "~/.local/share/xsel/clipboard_log"
 }
+
+SAMPLE OUTPUT
+{'full_text': 'selected text'}
 """
 
 

--- a/py3status/modules/xsel.py
+++ b/py3status/modules/xsel.py
@@ -13,8 +13,7 @@ Configuration parameters:
     max_size: strip the selection to this value (default 15)
     symmetric: show beginning and end of the selection string
         with respect to configured max_size. (default True)
-    log_file: where to log the clipboard, default doesn't log at all
-        (default None)
+    log_file: specify the clipboard log to use (default None)
 
 Format placeholders:
     {selection} output from clipboard command

--- a/py3status/modules/xsel.py
+++ b/py3status/modules/xsel.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-import re
 import time
 """
 Display X selection.
@@ -55,7 +54,7 @@ class Py3status:
                 f.write("{}\n{}\n".format(datetime, selection))
         self.selection_cache = selection
 
-        selection = re.sub(r"\s+", " ", selection)  # merge whitespace into one
+        selection = ' '.join(selection.split())
         if len(selection) >= self.max_size:
             if self.symmetric is True:
                 split = int(self.max_size / 2) - 1

--- a/py3status/modules/xsel.py
+++ b/py3status/modules/xsel.py
@@ -30,6 +30,7 @@ xsel {
   max_size = 50
   command = "xsel --clipboard --output"
   on_click 1 = "exec xsel --clear --clipboard"
+  log_file = "~/.local/share/xsel/clipboard_log"
 }
 """
 

--- a/py3status/modules/xsel.py
+++ b/py3status/modules/xsel.py
@@ -6,7 +6,7 @@ Display X selection.
 
 Configuration parameters:
     cache_timeout: refresh interval for this module (default 0.5)
-    command: the clipboard command to run (default 'xsel -output')
+    command: the clipboard command to run (default 'xsel --output')
     click_command: the clipboard command to run on click
         (default 'xsel --clear --clipboard')
     format: display format for this module (default '{selection}')
@@ -38,7 +38,7 @@ class Py3status:
     """
     # available configuration parameters
     cache_timeout = 0.5
-    command = 'xsel -output'
+    command = 'xsel --output'
     click_command = 'xsel --clear --clipboard'
     format = '{selection}'
     max_size = 15

--- a/py3status/modules/xsel.py
+++ b/py3status/modules/xsel.py
@@ -6,8 +6,6 @@ Display X selection.
 Configuration parameters:
     cache_timeout: refresh interval for this module (default 0.5)
     command: the clipboard command to run (default 'xsel --output')
-    click_command: the clipboard command to run on click
-        (default 'xsel --clear --clipboard')
     format: display format for this module (default '{selection}')
     max_size: strip the selection to this value (default 15)
     symmetric: show beginning and end of the selection string
@@ -26,8 +24,12 @@ Requires:
 SAMPLE OUTPUT
 {'full_text': 'selected text'}
 
-example
-{'full_text': 'rrrrr > wtf is a warlock doing in here'}
+Example:
+xsel {
+  max_size = 50
+  command = "xsel --clipboard --output"
+  on_click 1 = "exec xsel --clear --clipboard"
+}
 """
 
 
@@ -37,7 +39,6 @@ class Py3status:
     # available configuration parameters
     cache_timeout = 0.5
     command = 'xsel --output'
-    click_command = 'xsel --clear --clipboard'
     format = '{selection}'
     max_size = 15
     symmetric = True
@@ -65,9 +66,6 @@ class Py3status:
             'cached_until': self.py3.time_in(self.cache_timeout),
             'full_text': self.py3.safe_format(self.format, {'selection': selection})
         }
-
-    def on_click(self, event):
-        self.py3.command_output(self.click_command)
 
 
 if __name__ == "__main__":

--- a/py3status/modules/xsel.py
+++ b/py3status/modules/xsel.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 import time
+import os
 """
 Display X selection.
 
@@ -44,7 +45,9 @@ class Py3status:
     symmetric = True
     log_file = None
 
-    selection_cache = None
+    def post_config_hook(self):
+        self.selection_cache = None
+        self.log_file = os.path.expanduser(self.log_file)
 
     def xsel(self):
         selection = self.py3.command_output(self.command).strip()

--- a/py3status/modules/xsel.py
+++ b/py3status/modules/xsel.py
@@ -1,14 +1,20 @@
 # -*- coding: utf-8 -*-
+import re
+import time
 """
 Display X selection.
 
 Configuration parameters:
     cache_timeout: refresh interval for this module (default 0.5)
-    command: the clipboard command to run (default 'xsel -o')
+    command: the clipboard command to run (default 'xsel -output')
+    click_command: the clipboard command to run on click
+        (default 'xsel --clear --clipboard')
     format: display format for this module (default '{selection}')
     max_size: strip the selection to this value (default 15)
     symmetric: show beginning and end of the selection string
         with respect to configured max_size. (default True)
+    log_file: where to log the clipboard, default doesn't log at all
+        (default None)
 
 Format placeholders:
     {selection} output from clipboard command
@@ -32,13 +38,25 @@ class Py3status:
     """
     # available configuration parameters
     cache_timeout = 0.5
-    command = 'xsel -o'
+    command = 'xsel -output'
+    click_command = 'xsel --clear --clipboard'
     format = '{selection}'
     max_size = 15
     symmetric = True
+    log_file = None
+
+    selection_cache = None
 
     def xsel(self):
-        selection = ' '.join(self.py3.command_output(self.command).split())
+        selection = self.py3.command_output(self.command).strip()
+
+        if self.log_file and selection and selection != self.selection_cache:
+            with open(self.log_file, "a") as f:
+                datetime = time.strftime("%Y-%m-%d %H:%M:%S")
+                f.write("{}\n{}\n".format(datetime, selection))
+        self.selection_cache = selection
+
+        selection = re.sub(r"\s+", " ", selection)  # merge whitespace into one
         if len(selection) >= self.max_size:
             if self.symmetric is True:
                 split = int(self.max_size / 2) - 1
@@ -49,6 +67,9 @@ class Py3status:
             'cached_until': self.py3.time_in(self.cache_timeout),
             'full_text': self.py3.safe_format(self.format, {'selection': selection})
         }
+
+    def on_click(self, event):
+        self.py3.command_output(self.click_command)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
I don't like old string lying around in my clipboard visible all the time and if it is a password even more so. That is why you can now click the string to clear it out.
To not lose the old copied strings one can optionally turn on logging.