### PR TITLE
formatter: add {:g} to remove trailing zeroes

### DIFF
--- a/py3status/formatter.py
+++ b/py3status/formatter.py
@@ -244,10 +244,14 @@ class Placeholder:
                 # type then we see if we can coerce it to be.  This allows
                 # the user to format types that normally would not be
                 # allowed eg '123' it also allows {:d} to be used as a
-                # shorthand for {:.0f}.  If the parameter cannot be
-                # successfully converted then the format is removed.
+                # shorthand for {:.0f}.  Use {:g} to remove insignificant
+                # trailing zeroes and the decimal point too if there are
+                # no remaining digits following it.  If the parameter cannot
+                # be successfully converted then the format will be removed.
                 try:
                     if 'f' in self.format:
+                        value = float(value)
+                    if 'g' in self.format:
                         value = float(value)
                     if 'd' in self.format:
                         value = int(float(value))


### PR DESCRIPTION
This removes the insignificant trailing zeroes and the decimal point too if there are no remaining digits following it, eg `50.000` and `5.500` becomes `50` and `5.5`. 
