### PR TITLE
xrandr_rotate: display screen properly

### DIFF
--- a/py3status/modules/xrandr_rotate.py
+++ b/py3status/modules/xrandr_rotate.py
@@ -34,7 +34,7 @@ Color options:
     color_degraded: Screen is disconnected
     color_good: Displayed rotation is active
 
-@author Maxim Baz (https://github.com/maximbaz), @lasers
+@author Maxim Baz (https://github.com/maximbaz), lasers
 @license BSD
 
 SAMPLE OUTPUT
@@ -115,7 +115,7 @@ class Py3status:
             if not self.scrolling:
                 self.displayed = self._get_current_rotation_icon(all_outputs)
 
-            if len(all_outputs) == 1:
+            if self.screen or len(all_outputs) == 1:
                 screen = self.screen or all_outputs[0]
             else:
                 screen = 'ALL'


### PR DESCRIPTION
>screen: display output name to rotate, as detected by xrandr.
        If not provided, all enabled screens will be rotated.
        (default None)

Git bisect. None.
Old: If you provide a `screen` and have >1 outputs, it'll display `ALL` and rotate only that output.
New: If you provide a `screen` and have >1 outputs, it'll display `DP-2` and rotate only that output.

A minor bugfix... ~~plus a quick `psc` check to ensure we have a good `screen` too.~~
  