### PR TITLE
github: remove the trailing slashes

### DIFF
--- a/py3status/modules/github.py
+++ b/py3status/modules/github.py
@@ -105,6 +105,9 @@ class Py3status:
         self._issues = '?'
         self._pulls = '?'
         self._notify = '?'
+        # remove a trailing slash in the urls
+        self.url_api = self.url_api.strip('/')
+        self.url_base = self.url_base.strip('/')
 
     def _init(self):
         # Set format if user has not configured it.


### PR DESCRIPTION
I think we don't like slashes. This should allow users to copy and paste URL into a config and not having to worry about the trailing slash. If you prefer `rstrip`, let me know. I think `strip` may be a slightly faster (not that it matter....) 