### PR TITLE
sysdata: zip up the load stuffs

### DIFF
--- a/py3status/modules/sysdata.py
+++ b/py3status/modules/sysdata.py
@@ -349,11 +349,9 @@ class Py3status:
 
         # get load average
         if self.py3.format_contains(self.format, 'load*'):
-            load1, load5, load15 = self._get_loadavg()
-            sys['load1'] = load1
-            sys['load5'] = load5
-            sys['load15'] = load15
-            self.py3.threshold_get_color(load1, 'load')
+            load_data = self._get_loadavg()
+            sys.update(zip(['load1', 'load5', 'load15'], load_data))
+            self.py3.threshold_get_color(load_data[0], 'load')
 
         try:
             self.py3.threshold_get_color(max(cpu_usage, mem_used_percent), 'max_cpu_mem')


### PR DESCRIPTION
I create `self.keys` where keys will be kept. 99% keys and 1% caches... then I fill up the `self.keys` with names for `load` to zip up the load stuffs with.

In `sysdata: over 9000 optimizations, 3 bugfixes`, I rename the loads.
* From... `('load1', 'load5', 'load15')`
* To... `('load_1min', 'load_5min', 'load_15min')`. 

It probably would be just `('1min', '5min', '15min')` in new module `loadavg`.