### PR TITLE
py3: command_output call command with LC_ALL=C

### DIFF
--- a/py3status/modules/external_script.py
+++ b/py3status/modules/external_script.py
@@ -13,6 +13,8 @@ Configuration parameters:
     cache_timeout: how often we refresh this module in seconds
         (default 15)
     format: see placeholders below (default '{output}')
+    localize: should script output be localized (if available)
+        (default True)
     script_path: script you want to show output of (compulsory)
         (default None)
     strip_output: shall we strip leading and trailing spaces from output
@@ -49,6 +51,7 @@ class Py3status:
     # available configuration parameters
     cache_timeout = 15
     format = '{output}'
+    localize = True
     script_path = None
     strip_output = False
 
@@ -61,7 +64,7 @@ class Py3status:
         response = {}
         response['cached_until'] = self.py3.time_in(self.cache_timeout)
         try:
-            output = self.py3.command_output(self.script_path, shell=True, localized=True)
+            output = self.py3.command_output(self.script_path, shell=True, localized=self.localize)
             output_lines = output.splitlines()
             if len(output_lines) > 1:
                 output_color = output_lines[1]

--- a/py3status/modules/external_script.py
+++ b/py3status/modules/external_script.py
@@ -61,7 +61,7 @@ class Py3status:
         response = {}
         response['cached_until'] = self.py3.time_in(self.cache_timeout)
         try:
-            output = self.py3.command_output(self.script_path, shell=True)
+            output = self.py3.command_output(self.script_path, shell=True, localized=True)
             output_lines = output.splitlines()
             if len(output_lines) > 1:
                 output_color = output_lines[1]

--- a/py3status/py3.py
+++ b/py3status/py3.py
@@ -105,6 +105,8 @@ class Py3:
     def __init__(self, module=None):
         self._audio = None
         self._config_setting = {}
+        self._english_env = dict(os.environ)
+        self._english_env['LC_ALL'] = 'C'
         self._format_placeholders = {}
         self._format_placeholders_cache = {}
         self._is_python_2 = sys.version_info < (3, 0)
@@ -879,7 +881,7 @@ class Py3:
             msg = 'Command `{cmd}` {error}'.format(cmd=pretty_cmd, error=e.errno)
             raise exceptions.CommandError(msg, error_code=e.errno)
 
-    def command_output(self, command, shell=False, capture_stderr=False):
+    def command_output(self, command, shell=False, capture_stderr=False, localized=False):
         """
         Run a command and return its output as unicode.
         The command can either be supplied as a sequence or string.
@@ -887,6 +889,7 @@ class Py3:
         :param command: command to run can be a str or list
         :param shell: if `True` then command is run through the shell
         :param capture_stderr: if `True` then STDERR is piped to STDOUT
+        :param localized: if `False` then command is forced to use its default (English) locale
 
         A CommandError is raised if an error occurs
         """
@@ -900,10 +903,12 @@ class Py3:
             command = shlex.split(command)
 
         stderr = STDOUT if capture_stderr else PIPE
+        env = self._english_env if not localized else None
 
         try:
             process = Popen(command, stdout=PIPE, stderr=stderr, close_fds=True,
-                            universal_newlines=True, shell=shell)
+                            universal_newlines=True, shell=shell,
+                            env=env)
         except Exception as e:
             msg = 'Command `{cmd}` {error}'.format(cmd=pretty_cmd, error=e)
             raise exceptions.CommandError(msg, error_code=e.errno)


### PR DESCRIPTION
Many modules parse command's output by searching for keywords which
are mostly English words. This fails when command is able to provide
localized output based on user's locale

This PR adds to `localized` parameter (False by default) to py3.command_output 
to control whether it should set environment variable LC_ALL to C which
forces application to use default (mostly English) locale.

Having this, command output will be independent from user locale.

To consider:
- localized = False by default means that existing modules have to be modified if they
rely on output being localized, but since most (all?) modules scrap data from command's
output instead of displaying the output directly, it might not be a problem.