### PR TITLE
add new module: nvidia_smi

### DIFF
--- a/py3status/modules/nvidia_smi.py
+++ b/py3status/modules/nvidia_smi.py
@@ -1,0 +1,150 @@
+# -*- coding: utf-8 -*-
+"""
+Display NVIDIA properties currently exhibiting in the NVIDIA GPUs.
+
+nvidia-smi, short for NVIDIA System Management Interface program, is a cross
+platform tool that supports all standard NVIDIA driver-supported Linux distros.
+
+Configuration parameters:
+    cache_timeout: refresh interval for this module (default 10)
+    format: display format for this module (default '{format_gpu}')
+    format_gpu: display format for NVIDIA GPUs
+        *(default '{gpu_name} [\?color=temperature.gpu {temperature.gpu}°] '
+        '[\?color=memory.used_percent {memory.used} MiB]')*
+    format_gpu_separator: show separator if more than one (default ' ')
+    thresholds: specify color thresholds to use
+        (default [(0, 'good'), (65, 'degraded'), (75, 'orange'), (85, 'bad')])
+
+Format placeholders:
+    {format_gpu} format for NVIDIA GPUs
+
+format_gpu placeholders:
+    {index}               Zero based index of the GPU.
+    {count}               The number of NVIDIA GPUs in the system
+    {driver_version}      The version of the installed NVIDIA display driver
+    {gpu_name}            The official product name of the GPU
+    {gpu_uuid}            Globally unique immutable identifier of the GPU
+    {memory.free}         Total free memory
+    {memory.total}        Total installed GPU memory
+    {memory.used}         Total memory allocated by active contexts
+    {memory.used_percent} Total memory allocated by active contexts percentage
+    {temperature.gpu}     Core GPU temperature in degrees C
+
+    Use `python /path/to/nvidia_smi.py --list-properties` for a full list of
+    supported NVIDIA properties to use. Not all of supported NVIDIA properties
+    will be usable. See `nvidia-smi --help-query-gpu` for more information.
+
+Color thresholds:
+    format_gpu:
+        `xxx`: print a color based on the value of NVIDIA `xxx` property
+
+Requires:
+    nvidia-smi: command line interface to query NVIDIA devices
+
+Examples:
+```
+# add awesome {memory.used_percent} too
+nvidia_smi {
+    format_gpu = '{gpu_name} [\?color=temperature.gpu {temperature.gpu}°] '
+    format_gpu += '[\?color=memory.used_percent {memory.used} MiB'
+    format_gpu += '[\?color=darkgray&show \|]{memory.used_percent:.1f}%]'
+}
+```
+
+@author lasers
+
+SAMPLE OUTPUT
+[
+    {'full_text': 'GeForce GTX 1060 '},
+    {'color': '#00ff00', 'full_text': '51°C '},
+]
+
+memory
+[
+    {'full_text': 'GeForce GTX 1060 '},
+    {'color': '#ffff00', 'full_text': '65°C '},
+    {'color': '#00ff00', 'full_text': '188 MiB (3.12%)},
+]
+
+custom
+[
+    {'color': '#a9a9a9', 'full_text': 'temperature.gpu '},
+    {'color': '#00ff00', 'full_text': '54°C '},
+    {'color': '#a9a9a9', 'full_text': 'memory.used '},
+    {'color': '#ffff00', 'full_text': '135 MiB'}
+]
+"""
+
+STRING_NOT_INSTALLED = 'not installed'
+
+
+class Py3status:
+    """
+    """
+    # available configuration parameters
+    cache_timeout = 10
+    format = '{format_gpu}'
+    format_gpu = (u'{gpu_name} [\?color=temperature.gpu {temperature.gpu}°] '
+                  '[\?color=memory.used_percent {memory.used} MiB]')
+    format_gpu_separator = ' '
+    thresholds = [(0, 'good'), (65, 'degraded'), (75, 'orange'), (85, 'bad')]
+
+    def post_config_hook(self):
+        command = 'nvidia-smi --format=csv,noheader,nounits --query-gpu='
+        if not self.py3.check_commands(command.split()[0]):
+            raise Exception(STRING_NOT_INSTALLED)
+        self.properties = self.py3.get_placeholders_list(self.format_gpu)
+
+        format_gpu = {x: ':.1f' for x in self.properties if 'used_percent' in x}
+        self.format_gpu = self.py3.update_placeholder_formats(
+            self.format_gpu, format_gpu
+        )
+
+        for name in ['memory.used_percent']:
+            if name in self.properties:
+                self.properties.remove(name)
+        for name in ['memory.used', 'memory.total']:
+            if name not in self.properties:
+                self.properties.append(name)
+        self.nvidia_command = command + ','.join(self.properties)
+
+        self.thresholds_init = self.py3.get_color_names_list(self.format_gpu)
+
+    def _get_nvidia_data(self):
+        data = self.py3.command_output(self.nvidia_command)
+        if '[Not Supported]' in data:
+            data = data.replace('[Not Supported]', 'None')
+        return data
+
+    def nvidia_smi(self):
+        nvidia_data = self._get_nvidia_data()
+        new_gpu = []
+
+        for line in nvidia_data.splitlines():
+            gpu = dict(zip(self.properties, line.split(', ')))
+            gpu['memory.used_percent'] = (
+                float(gpu['memory.used']) / float(gpu['memory.total']) * 100.0
+            )
+            for x in self.thresholds_init:
+                if x in gpu:
+                    self.py3.threshold_get_color(gpu[x], x)
+
+            new_gpu.append(self.py3.safe_format(self.format_gpu, gpu))
+
+        format_gpu_separator = self.py3.safe_format(self.format_gpu_separator)
+        format_gpu = self.py3.composite_join(format_gpu_separator, new_gpu)
+
+        return {
+            'cached_until': self.py3.time_in(self.cache_timeout),
+            'full_text': self.py3.safe_format(
+                self.format, {'format_gpu': format_gpu}
+            )
+        }
+
+
+if __name__ == "__main__":
+    """
+    Run module in test mode.
+    """
+    from py3status.module_test import module_test
+    module_test(Py3status)


