### PR TITLE
moc: clean up docs and codes

### DIFF
--- a/py3status/modules/moc.py
+++ b/py3status/modules/moc.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 """
-Display currently playing song in moc.
+Display song currently playing in moc.
 
 MOC (music on console) is a console audio player for Linux/Unix designed to be
 powerful and easy to use. It consists of two parts, a server (moc) and a
@@ -15,10 +15,10 @@ Configuration parameters:
     format: display format for this module
         (default '\?if=is_started [\?if=is_stopped \[\] moc|
         [\?if=is_paused \|\|][\?if=is_playing >] {title}]')
-    sleep_timeout: sleep interval for this module. when moc is not running,
-        this interval will be used. this allows some flexible timing where one
-        might want to refresh constantly with some placeholders... or to refresh
-        only once every minute rather than every few seconds. (default 20)
+    sleep_timeout: when moc is not running, this interval will be used to
+        allow one to refresh constantly with time placeholders and/or
+        to refresh once every minute rather than every few seconds
+        (default 20)
 
 Control placeholders:
     {is_paused} a boolean based on moc status
@@ -43,7 +43,7 @@ Format placeholders:
     {totaltime} total time in seconds, eg 72:02
 
     Placeholders are retrieved directly from `mocp --info` command.
-    The list was harvested only once and should not represent a full list.
+    The list was harvested once and should not represent a full list.
 
 Color options:
     color_paused: Paused, defaults to color_degraded
@@ -52,6 +52,14 @@ Color options:
 
 Requires:
     moc: a console audio player with simple ncurses interface
+
+Examples:
+```
+# see 'man mocp' for more buttons
+moc {
+    on_click 9 = 'exec mocp --example'
+}
+```
 
 @author lasers
 
@@ -94,7 +102,7 @@ class Py3status:
 
     def _get_moc_data(self):
         try:
-            data = self.py3.command_output(['mocp', '--info'])
+            data = self.py3.command_output('mocp --info')
             is_started = True
         except:
             data = {}
@@ -102,8 +110,6 @@ class Py3status:
         return is_started, data
 
     def moc(self):
-        """
-        """
         is_paused = is_playing = is_stopped = None
         cached_until = self.sleep_timeout
         color = self.py3.COLOR_BAD
@@ -132,14 +138,16 @@ class Py3status:
         return {
             'cached_until': self.py3.time_in(cached_until),
             'color': color,
-            'full_text': self.py3.safe_format(self.format,
-                                              dict(
-                                                  is_paused=is_paused,
-                                                  is_playing=is_playing,
-                                                  is_started=is_started,
-                                                  is_stopped=is_stopped,
-                                                  **data
-                                              ))
+            'full_text': self.py3.safe_format(
+                self.format,
+                dict(
+                    is_paused=is_paused,
+                    is_playing=is_playing,
+                    is_started=is_started,
+                    is_stopped=is_stopped,
+                    **data
+                )
+            )
         }
 
     def on_click(self, event):


### PR DESCRIPTION
Seperate PR for small cleanup after fixing the `moc` bug with `rapid refresh` PR.
* Rephrasing.
* Use `list` so we don't have to convert `str` to `list` every time. This helps? 
* Adding an example of configuring extra buttons not listed in module.
* Fixing `dict` so we don't have to tilt too much... Right? Ty.