### PR TITLE
volume_status: use py3.command_output

### DIFF
--- a/py3status/modules/volume_status.py
+++ b/py3status/modules/volume_status.py
@@ -82,8 +82,7 @@ mute
 """
 
 import re
-from os import devnull, environ as os_environ
-from subprocess import check_output, call, CalledProcessError
+from py3status.exceptions import CommandError
 
 STRING_ERROR = 'invalid command `%s`'
 STRING_NOT_AVAILABLE = 'no available binary'
@@ -103,8 +102,10 @@ class AudioBackend():
         raise NotImplementedError
 
     def run_cmd(self, cmd):
-        with open(devnull, 'wb') as dn:
-            return call(cmd, stdout=dn, stderr=dn)
+        return self.parent.py3.command_run(cmd)
+
+    def command_output(self, cmd):
+        return self.parent.py3.command_output(cmd)
 
 
 class AmixerBackend(AudioBackend):
@@ -121,7 +122,7 @@ class AmixerBackend(AudioBackend):
                                '-c', self.card, 'sget', self.channel]
 
     def get_volume(self):
-        output = check_output(self.get_volume_cmd).decode('utf-8')
+        output = self.command_output(self.get_volume_cmd)
 
         # find percentage and status
         p = re.compile(r'\[(\d{1,3})%\].*\[(\w{2,3})\]')
@@ -157,12 +158,12 @@ class PamixerBackend(AudioBackend):
 
     def get_volume(self):
         try:
-            perc = check_output(self.cmd + ["--get-volume"])
-        except CalledProcessError as cpe:
+            perc = self.command_output(self.cmd + ["--get-volume"])
+        except CommandError as ce:
             # pamixer throws error on zero percent. see #1135
-            perc = cpe.output
+            perc = ce.output
 
-        perc = perc.decode().strip()
+        perc = perc.strip()
         muted = (self.run_cmd(self.cmd + ["--get-mute"]) == 0)
         return perc, muted
 
@@ -191,9 +192,6 @@ class PactlBackend(AudioBackend):
         if self.device is None:
             self.device = self.get_default_device()
 
-        self.english_env = dict(os_environ)
-        self.english_env['LC_ALL'] = 'C'
-
         self.max_volume = parent.max_volume
         self.re_volume = re.compile(r'{} \#{}.*?Mute: (\w{{2,3}}).*?Volume:.*?(\d{{1,3}})\%'
                                     .format(self.device_type_cap, self.device), re.M | re.DOTALL)
@@ -203,7 +201,8 @@ class PactlBackend(AudioBackend):
 
         # Find the default device for the device type
         default_dev_pattern = re.compile(r'^Default {}: (.*)$'.format(self.device_type_cap))
-        for info_line in check_output(['pactl', 'info']).decode('utf-8').splitlines():
+        output = self.command_output(['pactl', 'info'])
+        for info_line in output.splitlines():
             default_dev_match = default_dev_pattern.match(info_line)
             if default_dev_match is not None:
                 device_id = default_dev_match.groups()[0]
@@ -211,8 +210,8 @@ class PactlBackend(AudioBackend):
 
         # with the long gross id, find the associated number
         if device_id is not None:
-            for line in check_output(['pactl', 'list', 'short', self.device_type_pl]) \
-                    .decode('utf-8').splitlines():
+            output = self.command_output(['pactl', 'list', 'short', self.device_type_pl])
+            for line in output.splitlines():
                 parts = line.split()
                 if len(parts) < 2:
                     continue
@@ -223,8 +222,7 @@ class PactlBackend(AudioBackend):
             'input' if self.is_input else 'output', device_id))
 
     def get_volume(self):
-        output = check_output(
-            ['pactl', 'list', self.device_type_pl], env=self.english_env).decode('utf-8').strip()
+        output = self.command_output(['pactl', 'list', self.device_type_pl]).strip()
         muted, perc = self.re_volume.search(output).groups()
 
         # muted should be 'on' or 'off'


### PR DESCRIPTION
This PR partially relies on #1267 

volume_status module calls commands by using functions directly from subprocess
instead of using helper function from py3. It also fails to parse some commands
output with non-English locale set. 

This PR makes volume_status use py3.command_output function, which in
conjunction with #1267 fixes command parsing issue.