### PR TITLE
online_status: fix timeout for ping

### DIFF
--- a/py3status/modules/online_status.py
+++ b/py3status/modules/online_status.py
@@ -66,22 +66,22 @@ class Py3status:
     def post_config_hook(self):
         self.color_on = self.py3.COLOR_ON or self.py3.COLOR_GOOD
         self.color_off = self.py3.COLOR_OFF or self.py3.COLOR_BAD
+        self.ping_command = [
+            'ping', '-c', '1', '-W', '%s' % self.timeout, self.url]
 
     def _connection_present(self):
         if '://' in self.url:
             try:
                 urlopen(self.url, timeout=self.timeout)
+                return True
             except:
                 return False
-            else:
-                return True
         else:
             try:
-                self.py3.command_output(['ping', '-c', '1', self.url])
+                self.py3.command_output(self.ping_command)
+                return True
             except:
                 return False
-            else:
-                return True
 
     def online_status(self):
         if self._connection_present():


### PR DESCRIPTION
Reviewing a new module #1163 has been brought to my attention that we're not applying the `timeout` config to the `ping` section. This PR will include the `-W` option for `self.timeout`. Tested OK in `python2` and `python3`.

Like `ping`, I elicted no response from contributers and/or owners for days. My `timeout`, in days, have been reached so I will stop contributing until further notice. We can try again when everybody is not too occupied. Have a good day. :-)
