### PR TITLE
add new module: hddtemp

### DIFF
--- a/py3status/modules/hddtemp.py
+++ b/py3status/modules/hddtemp.py
@@ -1,0 +1,146 @@
+# -*- coding: utf-8 -*-
+"""
+Display hard drive temperatures.
+
+hddtemp is a small utility with daemon that gives the hard drive temperature
+via S.M.A.R.T. (Self-Monitoring, Analysis, and Reporting Technology). This
+module requires the user-defined hddtemp daemon to be running at all times.
+
+Configuration parameters:
+    cache_timeout: refresh interval for this module (default 10)
+    format: display format for this module (default '{format_hdd}')
+    format_hdd: display format for hard drives
+        (default '{name} [\?color=temperature {temperature}°{unit}]')
+    format_separator: show separator if more than one (default ' ')
+    thresholds: specify color thresholds to use
+        *(default [(0, 'deepskyblue'), (25, 'good'),
+        (41, 'degraded'), (46, 'orange'), (51, 'bad')])*
+
+Format placeholders:
+    {format_hdd} format for hard drives
+
+format_hdd placeholders:
+    {name}        name, eg ADATA SP550
+    {path}        path, eg /dev/sda
+    {temperature} temperature, eg 32
+    {unit}        temperature unit, eg C
+
+Temperatures:
+    Less than 25°C: Too cold     (color deepskyblue)
+    25°C to 40°C: Ideal          (color good)
+    41°C to 50°C: Acceptable     (color degraded)
+    46°C to 50°C: Almost too hot (color orange)
+    More than 50°C: Too hot      (color bad)
+
+Color thresholds:
+    temperature: print a color based on the value of hard drive temperature
+
+Requires:
+    hddtemp: utility to monitor hard drive temperatures
+
+Bible of HDD failures:
+    Hard disk temperatures higher than 45°C led to higher failure rates.
+    Temperatures lower than 25°C led to higher failure rates as well.
+    Aging hard disk drives (3 years and older) were much more prone to
+    failure when their average temperatures were 40°C and higher.
+
+    Hard disk manufacturers often state the operating temperatures of
+    their hard disk drives to be between 0°C to 60°C. This can be misleading
+    because what they mean is that your hard disk will function at these
+    temperatures, but it doesn't tell you anything about how long they are
+    going to survive at this range.
+    http://www.buildcomputers.net/hdd-temperature.html
+
+Backblaze:
+    Overall, there is not a correlation between operating temperature and
+    failure rates The one exception is the Seagate Barracuda 1.5TB drives,
+    which fail slightly more when they run warmer. As long as you run drives
+    well within their allowed range of operating temperatures, keeping them
+    cooler doesn’t matter.
+    https://www.backblaze.com/blog/hard-drive-temperature-does-it-matter/
+
+@author lasers
+
+Examples:
+```
+# compact
+hddtemp {
+    format = 'HDD {format_hdd}'
+    format_hdd = '\?color=temperature {temperature}'
+    format_separator = ','
+}
+
+# show paths instead of names
+hddtemp {
+    format_hdd = '{path} [\?color=temperature {temperature}°{unit}]'
+}
+```
+
+SAMPLE OUTPUT
+[
+    {'full_text': u'ADATA SP550 '},
+    {'full_text': u'32°C', 'color': '#00FF00'},
+    {'full_text': u'WDC WD10EURX-63FH1Y0 '},
+    {'full_text': u'44°C', 'color': '#FFFF00'},
+]
+
+path
+[
+    {'full_text': '/dev/sda '}, {'color': '#00BFFF', u'full_text': '22°C'}
+    {'full_text': '/dev/sdb '}, {'color': '#FFA500', u'full_text': '44°C'}
+]
+
+compact
+[
+    {'full_text': 'HDD '},
+    {'color': '#FF0000', 'full_text': '53'}, {'full_text': ','},
+    {'color': '#FFFF00', 'full_text': '44'}, {'full_text': ','},
+    {'color': '#FFA500', 'full_text': '51'}, {'full_text': ','},
+    {'color': '#00BFFF', 'full_text': '24'}, {'full_text': ','},
+    {'color': '#00FF00', 'full_text': '32'},
+]
+"""
+
+from telnetlib import Telnet
+
+
+class Py3status:
+    """
+    """
+    # available configuration parameters
+    cache_timeout = 10
+    format = '{format_hdd}'
+    format_hdd = u'{name} [\?color=temperature {temperature}°{unit}]'
+    format_separator = ' '
+    thresholds = [(0, 'deepskyblue'), (25, 'good'),
+                  (41, 'degraded'), (46, 'orange'), (51, 'bad')]
+
+    def post_config_hook(self):
+        self.keys = ['path', 'name', 'temperature', 'unit']
+
+    def hddtemp(self):
+        line = Telnet('localhost', 7634).read_all().decode()[1:-1]
+        new_data = []
+
+        for chunk in line.split('||'):
+            hdd = dict(zip(self.keys, chunk.split('|')))
+            self.py3.threshold_get_color(hdd['temperature'], 'temperature')
+            new_data.append(self.py3.safe_format(self.format_hdd, hdd))
+
+        format_separator = self.py3.safe_format(self.format_separator)
+        format_hdd = self.py3.composite_join(format_separator, new_data)
+
+        return {
+            'cached_until': self.py3.time_in(self.cache_timeout),
+            'full_text': self.py3.safe_format(
+                self.format, {'format_hdd': format_hdd}
+            )
+        }
+
+
+if __name__ == "__main__":
+    """
+    Run module in test mode.
+    """
+    from py3status.module_test import module_test
+    module_test(Py3status)


### PR DESCRIPTION
Hi. I made a new module `hddtemp`. This module display hard drive temperatures. I don't want this to go in `sysdata` and I think `sysdata` should be split up into `lm_sensors`, `loadavg`, etc... anyway for more clarification and more flexible / easier in customizing.

The screenshots shows `darkgray` but is white in default... as is traditional. I wonder about extending color palette... to support ~`color_default`~ `color_primary`, `color_secondary` too to help with the overall theme so users can change colors for all modules easily via few color options in `general {}`.

The thresholds contains `blue` and `orange` color too.... Too cold and almost too hot.
EDIT: The screenshots are slightly outdated. No color `blue`, `orange` and `red` in this one. 

![hddtemp_0](https://user-images.githubusercontent.com/852504/36510634-4de83af6-1729-11e8-83df-1742b14f1e09.png)

![hddtemp_1](https://user-images.githubusercontent.com/852504/36510635-4e0b2e80-1729-11e8-965b-718008df76c5.png)

![hddtemp_2](https://user-images.githubusercontent.com/852504/36510637-4e3c69e6-1729-11e8-9078-3e6a358fdf45.png)
