### PR TITLE
air_quality: new module from scratch

### DIFF
--- a/py3status/modules/air_quality.py
+++ b/py3status/modules/air_quality.py
@@ -17,7 +17,7 @@ Configuration parameters:
         burst up to 60 requests. See http://aqicn.org/api/ for more information.
         (default 3600)
     format: display format for this module
-        (default '[\?color=bad {message}]
+        (default '[\?if=status=error&color=bad {data}]
         |[\?if=aqi&color=aqi {city_name}: {aqi} {category}]')
     format_datetime: specify strftime characters to format (default {})
     location: location or uid to query. To search for nearby stations in Kraków,
@@ -41,9 +41,9 @@ Format placeholders:
     {city_geo_1} monitoring station longitude
     {city_name} monitoring station name
     {city_url} monitoring station url
+    {data} error message, eg Over quota, Invalid key, Unknown city
     {dominentpol} dominant pollutant, eg pm25
     {idx} Unique ID for the city monitoring station, eg 7396
-    {message} error message, eg Over quota, Invalid key, Unknown city
     {status} status message, eg ok, error
     {time} epoch timestamp, eg 1510246800
     {time_s} local timestamp, eg 2017-11-09 17:00:00
@@ -80,7 +80,7 @@ format_datetime placeholders:
     value: % strftime characters to be translated, eg '%b %d' ----> 'Nov 11'
 
 Color options:
-    color_bad: error message (if any) from the site
+    color_bad: print a color for error (if any) from the site
 
 Color thresholds:
     aqi: print a color based on the value of aqi
@@ -125,7 +125,7 @@ class Py3status:
     # available configuration parameters
     auth_token = 'demo'
     cache_timeout = 3600
-    format = ('[\?color=bad {message}]'
+    format = ('[\?if=status=error&color=bad {data}]'
               '|[\?if=aqi&color=aqi {city_name}: {aqi} {category}]')
     format_datetime = {}
     location = 'Shanghai'

--- a/py3status/modules/air_quality.py
+++ b/py3status/modules/air_quality.py
@@ -10,24 +10,65 @@ countries have their own air quality indices, corresponding to different nationa
 air quality standards.
 
 Configuration parameters:
-    auth_token: Required. Personal token. http://aqicn.org (default 'demo')
+    auth_token: Personal token required. See http://aqicn.org/data-platform/token
+        for more information. (default 'demo')
     cache_timeout: refresh interval for this module. A message from the site:
-        The default quota is max 1000 (one thousand) requests per minute (~16RPS)
-        and with burst up to 60 requests. Read more: http://aqicn.org/api/
+        The default quota is max 1000 requests per minute (~16RPS) and with
+        burst up to 60 requests. See http://aqicn.org/api/ for more information.
         (default 3600)
-    format: display format for this module (default '{location}: {aqi} {category}')
+    format: display format for this module (default '{city_name}: {aqi} {category}')
+    format_datetime: specify strftime characters to format (default {})
     location: location or uid to query. To search for nearby stations in Kraków,
         use `curl http://api.waqi.info/search/?token=YOUR_TOKEN&keyword=kraków`
-        We recommend you to use uid instead of name in location, eg "@8691"
+        For best results, use uid instead of name in location, eg `@8691`.
         (default 'Shanghai')
 
 Format placeholders:
     {aqi} air quality index
-    {category} health risk category
-    {location} location or uid
+    {attributions_0_name} attribution name
+    {attributions_0_url} attribution url
+    {category} health risk category, eg Good, Moderate, Unhealthy, etc
+    {city_geo_0} monitoring station latitude
+    {city_geo_1} monitoring station longitude
+    {city_name} monitoring station name
+    {city_url} monitoring station url
+    {dominentpol} dominant pollutant, eg pm25
+    {idx} Unique ID for the city monitoring station, eg 7396
+    {message} error message, eg Over quota, Invalid key, Unknown city
+    {status} status message, eg ok, error
+    {time} epoch timestamp, eg 1510246800
+    {time_s} local timestamp, eg 2017-11-09 17:00:00
+    {time_tz} local timezone, eg -06:00
 
-Note: Stations may use {pm25}, {pm10}, {o3}, {so2}, or other parameters.
-See http://api.waqi.info/feed/@UID/?token=TOKEN (Replace UID and TOKEN)
+    `{attribution_?_name}` can have more than 0.
+    `{attribution_?_url}` can have more than 0.
+
+    Your station may have individual scores for pollutants not listed below.
+    See http://api.waqi.info/feed/@UID/?token=TOKEN (Replace UID and TOKEN)
+    for an explicit list of valid placeholders to use, eg
+
+    {iaqi_co}   individual score for pollutant carbon monoxide
+    {iaqi_h}    individual score for pollutant h (?)
+    {iaqi_no2}  individual score for pollutant nitrogen dioxide
+    {iaqi_o3}   individual score for pollutant ozone
+    {iaqi_pm25} individual score for pollutant particulates
+                smaller than 2.5 μm in aerodynamic diameter
+    {iaqi_pm10} individual score for pollutant particulates
+                smaller than 10 μm in aerodynamic diameter
+    {iaqi_pm15} individual score for pollutant particulates
+                smaller than than 15 μm in aerodynamic diameter
+    {iaqi_p}    individual score for pollutant particulates
+    {iaqi_so2}  individual score for pollutant sulfur dioxide
+    {iaqi_t}    individual score for pollutant t (?)
+    {iaqi_w}    individual score for pollutant w (?)
+
+    AQI denotes an air quality index. IQAI denotes an individual AQI score.
+    Try https://en.wikipedia.org/wiki/Air_pollution#Pollutants for more
+    information on the pollutants retrieved from your monitoring station.
+
+format_datetime placeholders:
+    key: epoch_placeholder, eg time, vtime
+    value: % strftime characters to be translated, eg '%b %d' ----> 'Nov 11'
 
 Category options:
     category_<name>: display name
@@ -37,12 +78,12 @@ Color options:
     color_<category>: display color
         eg color_hazardous = '#7E0023'
 
-Example:
+Examples:
 ```
+# show last updated time
 air_quality {
-    auth_token = 'demo'
-    location = 'Shanghai'
-    format = 'Shanghai: {aqi} {category}'
+    format = '{city_name}: {aqi} {category} - {time}'
+    format_datetime = {'time': '%-I%P'}
 }
 ```
 @author beetleman, lasers
@@ -67,6 +108,8 @@ aqi_hazardous
 {'color':'#7E0023', 'full_text':'Shanghai: 301 Hazardous'}
 """
 
+from datetime import datetime
+
 AQI = (
     (0, 50, 'good'),
     (51, 100, 'moderate'),
@@ -77,32 +120,20 @@ AQI = (
 )
 CATEGORY = {
     'good': 'Good',
-    'hazardous': 'Hazardous',
     'moderate': 'Moderate',
     'sensitively_unhealthy': 'Sensitively Unhealthy',
     'unhealthy': 'Unhealthy',
-    'unknown': 'Unknown',
     'very_unhealthy': 'Very Unhealthy',
+    'hazardous': 'Hazardous',
 }
 COLOR = {
     'good': '#009966',
-    'hazardous': '#7E0023',
     'moderate': '#FFDE33',
     'sensitively_unhealthy': '#FF9933',
     'unhealthy': '#CC0033',
-    'unknown': '#ffffff',
     'very_unhealthy': '#660099',
+    'hazardous': '#7E0023',
 }
-STRING_UNKNOWN = 'Unknown'
-URL = 'http://api.waqi.info'
-
-
-def _get_in(coll, path, default=None):
-    first = path[0]
-    rest = path[1:len(path)]
-    if len(path) == 1:
-        return coll.get(first, default)
-    return _get_in(coll.get(first, default), rest, default)
 
 
 class Py3status:
@@ -112,64 +143,63 @@ class Py3status:
     auth_token = 'demo'
     cache_timeout = 3600
     format = '{location}: {aqi} {category}'
+    format_datetime = {}
     location = 'Shanghai'
 
     def post_config_hook(self):
-        url_path = 'feed/{}'.format(self.location)
-        self.url_token = {'token': self.auth_token}
-        self.url_full = '{url_base}/{url_path}/'.format(
-            url_base=URL,
-            url_path=url_path
-        )
+        self.auth_token = {'token': self.auth_token}
+        self.url = 'http://api.waqi.info/feed/%s/' % self.location
+        self.init_datetimes = []
+        for word in self.format_datetime:
+            if (self.py3.format_contains(self.format, word)) and (
+                    word in self.format_datetime):
+                self.init_datetimes.append(word)
 
-    def _update_data(self):
+    def _get_aqi_data(self):
         try:
-            self._api_data = self.py3.request(self.url_full, params=self.url_token).json()
-        except (self.py3.RequestException):
-            self._api_data = {}
+            return self.py3.request(self.url, params=self.auth_token).json()
+        except self.py3.RequestException:
+            return {}
 
-    def _update_key(self):
-        if self._api_data.get('status') == 'ok':
-            aqi = _get_in(self._api_data, ['data', 'aqi'], -1)
-            if type(aqi) is not int:
-                self._key = 'unknown'
-                return
-            for start, end, key in AQI:
-                if aqi >= start and aqi <= end:
-                    self._key = key
-                    return
-        self._key = 'unknown'
+    def _organize(self, data):
+        new_data = {}
+        for k, v in self.py3.flatten_dict(data, delimiter='_').items():
+            new_data[''.join(k.replace('data_', '', 1).rsplit('_v', 1))] = v
+        return new_data
 
-    def _get_full_text(self):
-        aqi = _get_in(self._api_data, ['data', 'aqi'], {})
-        iaqi = _get_in(self._api_data, ['data', 'iaqi'], {})
-        city = _get_in(self._api_data, ['data', 'city'], {})
-        try:
-            category = getattr(self, 'CATEGORY_{}'.format(self._key).lower())
-        except:
-            category = CATEGORY.get(self._key)
+    def _manipulate(self, data):
+        # get key
+        for start, end, key in AQI:
+            if data['aqi'] >= start and data['aqi'] <= end:
+                key = key
+                break
+        # get category
+        category = getattr(self, 'CATEGORY_{}'.format(key).lower(), None)
         if not category:
-            category = STRING_UNKNOWN
-        return self.py3.safe_format(self.format,
-                                    dict(location=city.get('name'),
-                                         category=category,
-                                         aqi=aqi,
-                                         **{k: v.get('v') for k, v in iaqi.items()}))
-
-    def _get_color(self):
-        color = getattr(self.py3, 'COLOR_{}'.format(self._key.upper()))
+            category = CATEGORY.get(key)
+        data['category'] = category
+        # get color
+        color = getattr(self.py3, 'COLOR_{}'.format(key.upper()))
         if not color:
-            color = COLOR.get(self._key)
-        return color
+            color = COLOR.get(key)
+        # format datetime?
+        for k in self.init_datetimes:
+            if k in data:
+                data[k] = self.py3.safe_format(datetime.strftime(
+                    datetime.fromtimestamp(data[k]), self.format_datetime[k]))
+        return data, color
 
     def air_quality(self):
-        self._update_data()
-        self._update_key()
+        aqi_data = self._get_aqi_data()
+        color = None
+        if aqi_data:
+            aqi_data = self._organize(aqi_data)
+            data, color = self._manipulate(aqi_data)
 
         return {
             'cached_until': self.py3.time_in(self.cache_timeout),
-            'full_text': self._get_full_text(),
-            'color': self._get_color()
+            'full_text': self.py3.safe_format(self.format, data),
+            'color': color,
         }
 
 

--- a/tests/test_module_doc.py
+++ b/tests/test_module_doc.py
@@ -35,6 +35,8 @@ IGNORE_ILLEGAL_CONFIG_OPTIONS = [
 # Ignored items will not have their default values checked or be included for
 # alphabetical order purposes
 IGNORE_ITEM = [
+    ('air_quality', 'format'),  # line too long for docstring parsing
+    ('air_quality', 'quality_thresholds'),  # line too long for docstring parsing
     ('moc', 'format'),  # line too long for docstring parsing
     ('cmus', 'format'),  # line too long for docstring parsing
     ('netdata', 'format'),  # line too long for docstring parsing


### PR DESCRIPTION
Hi. Quick rundown on this pull request. The first commit. We introduce all placeholders instead of using few placeholders. It's also something that we could merge in hopefully without any issues.

The second commit. I combined `AQI`, `category`, and `color` into one `quality_thresholds` config param. This would break somebody's config (if they have one) because of all this combinations. This, of course, is not perfect when it comes to supporting other URLs... because it's made to work with only one URL right now.

This should be easier for others to support a different `AQI` setup should they want to try it. Maybe if we get some URLs first to figure out the next step from there. I simplified many things to make `air_quality` more readable. This got `thresholds` for `aqi` and we're using `flatten_dict` in this too. Thx. +1 