### PR TITLE
allow brightness as a float

### DIFF
--- a/py3status/modules/backlight.py
+++ b/py3status/modules/backlight.py
@@ -84,6 +84,9 @@ class Py3status:
         if self.device is None:
             raise Exception(STRING_NOT_AVAILABLE)
 
+        self.format = self.py3.update_placeholder_formats(
+                self.format, {'level': ':d'}
+        )
         # check for an error code and an output
         self.xbacklight = False
         try:
@@ -120,12 +123,12 @@ class Py3status:
     def _get_backlight_level(self):
         if self.xbacklight:
             level = self.py3.command_output(['xbacklight', '-get']).strip()
-            return round(float(level))
+            return float(level)
         for brightness_line in open("%s/brightness" % self.device, 'rb'):
             brightness = int(brightness_line)
         for brightness_max_line in open("%s/max_brightness" % self.device, 'rb'):
             brightness_max = int(brightness_max_line)
-        return brightness * 100 // brightness_max
+        return brightness * 100 / brightness_max
 
     def backlight(self):
         full_text = ""


### PR DESCRIPTION
this is an alternative to #1076

It allows the user to do `format = '{level:2.f}'` if they want to see as a float

The default output should be as before.