### PR TITLE
volume_status: check the binaries

### DIFF
--- a/py3status/modules/volume_status.py
+++ b/py3status/modules/volume_status.py
@@ -93,6 +93,7 @@ from os import devnull, environ as os_environ
 from subprocess import check_output, call, CalledProcessError
 
 STRING_ERROR = 'invalid command `%s`'
+STRING_NOT_AVAILABLE = 'no available binary'
 STRING_NOT_INSTALLED = 'not installed'
 COMMAND_NOT_INSTALLED = 'command `%s` {}'.format(STRING_NOT_INSTALLED)
 
@@ -318,7 +319,7 @@ class Py3status:
         elif not self.py3.check_commands(self.command):
             raise Exception(COMMAND_NOT_INSTALLED % self.command)
         if not self.command:
-            raise Exception(STRING_NOT_INSTALLED)
+            raise Exception(STRING_NOT_AVAILABLE)
 
         # turn integers to strings
         if self.card is not None:

--- a/py3status/modules/volume_status.py
+++ b/py3status/modules/volume_status.py
@@ -94,8 +94,7 @@ from subprocess import check_output, call, CalledProcessError
 
 STRING_ERROR = 'invalid command `%s`'
 STRING_NOT_AVAILABLE = 'no available binary'
-STRING_NOT_INSTALLED = 'not installed'
-COMMAND_NOT_INSTALLED = 'command `%s` {}'.format(STRING_NOT_INSTALLED)
+COMMAND_NOT_INSTALLED = 'command `%s` not installed'
 
 
 class AudioBackend():

--- a/py3status/modules/volume_status.py
+++ b/py3status/modules/volume_status.py
@@ -92,7 +92,7 @@ import re
 from os import devnull, environ as os_environ
 from subprocess import check_output, call, CalledProcessError
 
-STRING_ERROR = 'invalid command'
+STRING_ERROR = 'invalid command `%s`'
 STRING_NOT_INSTALLED = 'not installed'
 COMMAND_NOT_INSTALLED = 'command `%s` {}'.format(STRING_NOT_INSTALLED)
 
@@ -314,7 +314,7 @@ class Py3status:
             self.command = self.py3.check_commands(
                 ['amixer', 'pamixer', 'pactl'])
         elif self.command not in ['amixer', 'pamixer', 'pactl']:
-            raise Exception(STRING_ERROR)
+            raise Exception(STRING_ERROR % self.command)
         elif not self.py3.check_commands(self.command):
             raise Exception(COMMAND_NOT_INSTALLED % self.command)
         if not self.command:

--- a/py3status/modules/volume_status.py
+++ b/py3status/modules/volume_status.py
@@ -92,6 +92,9 @@ import re
 from os import devnull, environ as os_environ
 from subprocess import check_output, call, CalledProcessError
 
+STRING_NOT_INSTALLED = 'not installed'
+STRING_ERROR = 'invalid command'
+
 
 class AudioBackend():
     def __init__(self, parent):
@@ -306,9 +309,15 @@ class Py3status:
         }
 
     def post_config_hook(self):
-        if self.command is None:
+        if not self.command:
             self.command = self.py3.check_commands(
                 ['amixer', 'pamixer', 'pactl'])
+        elif self.command not in ['amixer', 'pamixer', 'pactl']:
+            raise Exception(STRING_ERROR)
+        elif not self.py3.check_commands(self.command):
+            raise Exception('%s %s' % (self.command, STRING_NOT_INSTALLED))
+        if not self.command:
+            raise Exception(STRING_NOT_INSTALLED)
 
         # turn integers to strings
         if self.card is not None:
@@ -323,8 +332,6 @@ class Py3status:
             self.backend = PamixerBackend(self)
         elif self.command == 'pactl':
             self.backend = PactlBackend(self)
-        else:
-            raise NameError("Unknown command")
 
     # compares current volume to the thresholds, returns a color code
     def _perc_to_color(self, string):

--- a/py3status/modules/volume_status.py
+++ b/py3status/modules/volume_status.py
@@ -92,8 +92,9 @@ import re
 from os import devnull, environ as os_environ
 from subprocess import check_output, call, CalledProcessError
 
-STRING_NOT_INSTALLED = 'not installed'
 STRING_ERROR = 'invalid command'
+STRING_NOT_INSTALLED = 'not installed'
+COMMAND_NOT_INSTALLED = 'command `%s` {}'.format(STRING_NOT_INSTALLED)
 
 
 class AudioBackend():
@@ -315,7 +316,7 @@ class Py3status:
         elif self.command not in ['amixer', 'pamixer', 'pactl']:
             raise Exception(STRING_ERROR)
         elif not self.py3.check_commands(self.command):
-            raise Exception('%s %s' % (self.command, STRING_NOT_INSTALLED))
+            raise Exception(COMMAND_NOT_INSTALLED % self.command)
         if not self.command:
             raise Exception(STRING_NOT_INSTALLED)
 


### PR DESCRIPTION
The module will `check_command` when `self.command` is None.
The module will not `check_command` when `self.command` is not None.

I had `command = 'pamixer'` in the config and `pamixer` was not installed. This leads to an exception. I fix the `post_config_hook` so it can check everything. This occurs now because I did a fresh installation not long ago. Ho ho hum. :-) 

EDIT: Log for historical archiving purposes.
```
2017-10-22 13:14:27 WARNING Instance `volume_status`, user method `current_volume` failed (FileNotFoundError) volume_status.py line 160.
2017-10-22 13:14:27 INFO Traceback                                                                                                     
FileNotFoundError: [Errno 2] No such file or directory: 'pamixer'
  File "/home/chris/src/py3status/py3status/module.py", line 729, in run
    response = method()
  File "/home/chris/src/py3status/py3status/modules/volume_status.py", line 327, in current_volume
    perc, muted = self.backend.get_volume()
  File "/home/chris/src/py3status/py3status/modules/volume_status.py", line 160, in get_volume
    perc = check_output(self.cmd + ["--get-volume"]).decode('utf-8').strip()
  File "/usr/lib/python3.6/subprocess.py", line 336, in check_output
    **kwargs).stdout
  File "/usr/lib/python3.6/subprocess.py", line 403, in run
    with Popen(*popenargs, **kwargs) as process:
  File "/usr/lib/python3.6/subprocess.py", line 707, in __init__
    restore_signals, start_new_session)
  File "/usr/lib/python3.6/subprocess.py", line 1333, in _execute_child
    raise child_exception_type(errno_num, err_msg)
```
