### PR TITLE
gpmdp: new module from scratch

### DIFF
--- a/py3status/modules/gpmdp.py
+++ b/py3status/modules/gpmdp.py
@@ -3,33 +3,60 @@
 Display song currently playing in Google Play Music Desktop Player.
 
 Configuration parameters:
-    cache_timeout:  refresh interval for this module (default 5)
-    format:         specify the items and ordering of the data in the status bar.
-                    These area 1:1 match to gpmdp-remote's options
-                    (default '♫ {info}')
+    cache_timeout: refresh interval for this module (default 5)
+    format: display format for this module
+        *(default '[\?if=is_started [\?if=title [\?if=playing&color=playing '
+        '{title} - {artist}|\?color=paused (Paused) {title} - {artist}]|'
+        '\?color=stopped Google Play Music]]')*
+    sleep_timeout: sleep interval for this module (default 20)
+
+Control placeholders:
+    {is_started} a boolean based on pgrep data
+    {playing} a boolean based on data status
+    {rating_disliked} a boolean based on data status
+    {rating_liked} a boolean based on data status
 
 Format placeholders:
-    {info}            Print info about now playing song
-    {title}           Print current song title
-    {artist}          Print current song artist
-    {album}           Print current song album
-    {album_art}       Print current song album art URL
-    {time_current}    Print current song time in milliseconds
-    {time_total}      Print total song time in milliseconds
-    {status}          Print whether GPMDP is paused or playing
-    {current}         Print now playing song in "artist - song" format
+    {repeat} song repeat, eg NO_REPEAT, LIST_REPEAT, SINGLE_REPEAT
+    {shuffle} song shuffle, eg NO_SHUFFLE, ALL_SHUFFLE
+    {songLyrics} song lyrics, eg (whole lotta lyrics)
+    {song_albumArt} album art url
+    {song_album} album name
+    {song_artist} artist name
+    {song_title}  title name
+    {time_currenttime} current time in [HH:]MM:SS
+    {time_current} current time in milliseconds
+    {time_totaltime} total time in [HH:]MM:SS
+    {time_total} total time in milliseconds
+    {volume} volume percent
 
+Color options:
+    color_paused: Paused, defaults to color_degraded
+    color_playing: Playing, defaults to color_good
+    color_stopped: Not playing, defaults to color_bad
 
 Requires:
-    gpmdp: http://www.googleplaymusicdesktopplayer.com/
-    gpmdp-remote: https://github.com/iandrewt/gpmdp-remote
+    gpmdp: A beautiful cross platform Desktop Player for Google Play Music
 
-@author Aaron Fields https://twitter.com/spirotot
+@author Aaron Fields https://twitter.com/spirotot, lasers
 @license BSD
 
 SAMPLE OUTPUT
-{'full_text': '♫ Now Playing: The Show Goes On by Lupe Fiasco'}
+{'color': '#00ff00', 'full_text': 'The Show Goes On by Lupe Fiasco'}
+
+paused
+{'color': '#ffff00', 'full_text': '(Paused) The Show Goes On by Lupe Fiasco'}
+
+stopped
+{'color': '#ff0000', 'full_text': 'Google Play Music'}
 """
+
+from __future__ import division
+import json
+import os
+
+GPMDP = '~/.config/Google Play Music Desktop Player/json_store/playback.json'
+PGREP = ['pgrep', '-f', 'Google Play Music Desktop Player']
 
 
 class Py3status:
@@ -37,26 +64,87 @@ class Py3status:
     """
     # available configuration parameters
     cache_timeout = 5
