### PR TITLE
allow test modules to use storage

### DIFF
--- a/py3status/storage.py
+++ b/py3status/storage.py
@@ -17,7 +17,7 @@ class Storage:
         self.is_python_2 = is_python_2
         self.py3_wrapper = py3_wrapper
         config_dir = os.path.dirname(
-            py3_wrapper.config['i3status_config_path']
+            py3_wrapper.config.get('i3status_config_path', '/tmp')
         )
         storage_path = os.path.join(config_dir, 'py3status.data')
         self.storage_path = storage_path


### PR DESCRIPTION
#1261 running modules in test mode failed if they used storage.  This is a quick fix for that issue where we cannot get the `i3status_config_path`.

Really we need a proper fix where we load test modules via the full stack.  We will have to consider if test modules can write to our datastore as that may not be something we want them to do.  But that is for another day.