### PR TITLE
Added emerge status module

### DIFF
--- a/py3status/modules/emerge_status.py
+++ b/py3status/modules/emerge_status.py
@@ -25,7 +25,7 @@ Format examples:
     '{category} - {pkg}'
     Result: "x11-misc - py3status"
 
-@author: AnwariasEu
+@author AnwariasEu
 """
 
 import os

--- a/py3status/modules/emerge_status.py
+++ b/py3status/modules/emerge_status.py
@@ -104,8 +104,6 @@ class Py3status:
                         ret['category'] = res.group('category')
                         ret['pkg'] = res.group('pkg')
                         ret['action'] = res.group('action')
-                    else:
-                        raise Exception('Regex did not match a line')
                     break
         return ret
 

--- a/py3status/modules/emerge_status.py
+++ b/py3status/modules/emerge_status.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-
 """
 Emerge_status provides a short information on the current
 emerge status if there is an emerge process currently running

--- a/py3status/modules/emerge_status.py
+++ b/py3status/modules/emerge_status.py
@@ -44,7 +44,7 @@ class Py3status:
         Returns true if at least one instance of emerge is running.
         """
         try:
-            self.py3.command_output(['pidof', 'emerge'])
+            self.py3.command_output(['pgrep', 'emerge'])
             return True
         except:
             return False

--- a/py3status/modules/emerge_status.py
+++ b/py3status/modules/emerge_status.py
@@ -13,6 +13,7 @@ Format placeholders:
     {total} Total number of packages that will be emerged
     {category} Category of the currently emerged package
     {pkg} Name of the currently emerged packaged
+    {action} Current emerge action
 
 Format examples:
      {current} / {total}'
@@ -63,6 +64,7 @@ class Py3status:
         ret['total'] = None
         ret['category'] = None
         ret['pkg'] = None
+        ret['action'] = None
 
         input_data = []
 
@@ -92,6 +94,7 @@ class Py3status:
                 if match:
                     status_re = (
                         "\((?P<current>[0-9]+) of (?P<total>[0-9]+)\) "
+                        "\((?P<action>[a-zA-Z0-9\/]+( [a-zA-Z0-9]+)?) "
                         "(?P<category>[a-zA-Z0-9\-]+)\/(?P<pkg>[a-zA-Z0-9\.]+)"
                     )
                     res = re.search(status_re, match.group())
@@ -100,6 +103,7 @@ class Py3status:
                         ret['total'] = res.group('total')
                         ret['category'] = res.group('category')
                         ret['pkg'] = res.group('pkg')
+                        ret['action'] = res.group('action')
                     else:
                         raise Exception('Regex did not match a line')
                     break
@@ -123,6 +127,7 @@ class Py3status:
                 self.ret['total'] = "0"
                 self.ret['category'] = ""
                 self.ret['pkg'] = ""
+                self.ret['action'] = "None"
                 response['full_text'] = self.py3.safe_format(
                     self.format, self.ret)
 

--- a/py3status/modules/emerge_status.py
+++ b/py3status/modules/emerge_status.py
@@ -29,6 +29,8 @@ Format examples:
 
 import re
 
+STRING_NOT_INSTALLED = "emerge not installed"
+
 
 class Py3status:
     """
@@ -48,6 +50,10 @@ class Py3status:
             return True
         except:
             return False
+
+    def post_config_hook(self):
+        if not self.py3.check_commands('emerge'):
+            raise Exception(STRING_NOT_INSTALLED)
 
     def _getProgress(self):
         """

--- a/py3status/modules/emerge_status.py
+++ b/py3status/modules/emerge_status.py
@@ -73,8 +73,7 @@ class Py3status:
         """
         try:
             with open(emerge_log_file, 'r') as fp:
-                for line in fp:
-                    input_data.append(line)
+                input_data = fp.readlines()
         except IOError as err:
             raise Exception(err)
 

--- a/py3status/modules/emerge_status.py
+++ b/py3status/modules/emerge_status.py
@@ -27,7 +27,6 @@ Format examples:
 @author AnwariasEu
 """
 
-import os
 import re
 
 
@@ -41,15 +40,13 @@ class Py3status:
 
     def _emergeRunning(self):
         """
