### PR TITLE
Fix xrandr_rotate module

### DIFF
--- a/py3status/py3.py
+++ b/py3status/py3.py
@@ -857,8 +857,8 @@ class Py3:
 
         An Exception is raised if an error occurs
         """
-        # convert the command to sequence if a string
-        if isinstance(command, basestring):
+        # convert the non-shell command to sequence if it is a string
+        if not shell and isinstance(command, basestring):
             command = shlex.split(command)
         try:
             process = Popen(command, stdout=PIPE, stderr=PIPE, close_fds=True,


### PR DESCRIPTION
The module is totally broken now. Because since `cmd` is a string, and because we rely on shell (like pipe and grep), py3.command_output() will `shlex.split` it, and the command becomes invalid.

https://github.com/ultrabug/py3status/blob/c63d7fccfd0789d590a0f20c5bca3341423b0cdb/py3status/py3.py#L861-L865

Until the module is rewritten without relying on the shell, I'm wrapping it in an array so `shlex.split` is not being applied on the command.

I haven't been using this module for a while, so it could have been broken for a long time already 🙂