### PR TITLE
py3: return gradients properly

### DIFF
--- a/py3status/py3.py
+++ b/py3status/py3.py
@@ -1068,12 +1068,13 @@ class Py3:
                     self._threshold_gradients[name_used] = (colors, minimum, maximum)
 
                 if value < minimum:
-                    return colors[0]
-                if value > maximum:
-                    return colors[-1]
-                value -= minimum
-                col_index = int(((len(colors) - 1) / (maximum - minimum)) * value)
-                color = colors[col_index]
+                    color = colors[0]
+                elif value > maximum:
+                    color = colors[-1]
+                else:
+                    value -= minimum
+                    col_index = int(((len(colors) - 1) / (maximum - minimum)) * value)
+                    color = colors[col_index]
 
             elif color is None:
                 color = thresholds[0][1]


### PR DESCRIPTION
I ran into what I believe is a bug with `sysdata`. When we use `gradients = True` inside `sysdata` and the value is well over the threshold, we will get a white gradient. ~~Also, it seems to skip on every other threshold too.~~ EDIT: This fixes it for me... 