-        Use pgrep to check if emerge is running.
-
+        Check if emerge is running.
         Returns true if at least one instance of emerge is running.
         """
-        tmp = os.popen("pgrep emerge").read()
-        pcount = tmp.count("\n")
-        if pcount > 0:
+        try:
+            self.py3.command_output(['pidof', 'emerge'])
             return True
-        else:
+        except:
             return False
 
     def _getProgress(self):

--- a/py3status/modules/emerge_status.py
+++ b/py3status/modules/emerge_status.py
@@ -4,7 +4,7 @@ Emerge_status provides a short information on the current
 emerge status if there is an emerge process currently running
 
 Configuration parameters:
-    cache_timeout: how often we refresh this module in second (default 1)
+    cache_timeout: how often we refresh this module in second (default 0)
     emerge_log_file: in case it is placed somewhere else than the default
         (default '/var/log/emerge.log')
     format: Display format to user (default '{current} / {total}')
@@ -35,7 +35,7 @@ STRING_NOT_INSTALLED = "emerge not installed"
 class Py3status:
     """
     """
-    cache_timeout = 1
+    cache_timeout = 0
     emerge_log_file = '/var/log/emerge.log'
     format = u'{current} / {total}'
     hide_if_zero = True

--- a/py3status/modules/emerge_status.py
+++ b/py3status/modules/emerge_status.py
@@ -5,8 +5,6 @@ emerge status if there is an emerge process currently running
 
 Configuration parameters:
     cache_timeout: how often we refresh this module in second (default 0)
-    emerge_log_file: in case it is placed somewhere else than the default
-        (default '/var/log/emerge.log')
     format: Display format to user (default '{current} / {total}')
     hide_if_zero: Don't show in bar if there is no emerge running (default True)
 
@@ -36,7 +34,6 @@ class Py3status:
     """
     """
     cache_timeout = 0
-    emerge_log_file = '/var/log/emerge.log'
     format = u'{current} / {total}'
     hide_if_zero = True
 
@@ -61,6 +58,8 @@ class Py3status:
 
         returns a dict containing current and total value.
         """
+        emerge_log_file = '/var/log/emerge.log'
+
         ret = {}
         ret['current'] = None
         ret['total'] = None
@@ -75,13 +74,13 @@ class Py3status:
         Try to open file, if unable throw error to be catched later
         """
         try:
-            with open(self.emerge_log_file, 'r') as fp:
+            with open(emerge_log_file, 'r') as fp:
                 for line in fp:
                     input_data.append(line)
         except IOError as err:
             ret['err'] = True
             ret['err_text'] = "Opening {} failed: {}" \
-                .format(self.emerge_log_file, err)
+                .format(emerge_log_file, err)
             return ret
 
         """

--- a/py3status/modules/emerge_status.py
+++ b/py3status/modules/emerge_status.py
@@ -85,8 +85,7 @@ class Py3status:
         input_data.reverse()
 
         for line in input_data:
-            terminated = re.search("\*\*\* terminating\.", line)
-            if terminated:
+            if "*** terminating." in line:
                 ret['current'] = "0"
                 ret['total'] = "0"
                 break

--- a/py3status/modules/emerge_status.py
+++ b/py3status/modules/emerge_status.py
@@ -11,13 +11,19 @@ Configuration parameters:
     format: Display format to user (default '{current} / {total}')
     hide_if_zero: Don't show in bar if there is no emerge running (default True)
 
-    More format options:
-        Ex: '{current} / {total}'
-        Result: "3 / 14"
-        Ex: '{current} / {total} = {'
-        Result: "3 / 14 = py3status"
-        Ex: '{category} - {pkg}'
-        Result: "x11-misc - py3status"
+Format placeholders:
+    {current} Number of package that is currently emerged
+    {total} Total number of packages that will be emerged
+    {category} Category of the currently emerged package
+    {pkg} Name of the currently emerged packaged
+
+Format examples:
+     {current} / {total}'
+    Result: "3 / 14"
+    '{current} / {total} = {pkg}'
+    Result: "3 / 14 = py3status"
+    '{category} - {pkg}'
+    Result: "x11-misc - py3status"
 
 @author: AnwariasEu
 """

--- a/py3status/modules/emerge_status.py
+++ b/py3status/modules/emerge_status.py
@@ -5,7 +5,7 @@ emerge status if there is an emerge process currently running
 
 Configuration parameters:
     cache_timeout: how often we refresh this module in second (default 0)
-    format: Display format to user (default '{current} / {total}')
+    format: Display format to user (default 'EMRG: {current} / {total}')
     hide_if_zero: Don't show in bar if there is no emerge running (default True)
 
 Format placeholders:
@@ -33,7 +33,7 @@ class Py3status:
     """
     """
     cache_timeout = 0
-    format = u'{current} / {total}'
+    format = u'EMRG: {current} / {total}'
     hide_if_zero = True
 
     def _emergeRunning(self):

--- a/py3status/modules/emerge_status.py
+++ b/py3status/modules/emerge_status.py
@@ -6,7 +6,7 @@ emerge status if there is an emerge process currently running
 Configuration parameters:
     cache_timeout: how often we refresh this module in second (default 0)
     format: Display format to user (default 'EMRG: {current} / {total}')
-    hide_if_zero: Don't show in bar if there is no emerge running (default True)
+    hide_if_zero: Don't show in bar if there is no emerge running (default False)
 
 Format placeholders:
     {current} Number of package that is currently emerged
@@ -34,7 +34,7 @@ class Py3status:
     """
     cache_timeout = 0
     format = u'EMRG: {current} / {total}'
-    hide_if_zero = True
+    hide_if_zero = False
 
     def _emergeRunning(self):
         """


### PR DESCRIPTION
Added a module that displays current emerge information.
Multiple format options are available (documented in the module file).

User needs to have read access to the log file in /var/log/emerge.log. This can be acomplished by the Gentoo 'portage' group. 