### PR TITLE
formatter: return falsey properly

### DIFF
--- a/py3status/formatter.py
+++ b/py3status/formatter.py
@@ -267,7 +267,9 @@ class Placeholder:
                 output = u'{%s%s}' % (self.key, self.format)
                 value = value_ = output.format(**{self.key: value})
 
-            if block.commands.not_zero:
+            if block.parent is None:
+                valid = True
+            elif block.commands.not_zero:
                 valid = value_ not in ['', 'None', None, False, '0', '0.0', 0, 0.0]
             else:
                 # '', None, and False are ignored

--- a/tests/test_formatter.py
+++ b/tests/test_formatter.py
@@ -296,10 +296,18 @@ def test_26():
 
 
 def test_27():
-    run_formatter({'format': '{None}', 'expected': '', })
+    run_formatter({'format': '{None}', 'expected': 'None', })
 
 
 def test_27a():
+    run_formatter({'format': '{None} {no}', 'expected': 'None False', })
+
+
+def test_27b():
+    run_formatter({'format': '[Hello {None}] {no}', 'expected': ' False', })
+
+
+def test_27c():
     run_formatter({'format': '[Hi, my name is {None_str}]', 'expected': '', })
 
 
@@ -312,7 +320,7 @@ def test_29():
 
 
 def test_30():
-    run_formatter({'format': '{no}', 'expected': '', })
+    run_formatter({'format': '{no}', 'expected': 'False', })
 
 
 def test_31():
@@ -1134,7 +1142,7 @@ def test_module_true_value():
 
 
 def test_module_false_value():
-    run_formatter({'format': '{module_false}', 'expected': ''})
+    run_formatter({'format': '{module_false}', 'expected': 'False'})
 
 
 def test_zero_format_1():


### PR DESCRIPTION
Hi. I'm not familiar with the formatter code. This closes #1095 for me.
This is likely the reason why adding something at end makes it just work.
```python
            elif (self.parent is None and
                    ((not self.next_block and enough)or self.base_block)):
                valid = True
```
Without an `if` in there, the formatter think it is a `[{placeholder}]`.