### PR TITLE
timer: add colors

### DIFF
--- a/py3status/modules/timer.py
+++ b/py3status/modules/timer.py
@@ -71,7 +71,7 @@ class Py3status:
         Called when the timer expires
         """
         self.running = False
-        self.color = '#FF0000'
+        self.color = self.py3.COLOR_BAD
         self.time_left = 0
         self.done = True
         if self.sound:
@@ -116,7 +116,6 @@ class Py3status:
                 'index': 'hours',
             },
             {
-                'color': '#CCCCCC',
                 'full_text': ':',
             },
             {
@@ -125,7 +124,6 @@ class Py3status:
                 'index': 'mins',
             },
             {
-                'color': '#CCCCCC',
                 'full_text': ':',
             },
             {
@@ -162,7 +160,7 @@ class Py3status:
                 # pause timer
                 self.running = False
                 self.time_left = int(self.end_time - time())
-                self.color = '#FFFF00'
+                self.color = self.py3.COLOR_DEGRADED
                 if self.alarm_timer:
                     self.alarm_timer.cancel()
             else:
@@ -173,7 +171,7 @@ class Py3status:
                 else:
                     self.end_time = time() + self.time
                 self.cache_offset = self.end_time % 1
-                self.color = '#00FF00'
+                self.color = self.py3.COLOR_GOOD
                 if self.alarm_timer:
                     self.alarm_timer.cancel()
                 self.done = False


### PR DESCRIPTION
Use `self.py3.COLORS` instead to respect users's authoritah! ![2017-12-09-173229_87x24_scrot](https://user-images.githubusercontent.com/852504/33800539-4a540886-dd07-11e7-9602-7832062b3e6b.png) ![2017-12-09-173752_92x30_scrot](https://user-images.githubusercontent.com/852504/33800562-cfa2b816-dd07-11e7-8909-9de22517983e.png) ![2017-12-09-173649_115x26_scrot](https://user-images.githubusercontent.com/852504/33800552-9cb3cddc-dd07-11e7-9c5f-823decae293c.png) 

The colons can be duplicated via `format = '[\?color=#ccc {timer}]'` 