### PR TITLE
core: make notify_user less ambiguous in the logs

### DIFF
--- a/py3status/core.py
+++ b/py3status/core.py
@@ -378,10 +378,10 @@ class Py3statusWrapper:
             if gevent.socket.socket is socket.socket:
                 self.log('gevent monkey patching is active')
             else:
-                self.notify_user('gevent monkey patching failed')
+                self.notify_user('gevent monkey patching failed.')
         except ImportError:
             self.notify_user(
-                'gevent is not installed, monkey patching failed')
+                'gevent is not installed, monkey patching failed.')
 
     def get_user_modules(self):
         """
@@ -596,9 +596,12 @@ class Py3statusWrapper:
         msg_hash = hash(u'{}#{}#{}'.format(module_name, limit_key, msg))
         if msg_hash in self.notified_messages:
             return
+        elif module_name:
+            log_msg = 'Module `%s` sent a notification. "%s"' % (module_name, msg)
+            self.log(log_msg, level)
         else:
             self.log(msg, level)
-            self.notified_messages.add(msg_hash)
+        self.notified_messages.add(msg_hash)
 
         try:
             if dbus:


### PR DESCRIPTION
Hi. I'm not familiar with the core/py3 code. This closes #1082 for me.
```python
        else:
            self.log(msg, level)
```
It looks like `py3status` want to log all notifications just in case (eg, error, message, etc) which is why I added a parameter `module_msg` in `py3.py`. Both seems okay to me. Pls criticize my werk. Thx.