### PR TITLE
Do-not-distrub configurable signals

### DIFF
--- a/py3status/modules/do_not_disturb.py
+++ b/py3status/modules/do_not_disturb.py
@@ -11,14 +11,14 @@ Configuration parameters:
         (default 'dunst')
     refresh_interval: Refresh interval to use for killing notification manager process.
         (default 0.25)
-    state_off: Message when the "Do Not Disturb" mode is disabled.
-        (default 'OFF')
-    state_on: Message when the "Do Not Disturb" mode is enabled.
-        (default 'ON')
     signal_off: Signal to send to the process to disable "Do Not Distrub"
         (default 'SIGTERM')
     signal_on: Signal to send to the process to enable "Do Not Distrub"
         (default 'SIGUSR1')
+    state_off: Message when the "Do Not Disturb" mode is disabled.
+        (default 'OFF')
+    state_on: Message when the "Do Not Disturb" mode is enabled.
+        (default 'ON')
 
 Color options:
     color_bad: "Do Not Disturb" mode is enabled.
@@ -46,10 +46,10 @@ class Py3status:
     format = '{state}'
     notification_manager = 'dunst'
     refresh_interval = 0.25
-    state_off = 'OFF'
-    state_on = 'ON'
     signal_off = 'SIGTERM'
     signal_on = 'SIGUSR1'
+    state_off = 'OFF'
+    state_on = 'ON'
 
     def post_config_hook(self):
         self.is_on = False

--- a/py3status/modules/do_not_disturb.py
+++ b/py3status/modules/do_not_disturb.py
@@ -87,7 +87,7 @@ class Py3status:
             self.is_on = not self.is_on
             if self._is_dunst():
                 new_flag = "--signal {}".format(self.dunst_signal_on
-                        if self.is_on else self.dunst_signal_off)
+                                                if self.is_on else self.dunst_signal_off)
                 system("killall {} dunst".format(new_flag))
             else:
                 if self.is_on:

--- a/py3status/modules/do_not_disturb.py
+++ b/py3status/modules/do_not_disturb.py
@@ -5,9 +5,9 @@ Turn on and off dbus notifications.
 A left mouse click will toggle the state of this module.
 
 Configuration parameters:
-    dunst_signal_off: Signal to send to the dunst process to disable "Do Not Distrub"
+    dunst_signal_off: Signal to send to the dunst process to disable "Do Not Disturb."
         (default 'SIGTERM')
-    dunst_signal_on: Signal to send to the dunst process to enable "Do Not Distrub"
+    dunst_signal_on: Signal to send to the dunst process to enable "Do Not Disturb."
         (default 'SIGUSR1')
     format: Display format for the "Do Not Disturb" module.
         (default '{state}')

--- a/py3status/modules/do_not_disturb.py
+++ b/py3status/modules/do_not_disturb.py
@@ -15,6 +15,10 @@ Configuration parameters:
         (default 'OFF')
     state_on: Message when the "Do Not Disturb" mode is enabled.
         (default 'ON')
+    signal_off: Signal to send to the process to disable "Do Not Distrub"
+        (default '-SIGTERM')
+    signal_on: Signal to send to the process to enable "Do Not Distrub"
+        (default '-SIGUSR1')
 
 Color options:
     color_bad: "Do Not Disturb" mode is enabled.
@@ -44,6 +48,8 @@ class Py3status:
     refresh_interval = 0.25
     state_off = 'OFF'
     state_on = 'ON'
+    signal_off = '-SIGTERM'
+    signal_on = '-SIGUSR1'
 
     def post_config_hook(self):
         self.is_on = False
@@ -80,7 +86,7 @@ class Py3status:
         if event['button'] == 1:
             self.is_on = not self.is_on
             if self._is_dunst():
-                new_flag = '-SIGUSR1' if self.is_on else '-SIGTERM'
+                new_flag = self.signal_on if self.is_on else self.signal_off
                 system("killall {} dunst".format(new_flag))
             else:
                 if self.is_on:

