### PR TITLE
start modules in threads to parallelize

### DIFF
--- a/py3status/module.py
+++ b/py3status/module.py
@@ -31,6 +31,7 @@ class Module:
         self.click_events = False
         self.config = py3_wrapper.config
         self.disabled = False
+        self.enabled = False
         self.error_messages = None
         self.error_hide = False
         self.has_post_config_hook = False
@@ -144,6 +145,7 @@ class Module:
                 msg = 'Exception in `%s` post_config_hook()' % self.module_full_name
                 self._py3_wrapper.report_exception(msg, notify_user=False)
                 self._py3_wrapper.log('terminating module %s' % self.module_full_name)
+        self.enabled = True
 
     def runtime_error(self, msg, method):
         """
@@ -213,6 +215,7 @@ class Module:
         """
         Start the module running.
         """
+        self.prepare_module()
         if not (self.disabled or self.terminated):
             # Start the module and call its output method(s)
             self._py3_wrapper.log('starting module %s' % self.module_full_name)
@@ -222,7 +225,7 @@ class Module:
         """
         Forces an update of the module.
         """
-        if self.disabled or self.terminated:
+        if self.disabled or self.terminated or not self.enabled:
             return
         # clear cached_until for each method to allow update
         for meth in self.methods:


### PR DESCRIPTION
Currently modules are loaded in series and so one slow module running it's `post_config_hook()` blocks starting all modules.

This PR allows each module to be started in a thread.

We need to ensure that the module has been setup before it updates. hence `self.enabled`

