### PR TITLE
window_title: add new placeholders

### DIFF
--- a/py3status/modules/window_title.py
+++ b/py3status/modules/window_title.py
@@ -7,6 +7,8 @@ This module prints the properties of a focused window at frequent intervals.
 Configuration parameters:
     cache_timeout: refresh interval for this module (default 0.5)
     format: display format for this module (default '{title}')
+    max_width: If width of title is greater, shrink it and add '...'
+        (default 120)
 
 Format placeholders:
     {class} class name
@@ -41,6 +43,7 @@ class Py3status:
     # available configuration parameters
     cache_timeout = 0.5
     format = '{title}'
+    max_width = 120
 
     def _find_focused(self, tree):
         if isinstance(tree, list):
@@ -58,6 +61,11 @@ class Py3status:
         tree = loads(self.py3.command_output('i3-msg -t get_tree'))
         window_properties = self._find_focused(tree).get(
             'window_properties', {'title': ''})
+
+        if ('title' in window_properties and
+                len(window_properties['title']) > self.max_width):
+            window_properties['title'] = u"...{}".format(
+                window_properties['title'][-(self.max_width - 3):])
 
         return {
             'cached_until': self.py3.time_in(self.cache_timeout),

--- a/py3status/modules/window_title.py
+++ b/py3status/modules/window_title.py
@@ -45,6 +45,11 @@ class Py3status:
     format = '{title}'
     max_width = 120
 
+    def post_config_hook(self):
+        # empty defaults to replace window properties
+        self.empty_defaults = {
+            x: '' for x in self.py3.get_placeholders_list(self.format)}
+
     def _find_focused(self, tree):
         if isinstance(tree, list):
             for el in tree:
@@ -60,10 +65,9 @@ class Py3status:
     def window_title(self):
         tree = loads(self.py3.command_output('i3-msg -t get_tree'))
         window_properties = self._find_focused(tree).get(
-            'window_properties', {'title': ''})
+            'window_properties', self.empty_defaults)
 
-        if ('title' in window_properties and
-                len(window_properties['title']) > self.max_width):
+        if len(window_properties.get('title', '')) > self.max_width:
             window_properties['title'] = u"...{}".format(
                 window_properties['title'][-(self.max_width - 3):])
 

--- a/py3status/modules/window_title.py
+++ b/py3status/modules/window_title.py
@@ -2,36 +2,37 @@
 """
 Display window title.
 
-Prints the name of focused window at frequent intervals.
+This module prints the properties of a focused window at frequent intervals.
 
 Configuration parameters:
     cache_timeout: refresh interval for this module (default 0.5)
     format: display format for this module (default '{title}')
-    max_width: If width of title is greater, shrink it and add '...'
-        (default 120)
+
+Format placeholders:
+    {class} class name
+    {instance} instance name
+    {title} title name
+
+Examples:
+```
+# show heart if no title
+window_title {
+    format = '{title}|\u2665'
+}
+
+# specify a length
+window_title {
+    format = '[\?max_length=55 {title}]'
+}
 
 @author shadowprince
 @license Eclipse Public License
 
 SAMPLE OUTPUT
-{'full_text': u'business_plan_final3a.doc'}
+{'full_text': u'business_plan_final_3a.doc'}
 """
 
 from json import loads
-
-
-def find_focused(tree):
-    if type(tree) == list:
-        for el in tree:
-            res = find_focused(el)
-            if res:
-                return res
-    elif type(tree) == dict:
-        if tree['focused']:
-            return tree
-        else:
-            return find_focused(tree['nodes'] + tree['floating_nodes'])
-    return ''
 
 
 class Py3status:
@@ -40,22 +41,27 @@ class Py3status:
     # available configuration parameters
     cache_timeout = 0.5
     format = '{title}'
-    max_width = 120
+
+    def _find_focused(self, tree):
+        if isinstance(tree, list):
+            for el in tree:
+                res = self._find_focused(el)
+                if res:
+                    return res
+        elif isinstance(tree, dict):
+            if tree['focused']:
+                return tree
+            return self._find_focused(tree['nodes'] + tree['floating_nodes'])
+        return {}
 
     def window_title(self):
         tree = loads(self.py3.command_output('i3-msg -t get_tree'))
-        window = find_focused(tree)
-
-        if not window or window.get('name') is None or window.get('type') == 'workspace':
-            title = ''
-        elif len(window['name']) > self.max_width:
-            title = u"...{}".format(window['name'][-(self.max_width - 3):])
-        else:
-            title = window['name']
+        window_properties = self._find_focused(tree).get(
+            'window_properties', {'title': ''})
 
         return {
             'cached_until': self.py3.time_in(self.cache_timeout),
-            'full_text': self.py3.safe_format(self.format, {'title': title}),
+            'full_text': self.py3.safe_format(self.format, window_properties)
         }
 
 


### PR DESCRIPTION
I made this pull request to add `{class}` placeholder because that's what somebody in https://github.com/ultrabug/py3status/issues/1141 may be trying to accomplish using third-party scripts. Actually, I am not so sure as he may be wanting to `scrub` certain patterns inside the `{title}` for couple of reasons.
* Some applications can have class in their titles... making `{class}` useless.
* Some applications can start with class, then title.
* Some applications can start with title, then class.
* Some users may prefer to display `{class}` alone.

Having universal `scrub` option could be sufficent to scrub this kind of `window_title` irks.

----------

I also found a minor issue with `window_title`... Using title below as an example...
```
Formatter new features · Issue #752 · ultrabug/py3status - Firefox
```
If we want to use small value eg `20` in `max_width` instead of default `120`, we will see a reverse ellipsis, eg `...3status - Firefox` instead of `Formatter new fea...`. Using small numbers for `max_width` is not an option for many if we have `hardcoded` reverse ellipsis with no way to switch it off... and because `max_width` was built with a large number threshold in mind, I'm removing this option in favor of `max_length`... and the new formatters.