### PR DESCRIPTION
We revives an accidentally closed pull request. https://github.com/ultrabug/py3status/pull/903

![2017-10-28-061420_1343x148_scrot](https://user-images.githubusercontent.com/852504/32133946-d8f185d6-bba7-11e7-9aba-5915d0e97dfe.png)

* Support 140~ external placeholders. Some duplicates. eg, `gpu_name` and `name`, but unofficially, I can use 10~ placeholders. It can vary from GPU to GPU. See if we should make a script that'll output a list of properties and values, weeding out the others, eg `Not Supported`.

* I like `{memory.used}` here in the default format.

* Backward compatible not included for `nvidia_temp` as of this time. New module?

* Support color thresholds for placeholders in the `format_gpu`. _**New!**_
    ```
    thresholds = {
        'memory.used': [(0, 'good'), (1, 'degraded'), (2, 'bad')],
        'temperature.gpu': [(0, 'bad'), (1, 'degraded'), (2, 'good')],
    }
    ```
* I clean up things.

* I fix mistakes too. `format_gpu` makes more sense here than former `format_properties` as we're not formatting anything in the properties in the GPU, but the properties for every GPU we have.

* @tobes: I'm merely pointing out an issue with `color_threshold`. This lacks an optional `index`/`string` because lot of things are usually done in the loop and sometimes we will have same color thresholds for different things in the loop. An example.
    ```
    thresholds = {
        '1.temperature.gpu': [(0, 'good'), (80, 'degraded'), (90, 'bad')],  # same
        '2.temperature.gpu': [(0, 'good'), (80, 'degraded'), (90, 'bad')],  # same
        '3.temperature.gpu': [(0, 'good'), (80, 'degraded'), (90, 'bad')],  # same
        '4.temperature.gpu': [(0, 'good'), (80, 'degraded'), (90, 'bad')],  # same

        '1.memory.used': [(0, 'good'), (4096, 'degraded'), (8192, 'bad')],  # 8GB card
        '2.memory.used': [(0, 'good'), (2048, 'degraded'), (4096, 'bad')],  # 4GB card
        '3.memory.used': [(0, 'good'), (1024, 'degraded'), (2048, 'bad')],  # 2GB card
        '4.memory.used': [(0, 'good'), (512, 'degraded'), (1024, 'bad')],   # 1GB card
    }
    ```
