### PR TITLE
py3: add forever cache_timeout

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -128,6 +128,17 @@ To use an encoded string add ``:base64`` to the name of the parameter.
 .. note::
     Base64 encoding is very simple and should not be considered secure in any way.
 
+Configuring cache_timeout
+-------------------------
+
+Since version 3.8, users can specify `cache_timeout = -1`
+in the config to signal the module to run once.
+
+.. code-block:: py3status
+    xrandr {
+        cache_timeout = -1
+    }
+
 Configuring colors
 ------------------
 

--- a/py3status/py3.py
+++ b/py3status/py3.py
@@ -557,15 +557,15 @@ class Py3:
         .. note::
 
             from version 3.1 modules no longer need to explicitly set a
-            ``cached_until`` in their response unless they wish to directly control
-            it.
+            ``cached_until`` in their response unless they wish to directly
+            control it.
 
         seconds specifies the number of seconds that should occure before the
         update is required.
 
         sync_to causes the update to be syncronised to a time period.  1 would
-        cause the update on the second, 60 to the nearest minute. By defalt we
-        syncronise to the nearest second. 0 will disable this feature.
+        cause the update on the second, 60 to the nearest minute. By default
+        we syncronise to the nearest second. 0 will disable this feature.
 
         offset is used to alter the base time used. A timer that started at a
         certain time could set that as the offset and any syncronisation would
@@ -583,6 +583,9 @@ class Py3:
                 except AttributeError:
                     # use default cache_timeout
                     seconds = self._module.config['cache_timeout']
+        # cache_4ever
+        elif seconds < 0:
+            return PY3_CACHE_FOREVER
 
         # Unless explicitly set we sync to the nearest second
         # Unless the requested update is in less than a second


### PR DESCRIPTION
From https://github.com/ultrabug/py3status/issues/1115:
>@tobes: Sorry was confused. This might be hard as setting = something I believe gets interpreted as setting = "something" by the parser.

It does that. We can't use this alone:
```
if seconds == 'forever':
```
Since it does that, the solution is to use this...
```
if isinstance(seconds, str) and seconds == 'forever':
```
but then, users can make typos and it'd trip up... so we simplify above to this...
```
if isinstance(seconds, str):
```
And I think it's good idea to support `-1` too.
```
if isinstance(seconds, str) or seconds == -1:
```
but then, users can be curious... and use `-2` or whatever, so we should use:
```
if isinstance(seconds, str) or seconds < 0:
```
In the end, it was just silly and modules would have to go that repeatedly. After playing around, I think it is good to just support `-1` instead.

So I wish to keep `cache_timeout` simple, clean and just `int/float` only.
```
+        # cache_forever
+        elif seconds < 0:
+            return -1
```
Closes https://github.com/ultrabug/py3status/issues/1115.