### PR TITLE
google_calendar: remove unused variable

### DIFF
--- a/py3status/modules/google_calendar.py
+++ b/py3status/modules/google_calendar.py
@@ -193,7 +193,6 @@ class Py3status:
 
         self.credentials = self._get_credentials()
         self.is_authorized = False
-        self.first_run = True
 
     def _get_credentials(self):
         """


### PR DESCRIPTION
Parroting.

>Simplify the code.

>I think this makes things cleaner and is worth the minor change