### PR TITLE
allow overiding xrandr resolution using {output}_mode

### DIFF
--- a/py3status/modules/xrandr.py
+++ b/py3status/modules/xrandr.py
@@ -288,20 +288,25 @@ class Py3status:
             if output in combination:
                 pos = getattr(self, '{}_pos'.format(output), '0x0')
                 rotation = getattr(self, '{}_rotate'.format(output), 'normal')
+                resolution = getattr(self, '{}_mode'.format(output), None)
+                resolution = '--mode {}'.format(resolution) if resolution else '--auto'
                 if rotation not in ['inverted', 'left', 'normal', 'right']:
                     self.py3.log('configured rotation {} is not valid'.format(
                         rotation))
                     rotation = 'normal'
                 #
                 if mode == 'clone' and previous_output is not None:
-                    cmd += ' --auto --same-as {}'.format(previous_output)
+                    cmd += ' {} --same-as {}'.format(resolution,
+                                                     previous_output)
                 else:
                     if ('above' in pos or 'below' in pos or 'left-of' in pos or
                             'right-of' in pos):
-                        cmd += ' --auto --{} --rotate {}'.format(pos, rotation)
+                        cmd += ' {} --{} --rotate {}'.format(resolution, pos,
+                                                             rotation)
                     else:
-                        cmd += ' --auto --pos {} --rotate {}'.format(pos,
-                                                                     rotation)
+                        cmd += ' {} --pos {} --rotate {}'.format(resolution,
+                                                                 pos,
+                                                                 rotation)
                 previous_output = output
             else:
                 cmd += ' --off'

--- a/py3status/modules/xrandr.py
+++ b/py3status/modules/xrandr.py
@@ -65,6 +65,9 @@ Dynamic configuration parameters:
         Example: DP1_workspaces = "1,2,3"
     <OUTPUT>_rotate: rotate the output as told
         Example: DP1_rotate = "left"
+    <OUTPUT>_mode: define the mode (resolution) for the output
+                   if not specified use --auto : prefered mode
+        Example: eDP1_mode = "2560x1440
 
 Color options:
     color_bad: Displayed layout unavailable


### PR DESCRIPTION
Allow user to specify the resolution they want for each screen using a parameter {output}_mode in i3status.conf 