### PR TITLE
github: don't treat first run as special

### DIFF
--- a/py3status/modules/github.py
+++ b/py3status/modules/github.py
@@ -99,7 +99,6 @@ class Py3status:
     username = None
 
     def post_config_hook(self):
-        self.first = True
         self.notification_warning = False
         self.repo_warning = False
         self._issues = '?'
@@ -109,7 +108,6 @@ class Py3status:
         self.url_api = self.url_api.strip('/')
         self.url_base = self.url_base.strip('/')
 
-    def _init(self):
         # Set format if user has not configured it.
         if not self.format:
             if self.username and self.auth_token:
@@ -122,8 +120,6 @@ class Py3status:
         """
         Get counts for requests that return 'total_count' in the json response.
         """
-        if self.first:
-            return '?'
         url = self.url_api + url + '&per_page=1'
         # if we have authentication details use them as we get better
         # rate-limiting.
@@ -152,8 +148,6 @@ class Py3status:
                 self.py3.notify_user('Github module needs username and '
                                      'auth_token to check notifications.')
                 self.notification_warning = True
-            return '?'
-        if self.first:
             return '?'
         if self.notifications == 'all' or not self.repo:
             url = self.url_api + '/notifications'
@@ -194,8 +188,6 @@ class Py3status:
                 self.repo_warning = True
 
     def github(self):
-        if self.first:
-            self._init()
         status = {}
         urgent = False
         # issues
@@ -232,11 +224,7 @@ class Py3status:
             status['repo'] = 'Error'
         status['repo_full'] = self.repo
 
-        if self.first:
-            cached_until = 0
-            self.first = False
-        else:
-            cached_until = self.py3.time_in(self.cache_timeout)
+        cached_until = self.py3.time_in(self.cache_timeout)
 
         return {
             'full_text': self.py3.safe_format(self.format, status),


### PR DESCRIPTION
Simplify the code.

This slightly changes the behaviour as we now do not display until we get data.  Before we showed ?.

I think this makes things cleaner and is worth the minor change

This needs #1246 as otherwise it slows down startup of py3status.