### PR TITLE
mpris: deprecate build_composite

### DIFF
--- a/py3status/modules/mpris.py
+++ b/py3status/modules/mpris.py
@@ -530,9 +530,7 @@ class Py3status:
             (text, color, cached_until) = self._get_text()
             self._control_states = self._get_control_states()
             buttons = self._get_response_buttons()
-            composite = self.py3.build_composite(self.format,
-                                                 text,
-                                                 buttons)
+            composite = self.py3.safe_format(self.format, dict(text, **buttons))
 
         if self._kill:
             raise KeyboardInterrupt


### PR DESCRIPTION
Deprecating `build_composite` in favor of `safe_format` for `mpris`.
```
.../py3status/py3.py
--------------------
def build_composite(self, format_string, param_dict=None,
                    composites=None, attr_getter=None):
    """
    .. note::
        deprecated in 3.3 use safe_format().
```

