### PR TITLE
deadbeef: add button examples

### DIFF
--- a/py3status/modules/deadbeef.py
+++ b/py3status/modules/deadbeef.py
@@ -6,8 +6,8 @@ Configuration parameters:
     cache_timeout: refresh interval for this module (default 5)
     format: display format for this module (default '[{artist} - ][{title}]')
     sleep_timeout: when deadbeef is not running, this interval will be used
-        to allow one to refresh constantly with time placeholders and/or
-        to refresh once every minute rather than every few seconds
+        to allow faster refreshes with time-related placeholders and/or
+        to refresh few times per minute rather than every few seconds
         (default 20)
 
 Format placeholders:
@@ -31,6 +31,14 @@ Color options:
 
 Requires:
     deadbeef: a GTK+ audio player for GNU/Linux
+
+Examples:
+```
+# see 'deadbeef --help' for more buttons
+deadbeef {
+    on_click 1 = 'exec deadbeef --play-pause'
+    on_click 8 = 'exec deadbeef --random'
+}
 
 @author mrt-prodz, tobes, lasers
 


### PR DESCRIPTION
I like me some dead man's switches. :skull:

EDIT: I think I tried this before with `cmus` or `moc`. Question: Is better for the users (and modules, I guess) to have all available buttons exposed versus the selective buttons?

Like others, I don't include `button_random`, `button_stop`, and more.
```
          --play           Start playback
(pending) --stop           Stop playback
          --pause          Pause playback
          --toggle-pause   Toggle pause
(added)   --play-pause     Start playback if stopped, toggle pause otherwise
(added)   --next           Next song in playlist
(added)   --prev           Previous song in playlist
          --random         Random song in playlist
```
Should I not add `button_stop` here too? `cmus` have `button_stop` w/ sensible behavior..

Options in a nutshell:
1) Expose all buttons. Easier for users to assign numbers. Leave most on `None`.
    * Easier than `on_click`.
    * For other/different behaviors, use `on_click`.
2) Expose selective buttons enough to work with default `format`.
    * For other/different behaviors, use `on_click`.
    * Users can not know about other/different behaviors like `button_random`.
    * Users can miss out on some buttons.
3) Don't add buttons. No dead man's switches for `deadbeef`.
    * For other/different behaviors, use `on_click`.
    * Users can not know about other/different behaviors like `button_pause`, `button_next`, `button_prev`, `button_random`, etc. I add them just now here.
    * Users often have to set them up. They may not know that.
    * Users often have to set them up. They may not like that.

This question shouldn't be here. Sorry for making things complicated. :-(

EDIT: Hold off on this until we get the separator issue fixed first.