-    format = u'♫ {info}'
+    format = ('[\?if=is_started [\?if=title [\?if=playing&color=playing '
+              '{title} - {artist}|\?color=paused (Paused) {title} - {artist}]|'
+              '\?color=stopped Google Play Music]]')
+    sleep_timeout = 20
+
+    def post_config_hook(self):
+        self.color_paused = self.py3.COLOR_PAUSED or self.py3.COLOR_DEGRADED
+        self.color_playing = self.py3.COLOR_PLAYING or self.py3.COLOR_GOOD
+        self.color_stopped = self.py3.COLOR_STOPPED or self.py3.COLOR_BAD
+        self.playback_json = os.path.expanduser(GPMDP)
+        # DEPRECATION
+        current = self.py3.format_contains(self.format, 'current')
+        status = self.py3.format_contains(self.format, 'status')
+        info = self.py3.format_contains(self.format, 'info')
+        if current or status or info:
+            msg = 'DEPRECATION WARNING: you are using old style configuration'
+            msg += ' parameters you should update to use the new format.'
+            self.py3.log(msg)
+
+    def _is_running(self):
+        try:
+            self.py3.command_output(PGREP)
+            return True
+        except:
+            return False
+
+    def _ms_to_time(self, value):
+        s, ms = divmod(value, 1000)
+        m, s = divmod(s, 60)
+        h, m = divmod(m, 60)
+        time = '%d:%02d:%02d' % (h, m, s)
+        return time.lstrip('0').lstrip(':')
+
+    def _manipulate(self, data):
+        temporary = {}
+        for key, value in data.items():
+            # milliseconds to [hh:]mm:ss
+            if 'time_' in key:
+                new_key = '%s%s' % (key, 'time')
+                temporary[new_key] = self._ms_to_time(value)
+                temporary[key] = value
+            # DEPRECATION: compatible w/ gpmdp-remote's placeholders
+            elif 'song_' in key:
+                if 'albumArt' in key:
+                    new_key = 'album_art'
+                else:
+                    new_key = key.replace('song_', '')
+                temporary[new_key] = value
+                temporary[key] = value
+            else:
+                temporary[key] = value
+
+        # DEPRECATION: compatible w/ gpmdp-remote's status
+        if data['playing']:
+            status = temporary['status'] = 'Playing'
+        else:
+            status = temporary['status'] = 'Paused'
+        # DEPRECATION: compatible w/ gpmdp-remote's current and info
+        artist = data['song_artist']
+        title = data['song_title']
+        temporary['current'] = '%s - %s' % (artist, title)
+        temporary['info'] = 'Now %s: %s by %s' % (status, title, artist)
+
+        return temporary
 
     def gpmdp(self):
-        def _run_cmd(cmd):
-            return self.py3.command_output(['gpmdp-remote', cmd]).strip()
+        data = {}
+        is_started = None
+        cached_until = self.sleep_timeout
 
-        full_text = ''
-        if _run_cmd('status') == 'Playing':
-            cmds = ['info', 'title', 'artist', 'album', 'status', 'current',
-                    'time_total', 'time_current', 'album_art']
-            data = {}
-            for cmd in cmds:
-                if self.py3.format_contains(self.format, '{0}'.format(cmd)):
-                    data[cmd] = _run_cmd(cmd)
-            full_text = self.py3.safe_format(self.format, data)
+        if self._is_running():
+            cached_until = self.cache_timeout
+            is_started = True
+            with open(self.playback_json, 'r') as f:
+                data = self.py3.flatten_dict(json.load(f), '_')
+                data = self._manipulate(data)
 
         return {
-            'cached_until': self.py3.time_in(self.cache_timeout),
-            'full_text': full_text
-        }
+            'cached_until': self.py3.time_in(cached_until),
+            'full_text': self.py3.safe_format(
+                self.format, dict(is_started=is_started, **data))}
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
We revives a closed pull request. https://github.com/ultrabug/py3status/pull/878

* support 5+ external placeholders, same as before.
* remove dependency `gpmdp-remote`
* remove code where it'll run few things per placeholder on every loop
    1) it runs loop calling `gpmdp-shell` for every placeholder.
    2) shell `gpmdp-remote` itself contains `awk` and two `printf`
    3) instead of all that, we can just parse a json file ourselves in python.

Minor changes by taking advantage of new `allow` conditions...
* no more `is_playing`, `is_paused`, and `is_stopped`.
    1) use `\?if=playing` (for playing/paused) and `\?if=!title` (for stopped).
* i remove boolean placeholders for `repeat` and `shuffle`.
   1) users could do `\?if=!repeat=NO_REPEAT` (not sure if this is correct).
   2) users could do `\?if=!shuffle=NO_SHUFFLE` (not sure if this is correct).
* no more hardcoded colors. them colors in the `format` now.

Things to know...
* Get rid of deprecation? Original PR say yes?
* I keep `is_started` as there is no way to tell if `gpmdp` is running (so i can hide the module when it's not running).
* I don't like this...
    ```
    +    {time_currenttime} current time in [HH:]MM:SS
    +    {time_current} current time in milliseconds
    +    {time_totaltime} total time in [HH:]MM:SS
    +    {time_total} total time in milliseconds
    ```
   1) do we override `time_current` + `time_total` or use new formatter? 
* `gpmdp` client itself partially work with `mpris`. when clicking on `mpris`, `mpris` will throw an error. thx.