### PR TITLE
taskwarrior: make the command customizable

### DIFF
--- a/py3status/modules/taskwarrior.py
+++ b/py3status/modules/taskwarrior.py
@@ -5,6 +5,8 @@ Display tasks currently running in taskwarrior.
 Configuration parameters:
     cache_timeout: refresh interval for this module (default 5)
     format: display format for this module (default '{task}')
+    task_args: arguments passed to the command
+        (default 'start.before:today status:pending')
 
 Format placeholders:
     {task} active tasks
@@ -29,6 +31,7 @@ class Py3status:
     # available configuration parameters
     cache_timeout = 5
     format = '{task}'
+    task_args = 'start.before:today status:pending'
 
     def post_config_hook(self):
         if not self.py3.check_commands('task'):
@@ -38,7 +41,7 @@ class Py3status:
         def describeTask(taskObj):
             return str(taskObj['id']) + ' ' + taskObj['description']
 
-        task_command = 'task start.before:tomorrow status:pending export'
+        task_command = 'task ' + self.task_args + ' export'
         task_json = json.loads(self.py3.command_output(task_command))
         task_result = ', '.join(map(describeTask, task_json))
         return {

--- a/py3status/modules/taskwarrior.py
+++ b/py3status/modules/taskwarrior.py
@@ -4,9 +4,9 @@ Display tasks currently running in taskwarrior.
 
 Configuration parameters:
     cache_timeout: refresh interval for this module (default 5)
-    format: display format for this module (default '{task}')
     filter: arguments passed to the command
         (default 'start.before:today status:pending')
+    format: display format for this module (default '{task}')
 
 Format placeholders:
     {task} active tasks
@@ -30,8 +30,8 @@ class Py3status:
     """
     # available configuration parameters
     cache_timeout = 5
-    format = '{task}'
     filter = 'start.before:today status:pending'
+    format = '{task}'
 
     def post_config_hook(self):
         if not self.py3.check_commands('task'):

--- a/py3status/modules/taskwarrior.py
+++ b/py3status/modules/taskwarrior.py
@@ -30,7 +30,7 @@ class Py3status:
     """
     # available configuration parameters
     cache_timeout = 5
-    filter = 'start.before:today status:pending'
+    filter = 'status:pending'
     format = '{task}'
 
     def post_config_hook(self):

--- a/py3status/modules/taskwarrior.py
+++ b/py3status/modules/taskwarrior.py
@@ -41,7 +41,10 @@ class Py3status:
         def describeTask(taskObj):
             return str(taskObj['id']) + ' ' + taskObj['description']
 
-        filter = self.filter if self.filter is not None else ''
+        if self.filter:
+            task_command = 'task %s export' % self.filter
+        else:
+            task_command = 'task export'
         task_command = 'task %s export' % filter
         task_json = json.loads(self.py3.command_output(task_command))
         task_result = ', '.join(map(describeTask, task_json))

--- a/py3status/modules/taskwarrior.py
+++ b/py3status/modules/taskwarrior.py
@@ -41,7 +41,7 @@ class Py3status:
         def describeTask(taskObj):
             return str(taskObj['id']) + ' ' + taskObj['description']
 
-        task_command = 'task ' + self.filter + ' export'
+        task_command = 'task %s export' % self.filter
         task_json = json.loads(self.py3.command_output(task_command))
         task_result = ', '.join(map(describeTask, task_json))
         return {

--- a/py3status/modules/taskwarrior.py
+++ b/py3status/modules/taskwarrior.py
@@ -41,7 +41,8 @@ class Py3status:
         def describeTask(taskObj):
             return str(taskObj['id']) + ' ' + taskObj['description']
 
-        task_command = 'task %s export' % self.filter
+        filter = self.filter if self.filter is not None else ''
+        task_command = 'task %s export' % filter
         task_json = json.loads(self.py3.command_output(task_command))
         task_result = ', '.join(map(describeTask, task_json))
         return {

--- a/py3status/modules/taskwarrior.py
+++ b/py3status/modules/taskwarrior.py
@@ -5,7 +5,7 @@ Display tasks currently running in taskwarrior.
 Configuration parameters:
     cache_timeout: refresh interval for this module (default 5)
     format: display format for this module (default '{task}')
-    task_args: arguments passed to the command
+    filter: arguments passed to the command
         (default 'start.before:today status:pending')
 
 Format placeholders:
@@ -31,7 +31,7 @@ class Py3status:
     # available configuration parameters
     cache_timeout = 5
     format = '{task}'
-    task_args = 'start.before:today status:pending'
+    filter = 'start.before:today status:pending'
 
     def post_config_hook(self):
         if not self.py3.check_commands('task'):
@@ -41,7 +41,7 @@ class Py3status:
         def describeTask(taskObj):
             return str(taskObj['id']) + ' ' + taskObj['description']
 
-        task_command = 'task ' + self.task_args + ' export'
+        task_command = 'task ' + self.filter + ' export'
         task_json = json.loads(self.py3.command_output(task_command))
         task_result = ', '.join(map(describeTask, task_json))
         return {

--- a/py3status/modules/taskwarrior.py
+++ b/py3status/modules/taskwarrior.py
@@ -45,7 +45,6 @@ class Py3status:
             task_command = 'task %s export' % self.filter
         else:
             task_command = 'task export'
-        task_command = 'task %s export' % filter
         task_json = json.loads(self.py3.command_output(task_command))
         task_result = ', '.join(map(describeTask, task_json))
         return {


### PR DESCRIPTION
Add a new `task_args` to the `taskwarrior` module to allow customizing the arguments passed to the `task` executable.