### PR TITLE
moc: avoid missing data on rapid refresh

### DIFF
--- a/py3status/modules/moc.py
+++ b/py3status/modules/moc.py
@@ -87,18 +87,18 @@ class Py3status:
     def post_config_hook(self):
         if not self.py3.check_commands('mocp'):
             raise Exception(STRING_NOT_INSTALLED)
-
         self.color_stopped = self.py3.COLOR_STOPPED or self.py3.COLOR_BAD
         self.color_paused = self.py3.COLOR_PAUSED or self.py3.COLOR_DEGRADED
         self.color_playing = self.py3.COLOR_PLAYING or self.py3.COLOR_GOOD
+        self.cache = None
 
     def _get_moc_data(self):
         try:
-            data = self.py3.command_output(['mocp', '--info'])
+            data = self.cache = self.py3.command_output(['mocp', '--info'])
             is_started = True
-        except:
-            data = {}
-            is_started = False
+        except self.py3.CommandError as ce:
+            data = self.cache if ce.output else ce.output
+            is_started = True if ce.output else False
         return is_started, data
 
     def moc(self):


### PR DESCRIPTION
This fixes https://github.com/ultrabug/py3status/issues/1133.

It's a race condition issue with `mocp`. To scroll something (eg seek, volume, etc)... the module can run `mocp --an-example` then `mocp --info` repeatedly. This can result in an unexpected behavior and/or an error with the commands. As such, I got a `-6` with `mocp`.

This issue is hard to come by because this part is already done in `try/except` and the `seek/volume` commands are not part of `moc`'s `button_*` + `on_click` package deal... I picked this bug up with:
```
moc {
    on_click 4 = 'exec mocp --seek +5'
    on_click 5 = 'exec mocp --seek -5'
}
```

EDIT: @tobes Let me know If you want to keep #1133 open... Maybe to somehow incorporate new features into `on_click`.... 1) `prevent_refresh`   2)  `time_in` (delay between clicks)?  Idk. Probably too much.

EDIT: Maybe just `time_in` where `-1` means `prevent_refresh`...? `-1`, `0.5`, `1`. 