### PR TITLE
parse_config: onclick accepts number 1-20

### DIFF
--- a/py3status/parse_config.py
+++ b/py3status/parse_config.py
@@ -569,13 +569,13 @@ def process_config(config_path, py3_wrapper=None):
         button = ''
         try:
             button = key.split()[1]
-            if int(button) not in range(1, 6):
+            if int(button) not in range(1, 20):
                 button_error = True
         except (ValueError, IndexError):
-                button_error = True
+            button_error = True
 
         if button_error:
-            err = 'Invalid on_click for `{}` should be 1, 2, 3, 4 or 5 saw `{}`'
+            err = 'Invalid on_click for `{}`. Number not in range 1-20: `{}`.'
             notify_user(err.format(group_name, button))
             return False
         clicks = on_click.setdefault(group_name, {})


### PR DESCRIPTION
We remove hardcoded `not in range(1, 6)` to accept any integer number. Users with this kind of mouse will be able to use `10`, `15`, or `19` if they want to. This works fine with my `8`, `9` (back, forward).

![mouse-buttons](https://user-images.githubusercontent.com/852504/31076208-bd06dc68-a73e-11e7-8841-ed5876e65fd2.jpg)