### PR TITLE
xrandr_rotate: run command once

### DIFF
--- a/py3status/modules/xrandr_rotate.py
+++ b/py3status/modules/xrandr_rotate.py
@@ -82,9 +82,10 @@ class Py3status:
         else:
             rotation = self.vertical_rotation
         outputs = [self.screen] if self.screen else self._get_all_outputs()
+        cmd = 'xrandr'
         for output in outputs:
-            cmd = 'xrandr --output ' + output + ' --rotate ' + rotation
-            self.py3.command_run(cmd)
+            cmd += ' --output %s --rotate %s' % (output, rotation)
+        self.py3.command_run(cmd)
 
     def _switch_selection(self):
         if self.displayed == self.horizontal_icon:


### PR DESCRIPTION
Excerpted from the log...
```
INFO Module `xr`: ---------- RUNNING ----------
INFO Module `xr`: xrandr --output DP-2 --rotate left
INFO Module `xr`: ---------- RUNNING -------
INFO Module `xr`: ---------- RUNNING ----------
INFO Module `xr`: xrandr --output DP-3 --rotate left
INFO Module `xr`: ---------- RUNNING ----------
```

```
INFO Module `xr`: ---------- RUNNING ----------
INFO Module `xr`: xrandr --output DP-2 --rotate normal --output DP-3 --rotate normal
INFO Module `xr`: ---------- RUNNING ----------
```

Enuff said.

Okay, maybe not. I have two monitors. This will always run the `xrandr` command once instead of once, twice, thrice, etc. Somebody out there have six monitors. Poor soul. This removes flickering too.