### PR TITLE
py3: play sounds with ffplay

### DIFF
--- a/py3status/py3.py
+++ b/py3status/py3.py
@@ -1029,8 +1029,10 @@ class Py3:
         Plays sound_file if possible.
         """
         self.stop_sound()
-        cmd = self.check_commands(['paplay', 'play'])
+        cmd = self.check_commands(['ffplay', 'paplay', 'play'])
         if cmd:
+            if cmd == 'ffplay':
+                cmd = 'ffplay -autoexit -nodisp -loglevel 0'
             sound_file = os.path.expanduser(sound_file)
             c = shlex.split('{} {}'.format(cmd, sound_file))
             self._audio = Popen(c)


### PR DESCRIPTION
This is similar to `backlight: better xbacklight detection` pull request.

I was testing sounds in `pomodoro` with `mp3` file.

* I have `paplay` installed automatically due to `pulseaudio`, `pulseaudio-utils`. This does not play the audio for me. I get this in the terminal:

    ~~~
    ~/Downloads  $ paplay test.mp3
    Failed to open audio file.
    ~/Downloads $ echo $?
    1
    ~~~
* I did not have `aplay` installed. I tested it anyway. This play the audio okay.

I think it would be nice if we can avoid `pulseaudio/alsa` stuffs and just use external `ffplay` from `ffmpeg` package that's regularly updated and should be available everywhere just like `paplay` and `aplay`. EDIT: This supports more audio and video formats too.

```
FFplay is a very simple and portable media player using the FFmpeg libraries
and the SDL library. It is mostly used as a testbed for the various FFmpeg
APIs.

-autoexit
    Exit when video is done playing.

-nodisp
    Disable graphical display.

-loglevel loglevel
    Set the logging level used by the library

    panic, 0
        Only show fatal errors which could lead the process to crash, such as
        an assertion failure. This is not currently used for anything.
```
~~EDIT: Should I simplify `if cmd:` too?~~