### PR TITLE
add option to enable support for green threads using gevent.

### DIFF
--- a/py3status/__init__.py
+++ b/py3status/__init__.py
@@ -16,6 +16,16 @@ except NameError:
 
 
 def main():
+    # detect gevent option early because monkey patching should be done before
+    # everything else starts kicking
+    if '-g' in sys.argv or '--gevent' in sys.argv:
+        try:
+            from gevent import monkey
+            monkey.patch_all()
+        except ImportError:
+            print('Requested gevent, but it is not installed!')
+            sys.exit(4)
+
     from py3status.core import Py3statusWrapper
     try:
         locale.setlocale(locale.LC_ALL, '')

--- a/py3status/__init__.py
+++ b/py3status/__init__.py
@@ -22,9 +22,9 @@ def main():
         try:
             from gevent import monkey
             monkey.patch_all()
-        except ImportError:
-            print('Requested gevent, but it is not installed!')
-            sys.exit(4)
+        except Exception:
+            # user will be notified when we start
+            pass
 
     from py3status.core import Py3statusWrapper
     try:

--- a/py3status/core.py
+++ b/py3status/core.py
@@ -397,6 +397,13 @@ class Py3statusWrapper:
                             '--debug',
                             action="store_true",
                             help="be verbose in syslog")
+        parser.add_argument('-g',
+                            '--gevent',
+                            action="store_true",
+                            default=False,
+                            dest="gevent",
+                            help="""enable gevent monkey patching
+                            (default False)""")
         parser.add_argument('-i',
                             '--include',
                             action="append",
@@ -450,6 +457,7 @@ class Py3statusWrapper:
         config['cache_timeout'] = options.cache_timeout
         config['debug'] = options.debug
         config['dbus_notify'] = options.dbus_notify
+        config['gevent'] = options.gevent
         if options.include_paths:
             config['include_paths'] = options.include_paths
         config['interval'] = int(options.interval)
@@ -459,6 +467,21 @@ class Py3statusWrapper:
 
         # all done
         return config
+
+    def gevent_monkey_patch_report(self):
+        """
+        Report effective gevent monkey patching on the logs.
+        """
+        try:
+            import gevent.socket
+            import socket
+            if gevent.socket.socket is socket.socket:
+                self.log('gevent monkey patching is active')
+            else:
+                self.log('gevent monkey patching failed', level='error')
+        except ImportError:
+            self.log('gevent is not installed, monkey patching failed',
+                     level='error')
 
     def get_user_modules(self):
         """
@@ -575,6 +598,9 @@ class Py3statusWrapper:
         if self.config['debug']:
             self.log(
                 'py3status started with config {}'.format(self.config))
+
+        if self.config['gevent']:
+            self.gevent_monkey_patch_report()
 
         # read i3status.conf
         config_path = self.config['i3status_config_path']

--- a/py3status/core.py
+++ b/py3status/core.py
@@ -478,10 +478,10 @@ class Py3statusWrapper:
             if gevent.socket.socket is socket.socket:
                 self.log('gevent monkey patching is active')
             else:
-                self.log('gevent monkey patching failed', level='error')
+                self.notify_user('gevent monkey patching failed')
         except ImportError:
-            self.log('gevent is not installed, monkey patching failed',
-                     level='error')
+            self.notify_user(
+                'gevent is not installed, monkey patching failed')
 
     def get_user_modules(self):
         """
@@ -709,8 +709,8 @@ class Py3statusWrapper:
                 cmd = ['notify-send', '-u', DBUS_LEVELS.get(level, 'normal'),
                        '-t', '10000', 'py3status', msg]
             else:
-                py3_config = self.config['py3_config']
-                nagbar_font = py3_config.get('py3status').get('nagbar_font')
+                py3_config = self.config.get('py3_config', {})
+                nagbar_font = py3_config.get('py3status', {}).get('nagbar_font')
                 if nagbar_font:
                     cmd = ['i3-nagbar', '-f', nagbar_font, '-m', msg, '-t', level]
                 else:
@@ -718,8 +718,8 @@ class Py3statusWrapper:
             Popen(cmd,
                   stdout=open('/dev/null', 'w'),
                   stderr=open('/dev/null', 'w'))
-        except:
-            pass
+        except Exception as err:
+            self.log('notify_user error: %s' % err)
 
     def stop(self):
         """

--- a/setup.py
+++ b/setup.py
@@ -75,6 +75,7 @@ setup(
     author_email='ultrabug@ultrabug.net',
     description='py3status: an extensible i3status wrapper written in python',
     long_description=read('README.rst'),
+    extras_require={'gevent': ['gevent >= 1.1']},
     url='https://github.com/ultrabug/py3status',
     download_url='https://github.com/ultrabug/py3status/tags',
     license='BSD',


### PR DESCRIPTION
This allows to run py3status using the gevent event loop which effectively reduces the load of the system by running everything in a concurrent and non blocking way.

Note that py3status' setup now supports extra requires to allow users to choose their dependencies flavours.