### PR TITLE
py3: dismiss empty notifications

### DIFF
--- a/py3status/py3.py
+++ b/py3status/py3.py
@@ -514,9 +514,14 @@ class Py3:
         # force unicode for python2 str
         if self._is_python_2 and isinstance(msg, str):
             msg = msg.decode('utf-8')
-        module_name = self._module.module_full_name
-        self._py3_wrapper.notify_user(
-            msg, level=level, rate_limit=rate_limit, module_name=module_name)
+        if msg:
+            module_name = self._module.module_full_name
+            self._py3_wrapper.notify_user(
+                msg=msg,
+                level=level,
+                rate_limit=rate_limit,
+                module_name=module_name,
+            )
 
     def register_function(self, function_name, function):
         """


### PR DESCRIPTION
With `format_notification` exposed and very customizable in my branch for `pomodoro`, this allows ~~the users~~ py3status to dismiss empty notifications due to the respected formatting tricks and/or the user preference to turn them off via `format_notification = ''`. Let me know if this is okay.