### PR TITLE
[backlight] Allow slower value change after a threshold

### DIFF
--- a/py3status/modules/backlight.py
+++ b/py3status/modules/backlight.py
@@ -9,6 +9,9 @@ Configuration parameters:
         (default None)
     brightness_minimal: Don't go below this brightness to avoid black screen
         (default 1)
+    brightness_slow: If current brightness value is below this threshold,
+        the value is changed by a minimal value instead of the brightness_delta.
+        (default 0)
     button_down: Button to click to decrease brightness. Setting to 0 disables.
         (default 5)
     button_up: Button to click to increase brightness. Setting to 0 disables.
@@ -55,6 +58,7 @@ class Py3status:
     brightness_delta = 8
     brightness_initial = None
     brightness_minimal = 1
+    brightness_slow = 0
     button_down = 5
     button_up = 4
     cache_timeout = 10
@@ -98,12 +102,14 @@ class Py3status:
         level = self._get_backlight_level()
         button = event['button']
         if button == self.button_up:
-            level += self.brightness_delta
+            delta = self.brightness_delta if level >= self.brightness_slow else 1
+            level += delta
             if level > 100:
                 level = 100
             self._set_backlight_level(level)
         elif button == self.button_down:
-            level -= self.brightness_delta
+            delta = self.brightness_delta if level > self.brightness_slow else 1
+            level -= delta
             if level < self.brightness_minimal:
                 level = self.brightness_minimal
             self._set_backlight_level(level)

--- a/py3status/modules/backlight.py
+++ b/py3status/modules/backlight.py
@@ -7,11 +7,11 @@ Configuration parameters:
         (default 8)
     brightness_initial: Set brightness to this value on start.
         (default None)
-    brightness_minimal: Don't go below this brightness to avoid black screen
-        (default 1)
-    brightness_slow: If current brightness value is below this threshold,
+    brightness_low_tune_threshold: If current value is below this threshold,
         the value is changed by a minimal value instead of the brightness_delta.
         (default 0)
+    brightness_minimal: Don't go below this brightness to avoid black screen
+        (default 1)
     button_down: Button to click to decrease brightness. Setting to 0 disables.
         (default 5)
     button_up: Button to click to increase brightness. Setting to 0 disables.
@@ -57,8 +57,8 @@ class Py3status:
     # available configuration parameters
     brightness_delta = 8
     brightness_initial = None
+    brightness_low_tune_threshold = 0
     brightness_minimal = 1
-    brightness_slow = 0
     button_down = 5
     button_up = 4
     cache_timeout = 10
@@ -102,13 +102,13 @@ class Py3status:
         level = self._get_backlight_level()
         button = event['button']
         if button == self.button_up:
-            delta = self.brightness_delta if level >= self.brightness_slow else 1
+            delta = self.brightness_delta if level >= self.brightness_low_tune_threshold else 1
             level += delta
             if level > 100:
                 level = 100
             self._set_backlight_level(level)
         elif button == self.button_down:
-            delta = self.brightness_delta if level > self.brightness_slow else 1
+            delta = self.brightness_delta if level > self.brightness_low_tune_threshold else 1
             level -= delta
             if level < self.brightness_minimal:
                 level = self.brightness_minimal

--- a/py3status/modules/backlight.py
+++ b/py3status/modules/backlight.py
@@ -7,9 +7,6 @@ Configuration parameters:
         (default 8)
     brightness_initial: Set brightness to this value on start.
         (default None)
-    brightness_low_tune_threshold: If current value is below this threshold,
-        the value is changed by a minimal value instead of the brightness_delta.
-        (default 0)
     brightness_minimal: Don't go below this brightness to avoid black screen
         (default 1)
     button_down: Button to click to decrease brightness. Setting to 0 disables.
@@ -22,6 +19,9 @@ Configuration parameters:
         (default None)
     format: Display brightness, see placeholders below
         (default '☼: {level}%')
+    low_tune_threshold: If current brightness value is below this threshold,
+        the value is changed by a minimal value instead of the brightness_delta.
+        (default 0)
 
 Format status string parameters:
     {level} brightness
@@ -57,13 +57,13 @@ class Py3status:
     # available configuration parameters
     brightness_delta = 8
     brightness_initial = None
-    brightness_low_tune_threshold = 0
     brightness_minimal = 1
     button_down = 5
     button_up = 4
     cache_timeout = 10
     device = None
     format = u'☼: {level}%'
+    low_tune_threshold = 0
 
     class Meta:
         deprecated = {
@@ -102,13 +102,13 @@ class Py3status:
         level = self._get_backlight_level()
         button = event['button']
         if button == self.button_up:
-            delta = self.brightness_delta if level >= self.brightness_low_tune_threshold else 1
+            delta = self.brightness_delta if level >= self.low_tune_threshold else 1
             level += delta
             if level > 100:
                 level = 100
             self._set_backlight_level(level)
         elif button == self.button_down:
-            delta = self.brightness_delta if level > self.brightness_low_tune_threshold else 1
+            delta = self.brightness_delta if level > self.low_tune_threshold else 1
             level -= delta
             if level < self.brightness_minimal:
                 level = self.brightness_minimal


### PR DESCRIPTION
Until I learned about `py3-cmd` I was using my own script for changing brightness. I'm missing one feature in the py3status'es module that I had in my script:

I usually use a large `delta` value (`10`), but my screen is very bright and in the evening I want to fine-tune the brightness and use some value like `2` or `3`. With the constant `delta` it is impossible, it jumps between `10` and `1`.

This change introduces a `brightness_slow` parameter (please suggest a better name), which is a threshold, after which the value is being changed by a minimally possible value instead of the `delta` (I know the hardcoded value of `1` might change in #1077).

My favorite values:

```
backlight {
  brightness_delta = 10
  brightness_slow = 10
}
```

How this looks:

![py3status_backlight](https://user-images.githubusercontent.com/1177900/33045799-6860bf9e-ce4e-11e7-9915-56c1fe6fb1e6.gif)
