### PR TITLE
coin_market: multiple changes

### DIFF
--- a/py3status/modules/coin_market.py
+++ b/py3status/modules/coin_market.py
@@ -23,21 +23,21 @@ Format placeholder:
     {format_coin} format for cryptocurrency coins
 
 format_coin placeholders:
-    {24h_volume_usd}      eg 1435150000.0
-    {available_supply}    eg 16404825.0
-    {id}                  eg bitcoin
-    {last_updated}        eg 1498135152
-    {market_cap_usd}      eg 44119956596.0
-    {name}                eg Bitcoin
-    {percent_change_1h}   eg -0.17
-    {percent_change_24h}  eg -1.93
-    {percent_change_7d}   eg +14.73
-    {price_btc}           eg 1.0
-    {price_usd}           eg 2689.45
-    {rank}                eg 1
-    {symbol}              eg BTC
-    {total_supply}        eg 16404825.0
-    {max_supply}          eg 21000000.0
+    {id}                 eg bitcoin
+    {name}               eg Bitcoin
+    {symbol}             eg BTC
+    {rank}               eg 1
+    {price_usd}          eg 11163.4
+    {price_btc}          eg 1.0
+    {24h_volume_usd}     eg 10156700000.0
+    {market_cap_usd}     eg 186528134260
+    {available_supply}   eg 16708900.0
+    {total_supply}       eg 16708900.0
+    {max_supply}         eg 21000000.0
+    {percent_change_1h}  eg 0.92
+    {percent_change_24h} eg 11.2
+    {percent_change_7d}  eg 35.96
+    {last_updated}       eg 151197295
 
     Placeholders are retrieved directly from the URL.
     The list was harvested only once and should not represent a full list.

--- a/py3status/modules/coin_market.py
+++ b/py3status/modules/coin_market.py
@@ -37,6 +37,7 @@ format_coin placeholders:
     {rank}                eg 1
     {symbol}              eg BTC
     {total_supply}        eg 16404825.0
+    {max_supply}          eg 21000000.0
 
     Placeholders are retrieved directly from the URL.
     The list was harvested only once and should not represent a full list.


### PR DESCRIPTION
![2017-11-29-115258](https://user-images.githubusercontent.com/852504/33390724-69c4e3e2-d4fc-11e7-84af-ed191f41cdd6.png)
* Expose a new placeholder (upstream)
* Don't sort the placeholders. Leave it as-is. Better readability. 
* Add `format_datetime` for `{last_updated}` placeholder. The code is written in loop to deal with potential future `datetime-related` placeholders. It might be a bit excessive and/or not perfect as there is no other `datetime` placeholders to test.
* Docs/code cleanup.

Note: The time is not  always same. I saw coins that were 5 minutes apart. The users can use `{last_updated}` now... cuz nobody know epoch. 