--- a/py3status/modules/do_not_disturb.py
+++ b/py3status/modules/do_not_disturb.py
@@ -5,16 +5,16 @@ Turn on and off dbus notifications.
 A left mouse click will toggle the state of this module.
 
 Configuration parameters:
+    dunst_signal_off: Signal to send to the dunst process to disable "Do Not Distrub"
+        (default 'SIGTERM')
+    dunst_signal_on: Signal to send to the dunst process to enable "Do Not Distrub"
+        (default 'SIGUSR1')
     format: Display format for the "Do Not Disturb" module.
         (default '{state}')
     notification_manager: The process name of your notification manager.
         (default 'dunst')
     refresh_interval: Refresh interval to use for killing notification manager process.
         (default 0.25)
-    signal_off: Signal to send to the process to disable "Do Not Distrub"
-        (default 'SIGTERM')
-    signal_on: Signal to send to the process to enable "Do Not Distrub"
-        (default 'SIGUSR1')
     state_off: Message when the "Do Not Disturb" mode is disabled.
         (default 'OFF')
     state_on: Message when the "Do Not Disturb" mode is enabled.
@@ -43,11 +43,11 @@ class Py3status:
     """
     """
     # available configuration parameters
+    dunst_signal_off = 'SIGTERM'
+    dunst_signal_on = 'SIGUSR1'
     format = '{state}'
     notification_manager = 'dunst'
     refresh_interval = 0.25
-    signal_off = 'SIGTERM'
-    signal_on = 'SIGUSR1'
     state_off = 'OFF'
     state_on = 'ON'
 
@@ -86,7 +86,7 @@ class Py3status:
         if event['button'] == 1:
             self.is_on = not self.is_on
             if self._is_dunst():
-                new_flag = "--signal {}".format(self.signal_on if self.is_on else self.signal_off)
+                new_flag = "--signal {}".format(self.dunst_signal_on if self.is_on else self.dunst_signal_off)
                 system("killall {} dunst".format(new_flag))
             else:
                 if self.is_on:

--- a/py3status/modules/do_not_disturb.py
+++ b/py3status/modules/do_not_disturb.py
@@ -86,7 +86,8 @@ class Py3status:
         if event['button'] == 1:
             self.is_on = not self.is_on
             if self._is_dunst():
-                new_flag = "--signal {}".format(self.dunst_signal_on if self.is_on else self.dunst_signal_off)
+                new_flag = "--signal {}".format(self.dunst_signal_on
+                        if self.is_on else self.dunst_signal_off)
                 system("killall {} dunst".format(new_flag))
             else:
                 if self.is_on:

--- a/py3status/modules/do_not_disturb.py
+++ b/py3status/modules/do_not_disturb.py
@@ -16,9 +16,9 @@ Configuration parameters:
     state_on: Message when the "Do Not Disturb" mode is enabled.
         (default 'ON')
     signal_off: Signal to send to the process to disable "Do Not Distrub"
-        (default '-SIGTERM')
+        (default 'SIGTERM')
     signal_on: Signal to send to the process to enable "Do Not Distrub"
-        (default '-SIGUSR1')
+        (default 'SIGUSR1')
 
 Color options:
     color_bad: "Do Not Disturb" mode is enabled.
@@ -48,8 +48,8 @@ class Py3status:
     refresh_interval = 0.25
     state_off = 'OFF'
     state_on = 'ON'
-    signal_off = '-SIGTERM'
-    signal_on = '-SIGUSR1'
+    signal_off = 'SIGTERM'
+    signal_on = 'SIGUSR1'
 
     def post_config_hook(self):
         self.is_on = False
@@ -86,7 +86,7 @@ class Py3status:
         if event['button'] == 1:
             self.is_on = not self.is_on
             if self._is_dunst():
-                new_flag = self.signal_on if self.is_on else self.signal_off
+                new_flag = "--signal {}".format(self.signal_on if self.is_on else self.signal_off)
                 system("killall {} dunst".format(new_flag))
             else:
                 if self.is_on:


### PR DESCRIPTION
I use the do-not-disturb module with `dunst`, and prefer to use `SIGUSR2` to bring it out of DND mode (`SIGTERM` actually causes the process to exit). This patch makes the set of signals configurable.