### PR TITLE
 xrandr_rotate:  fix orientation

### DIFF
--- a/py3status/modules/xrandr_rotate.py
+++ b/py3status/modules/xrandr_rotate.py
@@ -34,7 +34,7 @@ Color options:
     color_degraded: Screen is disconnected
     color_good: Displayed rotation is active
 
-@author Maxim Baz (https://github.com/maximbaz) @contributor lasers
+@author Maxim Baz (https://github.com/maximbaz), @lasers
 @license BSD
 
 SAMPLE OUTPUT

--- a/py3status/modules/xrandr_rotate.py
+++ b/py3status/modules/xrandr_rotate.py
@@ -66,14 +66,15 @@ class Py3status:
         return [x.split()[0] for x in outputs if ' connected' in x]
 
     def _get_current_rotation_icon(self, all_outputs):
-        output = self.screen or all_outputs[0]
         data = self.py3.command_output(['xrandr']).splitlines()
-        orientation = ''.join(
-            [x.split()[3] for x in data if x.startswith(output)])
-        # xrandr may skip 'normal' so we check if it starts with '(' too
-        is_horizontal = (orientation.startswith('(') or
-                         orientation in ['normal', 'inverted'])
-        return self.horizontal_icon if is_horizontal else self.vertical_icon
+        output = self.screen or all_outputs[0]
+        output_line = ''.join([x for x in data if x.startswith(output)])
+
+        for x in output_line.split():
+            if 'normal' in x or 'inverted' in x:
+                return self.horizontal_icon
+            elif 'left' in x or 'right' in x:
+                return self.vertical_icon
 
     def _apply(self):
         if self.displayed == self.horizontal_icon:

--- a/py3status/modules/xrandr_rotate.py
+++ b/py3status/modules/xrandr_rotate.py
@@ -34,7 +34,7 @@ Color options:
     color_degraded: Screen is disconnected
     color_good: Displayed rotation is active
 
-@author Maxim Baz (https://github.com/maximbaz)
+@author Maxim Baz (https://github.com/maximbaz) @contributor lasers
 @license BSD
 
 SAMPLE OUTPUT
@@ -62,17 +62,17 @@ class Py3status:
         self.displayed = ''
 
     def _get_all_outputs(self):
-        cmd = 'xrandr -q | grep " connected [^(]" | cut -d " " -f1'
-        return self.py3.command_output(cmd, shell=True).splitlines()
+        outputs = self.py3.command_output(['xrandr']).splitlines()
+        return [x.split()[0] for x in outputs if ' connected' in x]
 
     def _get_current_rotation_icon(self, all_outputs):
         output = self.screen or all_outputs[0]
-        cmd = 'xrandr -q | grep "^' + output + '" | cut -d " " -f4'
-        output = self.py3.command_output(cmd, shell=True).strip()
-        # xrandr may skip printing the 'normal', in which case the output would
-        # start from '('
-        is_horizontal = (output.startswith('(') or
-                         output in ['normal', 'inverted'])
+        data = self.py3.command_output(['xrandr']).splitlines()
+        orientation = ''.join(
+            [x.split()[3] for x in data if x.startswith(output)])
+        # xrandr may skip 'normal' so we check if it starts with '(' too
+        is_horizontal = (orientation.startswith('(') or
+                         orientation in ['normal', 'inverted'])
         return self.horizontal_icon if is_horizontal else self.vertical_icon
 
     def _apply(self):


### PR DESCRIPTION
Hi. I studied the code. This fixes https://github.com/ultrabug/py3status/issues/837. Please merge https://github.com/ultrabug/py3status/pull/1103 first. 👍 

**ORIENTATION** 

I shared this in the bug report.
```
I expected green `H` for using landscape monitor.
I received green `V` instead.
```

We received green `V` instead because of this biased statement...
```
       is_horizontal = (orientation.startswith('(') or
                        orientation in ['normal', 'inverted'])
       return self.horizontal_icon if is_horizontal else self.vertical_icon
```

We get `self.vertical_icon` when it does not match `normal` or `inverted`. This also returns `V` on the empty lines and even on `(normal` too. I likely got empty lines based on the initial report.
```
xrandr: Output DP-3 is not disconnected but has no modes
xrandr: Output DP-3 is not disconnected but has no modes
xrandr: Output DP-3 is not disconnected but has no modes
```
Anyhow, now we explicitly check for `normal`, `inverted`, `left`, and `right` using `split()`, `in`, and `loop` to find the first match instead of `data[3]` as it could be wrong (ie, somebody uses `primary`) putting it in a different `split()` location. That may be the reason for the `(` checking.

**???**

```
    full_text = self.py3.safe_format(self.format,
                                     dict(icon=self.displayed or '?',
                                          screen=screen))
```
I don't think we can get `?` here because of `V` above. With this merged, we can get `?` now.

**COLOR** 

The reason we get `green` V is because of this...

```
        if not self.displayed:
            self.displayed = self._get_current_rotation_icon(all_outputs)
```
... and later... 
```
    elif self.displayed == self._get_current_rotation_icon(all_outputs):
        response['color'] = self.py3.COLOR_GOOD
```

Short explanation. We give the value from function to `self.displayed` then we checked the value against the same function. Boom. Same thing. Make it green. 💚 

This fixes the orientation. In doing so, we fixed `?` too... but not the color. There are other things too that could be addressed. We deal with https://github.com/ultrabug/py3status/issues/837 first. 💯 Please merge https://github.com/ultrabug/py3status/pull/1103. 👍 Ty.