### PR TITLE
graphite: use post_config_hook

### DIFF
--- a/py3status/modules/graphite.py
+++ b/py3status/modules/graphite.py
@@ -102,6 +102,9 @@ class Py3status:
     value_format = True
     value_round = True
 
+    def post_config_hook(self):
+        self._validate_config()
+
     def _reset_notifications(self):
         """
         """
@@ -219,7 +222,6 @@ class Py3status:
     def graphite(self):
         """
         """
-        self._validate_config()
         self._reset_notifications()
 
         color_key, r_json = self._render_graphite_json()


### PR DESCRIPTION
We can validate the config once in `post_config_hook` instead of the loop to optimally reduce cycles if applicable. There could be some other things to tweak, but likely not something for us to toy with.