### PR TITLE
Handle cookies within request

### DIFF
--- a/py3status/py3.py
+++ b/py3status/py3.py
@@ -1018,6 +1018,7 @@ class Py3:
         :param headers: http headers to be added to the request as a dict
         :param timeout: timeout for the request in seconds
         :param auth: authentication info as tuple `(username, password)`
+        :param cookiejar: an object of a CookieJar subclass
 
         :returns: HttpResponse
         """

--- a/py3status/py3.py
+++ b/py3status/py3.py
@@ -1008,7 +1008,7 @@ class Py3:
         return color
 
     def request(self, url, params=None, data=None, headers=None,
-                timeout=None, auth=None):
+                timeout=None, auth=None, cookiejar=None):
         """
         Make a request to a url and retrieve the results.
 
@@ -1039,4 +1039,5 @@ class Py3:
                             data=data,
                             headers=headers,
                             timeout=timeout,
-                            auth=auth)
+                            auth=auth,
+                            cookiejar=cookiejar)

--- a/py3status/request.py
+++ b/py3status/request.py
@@ -52,9 +52,7 @@ class HttpResponse:
             headers['Authorization'] = 'Basic %s' % auth_str.decode('utf-8')
         if data:
             data = urlencode(data).encode()
-        print(cookiejar)
         if cookiejar is not None:
-            print("prout")
             self._cookiejar = cookiejar
             opener = build_opener(HTTPCookieProcessor(cookiejar))
             install_opener(opener)

--- a/py3status/request.py
+++ b/py3status/request.py
@@ -7,14 +7,15 @@ try:
     from urllib.error import URLError, HTTPError
     from urllib.parse import urlsplit, urlunsplit, parse_qsl, urlencode
     from urllib.request import (
-        urlopen, Request
+        urlopen, Request, build_opener, install_opener, HTTPCookieProcessor
     )
     IS_PYTHON_3 = True
 except ImportError:
     # Python 2
     from urllib import urlencode
     from urllib2 import (
-        urlopen, Request, URLError, HTTPError
+        urlopen, Request, URLError, HTTPError,
+        build_opener, install_opener, HTTPCookieProcessor
     )
     from urlparse import urlsplit, urlunsplit, parse_qsl
     IS_PYTHON_3 = False
@@ -31,7 +32,7 @@ class HttpResponse:
     The aim is to support both python 2 and 3 and be a simple as possible
     """
 
-    def __init__(self, url, params, data, headers, timeout, auth):
+    def __init__(self, url, params, data, headers, timeout, auth, cookiejar):
         # fix the url if needed
         url_parts = urlsplit(url)
         if url_parts.query or params:
@@ -51,6 +52,13 @@ class HttpResponse:
             headers['Authorization'] = 'Basic %s' % auth_str.decode('utf-8')
         if data:
             data = urlencode(data).encode()
+        print(cookiejar)
+        if cookiejar is not None:
+            print("prout")
+            self._cookiejar = cookiejar
+            opener = build_opener(HTTPCookieProcessor(cookiejar))
+            install_opener(opener)
+
         request = Request(url, headers=headers)
 
         try:
@@ -123,3 +131,20 @@ class HttpResponse:
         except AttributeError:
             self._headers = self._response.headers
             return self._headers
+
+    @property
+    def cookiejar(self):
+        """
+        Get the cookie jar
+        """
+        try:
+            return self._cookiejar
+        except AttributeError:
+            return None
+
+    @cookiejar.setter
+    def cookiejar(self, cj):
+        """
+        Set the cookie jar in care we want to change it after object creation
+        """
+        self._cookiejar = cj


### PR DESCRIPTION
Some websites needs cookies in order to work. With this modification, you can specify a `CookieJar` or subclass object to `py3.request` in order to exploit cookies.