### PR TITLE
deadbeef: add sleep_timeout

### DIFF
--- a/py3status/modules/deadbeef.py
+++ b/py3status/modules/deadbeef.py
@@ -3,8 +3,12 @@
 Display song currently playing in deadbeef.
 
 Configuration parameters:
-    cache_timeout: refresh interval for this module (default 1)
+    cache_timeout: refresh interval for this module (default 5)
     format: display format for this module (default '[{artist} - ][{title}]')
+    sleep_timeout: when deadbeef is not running, this interval will be used
+        to allow one to refresh constantly with time placeholders and/or
+        to refresh once every minute rather than every few seconds
+        (default 20)
 
 Format placeholders:
     {album} name of the album
@@ -47,8 +51,9 @@ class Py3status:
     """
     """
     # available configuration parameters
-    cache_timeout = 1
+    cache_timeout = 5
     format = '[{artist} - ][{title}]'
+    sleep_timeout = 20
 
     class Meta:
         deprecated = {
@@ -96,8 +101,10 @@ class Py3status:
     def deadbeef(self):
         color = self.color_stopped
         status = self.empty_status
+        cached_until = self.sleep_timeout
 
         if self._is_running():
+            cached_until = self.cache_timeout
             # Starting deadbeef may generate lot of startup noises either
             # with or without error codes. Running command below may sometimes
             # change how things behaves onscreen. We use subprocess to ignore
@@ -119,7 +126,7 @@ class Py3status:
                 else:
                     color = self.color_paused
         return {
-            'cached_until': self.py3.time_in(self.cache_timeout),
+            'cached_until': self.py3.time_in(cached_until),
             'full_text': self.py3.safe_format(self.format, status),
             'color': color,
         }


### PR DESCRIPTION
I used `deadbeef` for short time yesterday to help out someone and sometimes later, I forget I still have the module running in the bar when I saw too many `deadbeef` in the log. I wish to fix this.

We can make `deadbeef` relax more... so we're changing `cache_timeout` to `5` and we're adding new config `sleep_timeout = 20` where the module can sleep longer between intervals when it's not in use.

Before
```
Not in use..... 1 second..... 60 refreshes per minute.
In use.....  1 second..... 60 refreshes per minute.
```

After
```
Not in use..... 20 seconds..... 3 refreshes per minute.
In use.....  5 seconds..... 12 refreshes per minute.
```
Ty. 🎧 