### PR TITLE
py3: fix pretty_cmd for shell

### DIFF
--- a/py3status/py3.py
+++ b/py3status/py3.py
@@ -876,12 +876,13 @@ class Py3:
         A CommandError is raised if an error occurs
         """
         # make a pretty command for error loggings and...
-        # convert the non-shell command to sequence if it is a string
-        if not shell and isinstance(command, basestring):
+        if isinstance(command, basestring):
             pretty_cmd = command
-            command = shlex.split(command)
         else:
             pretty_cmd = ' '.join(command)
+        # convert the non-shell command to sequence if it is a string
+        if not shell and isinstance(command, basestring):
+            command = shlex.split(command)
 
         stderr = STDOUT if capture_stderr else PIPE
 


### PR DESCRIPTION
*Sighs*. My bugfix for the `pretty_cmd` with `basestring`  AND the `shell` aspect in `py3.py`.

If there is an exception with `basestring` and `shell=True`, it'll print `Command p y 3 s t a t u s`. If there is an exception with `[cmd, cmd, cmd]` and `shell=True`, it will print correct. If there is an exception with `[cmd, cmd, cmd]` and `shell=False`, it'll print correct.

The `command_output` have an extra statement and I missed one of possibilities to test. In this, we get the `pretty_cmd` early and on its own.

Initially, it may be easier to just print everything as-is... but this should fully fix it. Also, for the future... we should merge pull requests now... so we can catch minor bugs (if any) on all working branches before the releases... instead of last days. Cheers. 👍 