### PR TITLE
Add YubiKey module (show a visible indication that YubiKey is waiting for a touch)

### DIFF
--- a/py3status/modules/yubikey.py
+++ b/py3status/modules/yubikey.py
@@ -19,11 +19,10 @@ Control placeholders:
 SAMPLE OUTPUT
 {'color': '#00FF00', 'full_text': 'YubiKey'}
 
-Dependencies:
-    gpg: to check for pending gpg access request
-    inotify-simple: to check for pending gpg and u2f requests
-    github.com/maximbaz/pam-u2f: a fork that adds watch capability to pam-u2f module
-    subprocess32: if after all these years you are still using python2
+Requires:
+    inotify-simple: (for gpg and u2f) to check for requests
+    github.com/maximbaz/pam-u2f: (for u2f) a fork that adds watch capability to pam-u2f module
+    subprocess32: (for gpg) needed only if after all these years you are still using python2
 
 @author Maxim Baz (https://github.com/maximbaz)
 @license BSD

--- a/py3status/modules/yubikey.py
+++ b/py3status/modules/yubikey.py
@@ -10,7 +10,7 @@ Configuration parameters:
         (default 0.1)
     gpg_check_watch_paths: A list of files to watch, start gpg check if any one was opened.
         (default ['~/.gnupg/pubring.kbx', '~/.ssh/known_hosts'])
-    sudo_check_watch_paths: A list of files to watch, toggle sudo check if any one was opened.
+    u2f_check_watch_paths: A list of files to watch, toggle u2f check if any one was opened.
         (default ['~/.config/Yubico/u2f_keys'])
 
 Control placeholders:
@@ -21,7 +21,7 @@ SAMPLE OUTPUT
 
 Dependencies:
     gpg: to check for pending gpg access request
-    inotify-simple: to check for pending gpg and sudo requests
+    inotify-simple: to check for pending gpg and u2f requests
     github.com/maximbaz/pam-u2f: a fork that adds watch capability to pam-u2f module
     subprocess32: if after all these years you are still using python2
 
@@ -42,6 +42,96 @@ else:
     import subprocess
 
 
+class GpgWatchingThread(threading.Thread):
+    """
+    A thread watchng if YubiKey is waiting for a touch for gpg access
+    """
+
+    def __init__(self, parent):
+        super(GpgWatchingThread, self).__init__()
+        self.parent = parent
+
+    def _check_card_status(self):
+        return subprocess.Popen(
+            'gpg --no-tty --card-status',
+            shell=True,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            preexec_fn=os.setsid)
+
+    def _set_pending(self, new_value):
+        self.parent.pending_gpg = new_value
+        if not self.parent.pending_u2f:
+            self.parent.py3.update()
+
+    def run(self):
+        inotify = inotify_simple.INotify()
+        watches = []
+        for path in self.parent.gpg_check_watch_paths:
+            if os.path.isfile(path):
+                watch = inotify.add_watch(path, inotify_simple.flags.OPEN)
+                watches.append(watch)
+
+        while not self.parent.killed.is_set():
+            for event in inotify.read():
+                # e.g. ssh doesn't start immediately, try several seconds to be sure
+                for i in range(20):
+                    with self._check_card_status() as check:
+                        try:
+                            # if this doesn't return very quickly, touch is pending
+                            check.communicate(
+                                timeout=self.parent.gpg_check_timeout)
+                            time.sleep(0.25)
+                        except subprocess.TimeoutExpired:
+                            self._set_pending(True)
+                            os.killpg(check.pid, signal.SIGINT)
+                            check.communicate()
+                            # wait until device is touched
+                            with self._check_card_status() as wait:
+                                wait.communicate()
+                                self._set_pending(False)
+                                break
+
+                # ignore all events caused by operations above
+                for _ in inotify.read():
+                    pass
+
+        for watch in watches:
+            inotify.rm_watch(watch)
+
+
+class U2fWatchingThread(threading.Thread):
+    """
+    A thread watchng if YubiKey is waiting for a touch for u2f access
+    """
+
+    def __init__(self, parent):
+        super(U2fWatchingThread, self).__init__()
+        self.parent = parent
+
+    def _set_pending(self, new_value):
+        self.parent.pending_u2f = new_value
+        if not self.parent.pending_gpg:
+            self.parent.py3.update()
+
+    def run(self):
+        inotify = inotify_simple.INotify()
+        watches = []
+        for path in self.parent.u2f_check_watch_paths:
+            if os.path.isfile(path):
+                watch = inotify.add_watch(path, inotify_simple.flags.OPEN)
+                watches.append(watch)
+
+        while not self.parent.killed.is_set():
+            for event in inotify.read():
+                self._set_pending(True)
+                for event in inotify.read():
+                    self._set_pending(False)
+
+        for watch in watches:
+            inotify.rm_watch(watch)
+
+
 class Py3status:
     """
     """
@@ -49,103 +139,29 @@ class Py3status:
     format = '\?if=is_waiting YubiKey'
     gpg_check_timeout = 0.1
     gpg_check_watch_paths = ['~/.gnupg/pubring.kbx', '~/.ssh/known_hosts']
-    sudo_check_watch_paths = ['~/.config/Yubico/u2f_keys']
+    u2f_check_watch_paths = ['~/.config/Yubico/u2f_keys']
 
     def post_config_hook(self):
         self.gpg_check_watch_paths = [
             os.path.expanduser(p) for p in self.gpg_check_watch_paths
         ]
-        self.sudo_check_watch_paths = [
-            os.path.expanduser(p) for p in self.sudo_check_watch_paths
+        self.u2f_check_watch_paths = [
+            os.path.expanduser(p) for p in self.u2f_check_watch_paths
         ]
 
         self.killed = threading.Event()
 
         self.pending_gpg = False
-        self.pending_sudo = False
-
-        class GpgThread(threading.Thread):
-            def _check_card_status(this):
-                return subprocess.Popen(
-                    'gpg --no-tty --card-status',
-                    shell=True,
-                    stdout=subprocess.DEVNULL,
-                    stderr=subprocess.DEVNULL,
-                    preexec_fn=os.setsid)
-
-            def _set_pending(this, new_value):
-                self.pending_gpg = new_value
-                if not self.pending_sudo:
-                    self.py3.update()
-
-            def run(this):
-                inotify = inotify_simple.INotify()
-                watches = []
-                for path in self.gpg_check_watch_paths:
-                    if os.path.isfile(path):
-                        watch = inotify.add_watch(path,
-                                                  inotify_simple.flags.OPEN)
-                        watches.append(watch)
-
-                while not self.killed.is_set():
-                    for event in inotify.read():
-                        # e.g. ssh doesn't start immediately, try several seconds to be sure
-                        for i in range(20):
-                            with this._check_card_status() as check:
-                                try:
-                                    # if this doesn't return very quickly, touch is pending
-                                    check.communicate(
-                                        timeout=self.gpg_check_timeout)
-                                    time.sleep(0.25)
-                                except subprocess.TimeoutExpired:
-                                    this._set_pending(True)
-                                    os.killpg(check.pid, signal.SIGINT)
-                                    check.communicate()
-                                    # wait until device is touched
-                                    with this._check_card_status() as wait:
-                                        wait.communicate()
-                                        this._set_pending(False)
-                                        break
-
-                        # ignore all events caused by operations above
-                        for _ in inotify.read():
-                            pass
-
-                for watch in watches:
-                    inotify.rm_watch(watch)
-
-        class SudoThread(threading.Thread):
-            def _set_pending(this, new_value):
-                self.pending_sudo = new_value
-                if not self.pending_gpg:
-                    self.py3.update()
-
-            def run(this):
-                inotify = inotify_simple.INotify()
-                watches = []
-                for path in self.sudo_check_watch_paths:
-                    if os.path.isfile(path):
-                        watch = inotify.add_watch(path,
-                                                  inotify_simple.flags.OPEN)
-                        watches.append(watch)
-
-                while not self.killed.is_set():
-                    for event in inotify.read():
-                        this._set_pending(True)
-                        for event in inotify.read():
-                            this._set_pending(False)
-
-                for watch in watches:
-                    inotify.rm_watch(watch)
+        self.pending_u2f = False
 
         if len(self.gpg_check_watch_paths) > 0:
-            GpgThread().start()
+            GpgWatchingThread(self).start()
 
-        if len(self.sudo_check_watch_paths) > 0:
-            SudoThread().start()
+        if len(self.u2f_check_watch_paths) > 0:
+            U2fWatchingThread(self).start()
 
     def yubikey(self):
-        is_waiting = self.pending_gpg or self.pending_sudo
+        is_waiting = self.pending_gpg or self.pending_u2f
         format_params = {'is_waiting': is_waiting}
         response = {
             'cached_until': self.py3.CACHE_FOREVER,

--- a/py3status/modules/yubikey.py
+++ b/py3status/modules/yubikey.py
@@ -93,7 +93,7 @@ class Py3status:
             'cached_until': self.py3.CACHE_FOREVER,
             'full_text': self.py3.safe_format(self.format, self.status),
         }
-        if any([waiting for waiting in self.status.values()]):
+        if any(self.status.values()):
             response['urgent'] = True
         return response
 

--- a/py3status/modules/yubikey.py
+++ b/py3status/modules/yubikey.py
@@ -4,7 +4,7 @@ Show an indicator when YubiKey is waiting for a touch.
 
 Configuration parameters:
     format: Display format for the module.
-        (default '[\?if=is_gpg YubiKey][\?if=is_u2f YubiKey]')
+        (default '[YubiKey[\?if=is_gpg ][\?if=is_u2f ]]')
     socket_path: A path to the yubikey-touch-detector socket file.
         (default '$XDG_RUNTIME_DIR/yubikey-touch-detector.socket')
 
@@ -80,7 +80,7 @@ class Py3status:
     """
     """
     # available configuration parameters
-    format = '[\?if=is_gpg YubiKey][\?if=is_u2f YubiKey]'
+    format = '[YubiKey[\?if=is_gpg ][\?if=is_u2f ]]'
     socket_path = '$XDG_RUNTIME_DIR/yubikey-touch-detector.socket'
 
     def post_config_hook(self):

--- a/py3status/modules/yubikey.py
+++ b/py3status/modules/yubikey.py
@@ -51,9 +51,11 @@ class YubiKeyTouchDetectorListener(threading.Thread):
         while not self.parent.killed.is_set():
             self._connect_socket()
 
+            # Refresh once to show or clear error as needed
+            self.parent.py3.update()
+
             if self.socket is None:
-                # Socket is not available, show error and try again soon
-                self.parent.py3.update()
+                # Socket is not available, try again soon
                 time.sleep(60)
                 continue
 
@@ -95,7 +97,8 @@ class Py3status:
 
     def yubikey(self):
         if self.error:
-            raise self.error
+            self.py3.error(str(self.error), self.py3.CACHE_FOREVER)
+
         response = {
             'cached_until': self.py3.CACHE_FOREVER,
             'full_text': self.py3.safe_format(self.format, self.status),

--- a/py3status/modules/yubikey.py
+++ b/py3status/modules/yubikey.py
@@ -6,7 +6,7 @@ Configuration parameters:
     cache_timeout: How often to detect a pending touch request.
         (default 1)
     format: Display format for the module.
-        (default '\?if=is_waiting&color=bad Y')
+        (default '\?if=is_waiting Touch YubiKey')
     u2f_keys_path: Full path to u2f_keys if you want to monitor sudo access.
         (default '~/.config/Yubico/u2f_keys')
 
@@ -40,7 +40,7 @@ class Py3status:
     """
     # available configuration parameters
     cache_timeout = 1
-    format = '\?if=is_waiting&color=bad Y'
+    format = '\?if=is_waiting Touch YubiKey'
     u2f_keys_path = '~/.config/Yubico/u2f_keys'
 
     def post_config_hook(self):
@@ -98,11 +98,11 @@ class Py3status:
 
     def yubikey(self):
         is_waiting = self.pending_gpg or self.pending_sudo
+        format_params = {'is_waiting': is_waiting}
         response = {
-            'cached_until':
-            self.py3.time_in(self.cache_timeout),
-            'full_text':
-            self.py3.safe_format(self.format, {'is_waiting': is_waiting})
+            'cached_until': self.py3.time_in(self.cache_timeout),
+            'full_text': self.py3.safe_format(self.format, format_params),
+            'urgent': is_waiting
         }
         return response
 

--- a/py3status/modules/yubikey.py
+++ b/py3status/modules/yubikey.py
@@ -12,14 +12,14 @@ Control placeholders:
     {is_gpg} a boolean, True if YubiKey is waiting for a touch due to a gpg operation.
     {is_u2f} a boolean, True if YubiKey is waiting for a touch due to a pam-u2f request.
 
-SAMPLE OUTPUT
-{'full_text': 'YubiKey', 'urgent': True}
-
 Requires:
     github.com/maximbaz/yubikey-touch-detector: tool to detect when YubiKey is waiting for a touch
 
 @author Maxim Baz (https://github.com/maximbaz)
 @license BSD
+
+SAMPLE OUTPUT
+{'full_text': 'YubiKey', 'urgent': True}
 """
 
 import time
@@ -59,13 +59,13 @@ class YubikeyTouchDetectorListener(threading.Thread):
                     # Connection dropped, need to reconnect
                     break
                 elif data == b"GPG_1":
-                    self.parent.is_waiting_gpg = True
+                    self.parent.is_gpg = True
                 elif data == b"GPG_0":
-                    self.parent.is_waiting_gpg = False
+                    self.parent.is_gpg = False
                 elif data == b"U2F_1":
-                    self.parent.is_waiting_u2f = True
+                    self.parent.is_u2f = True
                 elif data == b"U2F_0":
-                    self.parent.is_waiting_u2f = False
+                    self.parent.is_u2f = False
                 self.parent.py3.update()
 
 
@@ -82,21 +82,21 @@ class Py3status:
 
         self.killed = threading.Event()
 
-        self.is_waiting_gpg = False
-        self.is_waiting_u2f = False
+        self.is_gpg = False
+        self.is_u2f = False
 
         YubikeyTouchDetectorListener(self).start()
 
     def yubikey(self):
         format_params = {
-            'is_gpg': self.is_waiting_gpg,
-            'is_u2f': self.is_waiting_u2f,
+            'is_gpg': self.is_gpg,
+            'is_u2f': self.is_u2f,
         }
         response = {
             'cached_until': self.py3.CACHE_FOREVER,
             'full_text': self.py3.safe_format(self.format, format_params),
         }
-        if self.is_waiting_gpg or self.is_waiting_u2f:
+        if self.is_gpg or self.is_u2f:
             response['urgent'] = True
         return response
 

--- a/py3status/modules/yubikey.py
+++ b/py3status/modules/yubikey.py
@@ -4,17 +4,16 @@ Show an indicator when YubiKey is waiting for a touch.
 
 Configuration parameters:
     format: Display format for the module.
-        (default '\?if=is_waiting YubiKey')
+        (default '[\?if=is_gpg YubiKey][\?if=is_u2f YubiKey]')
     socket_path: A path to the yubikey-touch-detector socket file.
         (default '$XDG_RUNTIME_DIR/yubikey-touch-detector.socket')
 
 Control placeholders:
-    {is_waiting} a boolean, True if YubiKey is waiting for a touch for any reason.
-    {is_waiting_gpg} a boolean, True if YubiKey is waiting for a touch due to a gpg operation.
-    {is_waiting_u2f} a boolean, True if YubiKey is waiting for a touch due to a pam-u2f request.
+    {is_gpg} a boolean, True if YubiKey is waiting for a touch due to a gpg operation.
+    {is_u2f} a boolean, True if YubiKey is waiting for a touch due to a pam-u2f request.
 
 SAMPLE OUTPUT
-{'color': '#00FF00', 'full_text': 'YubiKey'}
+{'full_text': 'YubiKey', 'urgent': True}
 
 Requires:
     github.com/maximbaz/yubikey-touch-detector: tool to detect when YubiKey is waiting for a touch
@@ -81,7 +80,7 @@ class Py3status:
     """
     """
     # available configuration parameters
-    format = '\?if=is_waiting YubiKey'
+    format = '[\?if=is_gpg YubiKey][\?if=is_u2f YubiKey]'
     socket_path = '$XDG_RUNTIME_DIR/yubikey-touch-detector.socket'
 
     def post_config_hook(self):
@@ -97,15 +96,14 @@ class Py3status:
 
     def yubikey(self):
         format_params = {
-            'is_waiting': self.waiting_gpg > 0 or self.waiting_u2f > 0,
-            'is_waiting_gpg': self.waiting_gpg > 0,
-            'is_waiting_u2f': self.waiting_u2f > 0,
+            'is_gpg': self.waiting_gpg > 0,
+            'is_u2f': self.waiting_u2f > 0,
         }
         response = {
             'cached_until': self.py3.CACHE_FOREVER,
             'full_text': self.py3.safe_format(self.format, format_params),
         }
-        if format_params['is_waiting']:
+        if self.waiting_gpg > 0 or self.waiting_u2f > 0:
             response['urgent'] = True
         return response
 

--- a/py3status/modules/yubikey.py
+++ b/py3status/modules/yubikey.py
@@ -59,13 +59,13 @@ class YubikeyTouchDetectorListener(threading.Thread):
                     # Connection dropped, need to reconnect
                     break
                 elif data == b"GPG_1":
-                    self.parent.is_gpg = True
+                    self.parent.status['is_gpg'] = True
                 elif data == b"GPG_0":
-                    self.parent.is_gpg = False
+                    self.parent.status['is_gpg'] = False
                 elif data == b"U2F_1":
-                    self.parent.is_u2f = True
+                    self.parent.status['is_u2f'] = True
                 elif data == b"U2F_0":
-                    self.parent.is_u2f = False
+                    self.parent.status['is_u2f'] = False
                 self.parent.py3.update()
 
 
@@ -80,23 +80,20 @@ class Py3status:
         self.socket_path = os.path.expanduser(self.socket_path)
         self.socket_path = os.path.expandvars(self.socket_path)
 
+        self.status = {
+            'is_gpg': False,
+            'is_u2f': False,
+        }
+
         self.killed = threading.Event()
-
-        self.is_gpg = False
-        self.is_u2f = False
-
         YubikeyTouchDetectorListener(self).start()
 
     def yubikey(self):
-        format_params = {
-            'is_gpg': self.is_gpg,
-            'is_u2f': self.is_u2f,
-        }
         response = {
             'cached_until': self.py3.CACHE_FOREVER,
-            'full_text': self.py3.safe_format(self.format, format_params),
+            'full_text': self.py3.safe_format(self.format, self.status),
         }
-        if self.is_gpg or self.is_u2f:
+        if any([waiting for waiting in self.status.values()]):
             response['urgent'] = True
         return response
 

--- a/py3status/modules/yubikey.py
+++ b/py3status/modules/yubikey.py
@@ -6,12 +6,15 @@ Configuration parameters:
     cache_timeout: How often to detect a pending touch request.
         (default 1)
     format: Display format for the module.
-        (default '\?if=is_waiting Touch YubiKey')
+        (default '\?if=is_waiting YubiKey')
     u2f_keys_path: Full path to u2f_keys if you want to monitor sudo access.
         (default '~/.config/Yubico/u2f_keys')
 
+Control placeholders:
+    {is_waiting} a boolean indicating whether YubiKey is waiting for a touch.
+
 SAMPLE OUTPUT
-{'color': '#FF0000', 'full_text': 'Y'}
+{'color': '#00FF00', 'full_text': 'YubiKey'}
 
 Dependencies:
     gpg: to check for pending gpg access request
@@ -40,7 +43,7 @@ class Py3status:
     """
     # available configuration parameters
     cache_timeout = 1
-    format = '\?if=is_waiting Touch YubiKey'
+    format = '\?if=is_waiting YubiKey'
     u2f_keys_path = '~/.config/Yubico/u2f_keys'
 
     def post_config_hook(self):
@@ -102,8 +105,9 @@ class Py3status:
         response = {
             'cached_until': self.py3.time_in(self.cache_timeout),
             'full_text': self.py3.safe_format(self.format, format_params),
-            'urgent': is_waiting
         }
+        if is_waiting:
+            response['urgent'] = True
         return response
 
     def kill(self):

--- a/py3status/modules/yubikey.py
+++ b/py3status/modules/yubikey.py
@@ -1,0 +1,128 @@
+# -*- coding: utf-8 -*-
+"""
+Show an indicator when YubiKey is waiting for a touch.
+
+Configuration parameters:
+    cache_timeout: How often to detect a pending touch request.
+        (default 1)
+    format: Display format for the module.
+        (default '{state}')
+    state_off: Message when the touch is not needed.
+        (default '')
+    state_on: Message when the YubiKey is waiting for a touch.
+        (default 'Y')
+    u2f_keys_path: Full path to u2f_keys if you want to monitor sudo access.
+        (default '')
+
+Color options:
+    color_bad: Touch is needed.
+    color_good: Touch is not needed.
+
+SAMPLE OUTPUT
+{'color': '#00FF00', 'full_text': ''}
+{'color': '#FF0000', 'full_text': 'Y'}
+
+Dependencies:
+    gpg: to check for pending gpg access request
+    inotify-simple: to check for pending sudo request
+    subprocess32: if after all these years you are still using python2
+
+@author Maxim Baz (https://github.com/maximbaz)
+@license BSD
+"""
+
+import time
+import os
+import signal
+import sys
+import threading
+import inotify_simple
+
+if os.name == 'posix' and sys.version_info[0] < 3:
+    import subprocess32 as subprocess
+else:
+    import subprocess
+
+
+class Py3status:
+    """
+    """
+    # available configuration parameters
+    cache_timeout = 1
+    format = '{state}'
+    state_off = ''
+    state_on = 'Y'
+    u2f_keys_path = ''
+
+    def post_config_hook(self):
+        self.killed = threading.Event()
+
+        self.pending_gpg = False
+        self.pending_sudo = False
+        self.sudo_reset_timer = None
+
+        class GpgThread(threading.Thread):
+            def run(this):
+                while not self.killed.is_set():
+                    with subprocess.Popen(
+                            'gpg --no-tty --card-status',
+                            shell=True,
+                            stdout=subprocess.DEVNULL,
+                            stderr=subprocess.DEVNULL,
+                            preexec_fn=os.setsid) as process:
+                        try:
+                            process.communicate(timeout=0.1)
+                            self.pending_gpg = False
+                        except subprocess.TimeoutExpired:
+                            self.pending_gpg = True
+                            os.killpg(process.pid, signal.SIGINT)
+                            process.communicate()
+                    time.sleep(self.cache_timeout)
+
+        class SudoThread(threading.Thread):
+            def run(this):
+                inotify = inotify_simple.INotify()
+                watch = inotify.add_watch(self.u2f_keys_path,
+                                          inotify_simple.flags.ACCESS)
+                while not self.killed.is_set():
+                    for event in inotify.read():
+                        self._restart_sudo_reset_timer()
+                        self.pending_sudo = True
+                inotify.rm_watch(watch)
+
+        GpgThread().start()
+
+        if self.u2f_keys_path != '':
+            SudoThread().start()
+
+    def _restart_sudo_reset_timer(self):
+        def reset_pending_sudo():
+            self.pending_sudo = False
+
+        if self.sudo_reset_timer is not None:
+            self.sudo_reset_timer.cancel()
+
+        self.sudo_reset_timer = threading.Timer(5, reset_pending_sudo)
+        self.sudo_reset_timer.start()
+
+    def yubikey(self):
+        pending_touch = self.pending_gpg or self.pending_sudo
+        state = self.state_on if pending_touch else self.state_off
+        response = {
+            'cached_until': self.py3.time_in(self.cache_timeout),
+            'full_text': self.py3.safe_format(self.format, {'state': state}),
+            'color': self.py3.COLOR_BAD
+            if pending_touch else self.py3.COLOR_GOOD
+        }
+        return response
+
+    def kill(self):
+        self.killed.set()
+
+
+if __name__ == "__main__":
+    """
+    Run module in test mode.
+    """
+    from py3status.module_test import module_test
+    module_test(Py3status)

--- a/py3status/modules/yubikey.py
+++ b/py3status/modules/yubikey.py
@@ -28,13 +28,13 @@ import socket
 import threading
 
 
-class YubikeyTouchDetectorListener(threading.Thread):
+class YubiKeyTouchDetectorListener(threading.Thread):
     """
     A thread watchng if YubiKey is waiting for a touch
     """
 
     def __init__(self, parent):
-        super(YubikeyTouchDetectorListener, self).__init__()
+        super(YubiKeyTouchDetectorListener, self).__init__()
         self.parent = parent
 
     def _connect_socket(self):
@@ -86,7 +86,7 @@ class Py3status:
         }
 
         self.killed = threading.Event()
-        YubikeyTouchDetectorListener(self).start()
+        YubiKeyTouchDetectorListener(self).start()
 
     def yubikey(self):
         response = {


### PR DESCRIPTION
This module is designed to show a visible indication that YubiKey is waiting for a touch.

Basically it uses a bunch of hacks to solve [this issue](https://forum.yubico.com/viewtopic.php?f=35&t=2397). 
Owners of YubiKey, especially YubiKey 4 Nano would be extremely glad for this module 🙂

How it works:
- It requires [maximbaz/yubikey-touch-detector](https://github.com/maximbaz/yubikey-touch-detector) to run in the background and subscribes to updates from it via unix sockets.


**DEMO**:

![yubikey_indicator](https://user-images.githubusercontent.com/1177900/31579601-c212a3ea-b139-11e7-818d-eed56cf7e09e.gif)