### PR TITLE
task to monitor i3status thread

### DIFF
--- a/py3status/i3status.py
+++ b/py3status/i3status.py
@@ -124,7 +124,7 @@ class I3statusModule:
     def get_latest(self):
         return [self.item.copy()]
 
-    def update(self):
+    def run(self):
         """
         updates the modules output.
         Currently only time and tztime need to do this
@@ -133,7 +133,7 @@ class I3statusModule:
             self.i3status.py3_wrapper.notify_update(self.module_name)
         due_time = self.py3.time_in(sync_to=self.time_delta)
 
-        self.i3status.py3_wrapper.timeout_queue_add_module(self, due_time)
+        self.i3status.py3_wrapper.timeout_queue_add(self, due_time)
 
     def update_from_item(self, item):
         """
@@ -171,7 +171,7 @@ class I3statusModule:
                     self.time_zone_check_due = ((int(t) // 1800) * 1800) + 1800
                 if not self.time_started:
                     self.time_started = True
-                    self.i3status.py3_wrapper.timeout_queue_add_module(self)
+                    self.i3status.py3_wrapper.timeout_queue_add(self)
             is_updated = False
             # update time to be shown
         return is_updated
@@ -392,11 +392,6 @@ class I3status(Thread):
                 break
             # limit restart rate
             self.lock.wait(5)
-        if not self.py3_wrapper.lock.is_set():
-            err = self.error
-            if not err:
-                err = 'I3status died horribly.'
-            self.py3_wrapper.notify_user(err)
 
     def spawn_i3status(self):
         """

--- a/py3status/module.py
+++ b/py3status/module.py
@@ -216,7 +216,7 @@ class Module:
         if not (self.disabled or self.terminated):
             # Start the module and call its output method(s)
             self._py3_wrapper.log('starting module %s' % self.module_full_name)
-            self._py3_wrapper.timeout_queue_add_module(self)
+            self._py3_wrapper.timeout_queue_add(self)
 
     def force_update(self):
         """
@@ -230,7 +230,7 @@ class Module:
             if self.config['debug']:
                 self._py3_wrapper.log('clearing cache for method {}'.format(meth))
         # set module to update
-        self._py3_wrapper.timeout_queue_add_module(self)
+        self._py3_wrapper.timeout_queue_add(self)
 
     def sleep(self):
         self.sleeping = True
@@ -254,7 +254,7 @@ class Module:
         if self.cache_time == PY3_CACHE_FOREVER:
             return
         # restart
-        self._py3_wrapper.timeout_queue_add_module(self, self.cache_time)
+        self._py3_wrapper.timeout_queue_add(self, self.cache_time)
 
     def set_updated(self):
         """
@@ -840,7 +840,7 @@ class Module:
             if not cache_time:
                 cache_time = time() + self.config['minimum_interval']
 
-            self._py3_wrapper.timeout_queue_add_module(self, cache_time)
+            self._py3_wrapper.timeout_queue_add(self, cache_time)
 
     def kill(self):
         # check and execute the 'kill' method if present

--- a/py3status/module_test.py
+++ b/py3status/module_test.py
@@ -39,7 +39,7 @@ class MockPy3statusWrapper:
     def notify_user(self, *arg, **kw):
         pass
 
-    def timeout_queue_add_module(self, *arg, **kw):
+    def timeout_queue_add(self, *arg, **kw):
         pass
 
     def log(self, *arg, **kw):


### PR DESCRIPTION
I forgot I'd done this.

It is slightly complicated as it adds a generic way to add random a user defined tasked to the queue.  If accepted I'll make the i3time update one of these too.

Maybe we should make them run in a thread like the py3status modules to simplify stuff too
