### PR TITLE
google_calendar: fix resume from sleep bug

### DIFF
--- a/py3status/modules/google_calendar.py
+++ b/py3status/modules/google_calendar.py
@@ -399,6 +399,9 @@ class Py3status:
                     event['start'].get('dateTime'))
                 end_dt = self._gstr_to_datetime(event['end'].get('dateTime'))
 
+            if end_dt < datetime.datetime.now(tzlocal()):
+                continue
+
             event_dict['start_time'] = self._datetime_to_str(start_dt,
                                                              self.format_time)
             event_dict['end_time'] = self._datetime_to_str(end_dt,


### PR DESCRIPTION
Hey, I noticed this bug recently when resuming the module from sleep. What happens is, when the system resumes from sleep, clicking on the module will refresh it, but since there usually isn't an internet connection for a few seconds after resuming, when the module builds a response, it will display a negative value in `format_timer` since it's calculating time_delta based on an event that is already over. 

How to reproduce:
1. Make an event for some time in the future.
2. Put the computer to sleep.
3. Resume from sleep AFTER the event has passed.
4. Click on the event in py3status to refresh the module.

The module should now display a negative  value for `format_timer`, like so `(-xd xxh xxm)`.

The small change I made fixes this behavior. 