### PR TITLE
sysdata: replace /proc/loadavg with getloadavg()

### DIFF
--- a/py3status/modules/sysdata.py
+++ b/py3status/modules/sysdata.py
@@ -56,6 +56,7 @@ SAMPLE OUTPUT
 """
 
 from __future__ import division
+from os import getloadavg
 
 import re
 
@@ -200,18 +201,6 @@ class Py3status:
         # return the cpu total&idle time
         return total_cpu_time, cpu_idle_time
 
-    def _get_loadavg(self):
-        """
-        Get the load average from /proc/loadavg :
-        """
-        with open('/proc/loadavg', 'r') as fd:
-            line = fd.readline()
-        load_data = line.split()
-        load1 = float(load_data[0])
-        load5 = float(load_data[1])
-        load15 = float(load_data[2])
-        return load1, load5, load15
-
     def _calc_mem_info(self, unit='GiB', memi=dict, keys=list):
         """
         Parse /proc/meminfo, grab the memory capacity and used size
@@ -345,9 +334,9 @@ class Py3status:
 
         # get load average
         if self.py3.format_contains(self.format, 'load*'):
-            load_data = self._get_loadavg()
-            sys.update(zip(['load1', 'load5', 'load15'], load_data))
-            self.py3.threshold_get_color(load_data[0], 'load')
+            load_keys = ['load1', 'load5', 'load15']
+            sys.update(zip(load_keys, getloadavg()))
+            self.py3.threshold_get_color(sys['load1'], 'load')
 
         try:
             self.py3.threshold_get_color(


### PR DESCRIPTION
The differences between load averages with `timeit`.

Using `/proc/loadavg`.
```
    def _get_loadavg():
        """
        Get the load average from /proc/loadavg :
        """
        with open('/proc/loadavg', 'r') as fd:
            line = fd.readline()
        load_data = line.split()
        load1 = float(load_data[0])
        load5 = float(load_data[1])
        load15 = float(load_data[2])
        return load1, load5, load15

    sys = {}
    keys = ['1min', '5min', '15min']
    sys.update(zip(keys['load'], _get_loadavg()))
# ----------
35.29173210001318
35.370016951987054
34.465308131999336
35.80027389898896
```
Using `os.getloadavg()`...
```
    sys = {}
    keys = ['1min', '5min', '15min']
    sys.update(zip(keys['load'], _get_loadavg()))

# ----------
6.896805440017488
6.9395914629567415
7.0003847110201605
6.975486984010786
```

Using `os.getloadavg()` and some more
for new `loadavg` module hopefully one day.
```
    # loadavg module
    keys = ['1min', '5min', '15min']
    averages = dict(zip(keys['load'], getloadavg()))

    for i, (key, value) in enumerate(averages.items()):
        # blank line for thershold code + divkey[i]
        averages[key] = '{:.2f}'.format(value)

# ----------
9.574465896002948
9.952808197005652
9.94225910201203
10.188999628007878
10.019288128998596
```
