### PR TITLE
Run event in threads to fix latency problems

### DIFF
--- a/py3status/core.py
+++ b/py3status/core.py
@@ -45,10 +45,11 @@ class Runner(Thread):
     """
     A Simple helper to run a module in a Thread so it is non-locking.
     """
-    def __init__(self, module, py3_wrapper):
+    def __init__(self, module, py3_wrapper, module_name):
         Thread.__init__(self)
         self.daemon = True
         self.module = module
+        self.module_name = module_name
         self.py3_wrapper = py3_wrapper
         self.start()
 
@@ -57,6 +58,9 @@ class Runner(Thread):
             self.module.run()
         except:
             self.py3_wrapper.report_exception('Runner')
+        # the module is no longer running so notify the timeout logic
+        if self.module_name:
+            self.py3_wrapper.timeout_finished.append(self.module_name)
 
 
 class NoneSetting:
@@ -259,10 +263,13 @@ class Py3statusWrapper:
         # these are used to schedule module updates
         self.timeout_add_queue = deque()
         self.timeout_due = None
-        self.timeout_update_due = deque()
+        self.timeout_finished = deque()
+        self.timeout_keys = []
+        self.timeout_missed = {}
         self.timeout_queue = {}
         self.timeout_queue_lookup = {}
-        self.timeout_keys = []
+        self.timeout_running = set()
+        self.timeout_update_due = deque()
 
     def timeout_queue_add(self, item, cache_time=0):
         """
@@ -358,10 +365,33 @@ class Py3statusWrapper:
             except IndexError:
                 self.timeout_due = None
 
+        # process any finished modules.
+        # Now that the module has finished running it may have been marked to
+        # be triggered again. This is most likely to happen when events are
+        # being processed and the events are arriving much faster than the
+        # module can handle them.  It is important as a module may handle
+        # events but not trigger the module update.  If during the event the
+        # module is due to update the update is not actioned but it needs to be
+        # once the events have finished or else the module will no longer
+        # continue to update.
+        while self.timeout_finished:
+            module_name = self.timeout_finished.popleft()
+            self.timeout_running.discard(module_name)
+            if module_name in self.timeout_missed:
+                module = self.timeout_missed.pop(module_name)
+                self.timeout_update_due.append(module)
+
         # run any modules that are due
         while self.timeout_update_due:
             module = self.timeout_update_due.popleft()
-            Runner(module, self)
+            module_name = getattr(module, 'module_full_name', None)
+            # if the module is running then we do not want to trigger it but
+            # instead wait till it has finished running and then trigger
+            if module_name and module_name in self.timeout_running:
+                self.timeout_missed[module_name] = module
+            else:
+                self.timeout_running.add(module_name)
+                Runner(module, self, module_name)
 
         # we return how long till we next need to process the timeout_queue
         if self.timeout_due is not None:

--- a/py3status/events.py
+++ b/py3status/events.py
@@ -50,6 +50,19 @@ class IOPoller:
             return None
 
 
+class EventTask:
+    """
+    A simple task that can be run by the scheduler.
+    """
+    def __init__(self, module_name, event, events_thread):
+        self.events_thread = events_thread
+        self.module_full_name = module_name
+        self.event = event
+
+    def run(self):
+        self.events_thread.process_event(self.module_full_name, self.event)
+
+
 class Events(Thread):
     """
     This class is responsible for dispatching event JSONs sent by the i3bar.
@@ -220,7 +233,8 @@ class Events(Thread):
         # guess the module config name
         module_name = '{} {}'.format(name, instance).strip()
         # do the work
-        self.process_event(module_name, event)
+        task = EventTask(module_name, event, self)
+        self.py3_wrapper.timeout_queue_add(task)
 
     @profile
     def run(self):


### PR DESCRIPTION
To test these changes it is easy to add a `sleep(0.5)` in a module like `volume_status` and then create some scrollwheel events.

This PR allows events to be handled in threads.  This is good because

* An event no longer blocks other events being handled.  This is a problem if an event takes a long time to run

* We do not end up with a backlog of events that can confuse the user as they are handled when they are triggered rather than in a queue.

To work smoothly we also discard some events/updates.  A module should only handle events one at a time this includes it's own scheduled updates.  So we only let a module instance run one thing at a time.  There is a complication that if a module has a scheduled update during an event the update is discarded.  If the event does not trigger an update this would lead to the module stopping updating.  Therefore we need to trigger these 'missed' updates when we can.  This logic is slightly complicated as we need to ensure that the logic is carried out in the main thread so that we do not have any inter-thread timing issues etc.

I've done a fair bit of testing and this seems stable and makes for a much improved user experience

related issue #1169