### PR TITLE
pomodoro: new module from scratch

### DIFF
--- a/py3status/formatter.py
+++ b/py3status/formatter.py
@@ -2,6 +2,7 @@
 import re
 import sys
 
+from math import ceil
 from numbers import Number
 
 from py3status.composite import Composite
@@ -249,6 +250,8 @@ class Placeholder:
                 # no remaining digits following it.  If the parameter cannot
                 # be successfully converted then the format will be removed.
                 try:
+                    if 'ceil' in self.format:
+                        value = int(ceil(float(value)))
                     if 'f' in self.format:
                         value = float(value)
                     if 'g' in self.format:

--- a/py3status/modules/pomodoro.py
+++ b/py3status/modules/pomodoro.py
@@ -2,341 +2,571 @@
 """
 Use Pomodoro technique to get things done easily.
 
-Button 1 starts/pauses countdown.
-Button 2 switch Pomodoro/Break.
-Button 3 resets timer.
-
 Configuration parameters:
-    display_bar: display time in bars when True, otherwise in seconds
-        (default False)
-    format: define custom time format. See placeholders below (default '{ss}')
-    format_active: format to display when timer is active
-        (default 'Pomodoro [{format}]')
-    format_break: format to display during break
-        (default 'Break #{breakno} [{format}]')
-    format_break_stopped: format to display during a break that is stopped
-        (default 'Break #{breakno} ({format})')
-    format_separator: separator between minutes:seconds (default ':')
-    format_stopped: format to display when timer is stopped
-        (default 'Pomodoro ({format})')
-    num_progress_bars: number of progress bars (default 5)
+    button_advance: mouse button to advance the timer (default 3)
+    button_reset: mouse button to reset the timer (default 2)
+    button_toggle: mouse button to start/pause the timer (default 1)
+    cache_timeout: refresh interval for this module, otherwise auto
+        (default None)
+    format: display format for this module
+        *(default '[\?color=state [{progress_bar} ]{name} '
+        '[\?if=name=Pomodoro {pomodoro} ][\?if=name=Break {break} ]'
+        '[\?if=state ({time})|\[{time}\]]]')*
+    format_notification: specify notification to format excluding colors
+        (default 'End of {name}.')
     pomodoros: specify a number of pomodoros (intervals) (default 4)
-    sound_break_end: break end sound (file path) (requires pyglet
-        or pygame) (default None)
-    sound_pomodoro_end: pomodoro end sound (file path) (requires pyglet
-        or pygame) (default None)
-    sound_pomodoro_start: pomodoro start sound (file path) (requires pyglet
-        or pygame) (default None)
-    timer_break: normal break time (seconds) (default 300)
-    timer_long_break: long break time (seconds) (default 900)
-    timer_pomodoro: pomodoro time (seconds) (default 1500)
+    progress_bars: specify a number of bars or 3-tuples of numbers of
+        bars for pomodoro, break, long break (default (0, 0, 0))
+    sounds: specify a dict of sound file paths to play (default {})
+    thresholds: specify color thresholds to use
+        (default [(0, 'bad'), (1, 'good'), (2, 'degraded'), (3, 'orange')])
+    timers: specify a number of seconds or 3-tuples of numbers of seconds
+        for pomodoro, break, long break (default (1500, 300, 900))
+
+Control placeholders:
+    {alarm}          alarm boolean, eg False, True
+    {started}        started boolean, eg False, True
+    {state}          state number, eg 0, 1, 2, 3 for
+                     stopped, pomodoro, break, long break
 
 Format placeholders:
-    {bar} display time in bars
-    {breakno} current break number
-    {ss} display time in total seconds (1500)
-    {mm} display time in total minutes (25)
-    {mmss} display time in (hh-)mm-ss (25:00)
+    {name}           name, eg Pomodoro, Break, Long Break
+    {pomodoro}       pomodoro number, eg 3
+    {break}          break number, eg 2
+    {pomodoros}      total number of pomodoros, eg 4
+    {progress}       progress percentage, eg 95
+    {progress_bar}   progress bar, eg ◼◼◼◼◼◼◼◼◼◼
+    {time}           time in [hh:]mm:ss, eg 8:16
+    {time_hours}     time in hours, eg 0
+    {time_minutes}   time in minutes, eg 8
+    {time_seconds}   time in seconds, eg 16
+    {total}          total time in [hh:]mm:ss, eg 24:1499
+    {total_hours}    total time in hours, eg 0
+    {total_minutes}  total time in minutes, eg 24
+    {total_seconds}  total time in seconds, eg 1499
+    {length}         length time in [hh:]mm:ss, eg 25:00
+    {length_hours}   length time in hours, eg 0
+    {length_minutes} length time in minutes, eg 25
+    {length_seconds} length time in seconds, eg 00
+
+Notes:
+    We can also perform ceiling functions on time unit placeholders, eg
+    `{placeholder:ceil}` to print `6` instead of `5.01`. You can find a
+    format illustrating the differences between all four times in Examples
+    below. You should only use `:ceil` on `{total_minutes}` placeholder.
+
+    {total_hours:ceil}   ceil total time in hours, eg 1
+    {total_minutes:ceil} ceil total time in minutes, eg 25
+    {total_seconds:ceil} ceil total time in seconds, eg 1500
+
+Format_notification placeholders:
+    {name}      name, eg Pomodoro, Break, Long Break
+    {pomodoro}  pomodoro number, eg 3
+    {break}     break number, eg 2
+    {pomodoros} total number of pomodoros, eg 4
 
 Color options:
-    color_bad: Pomodoro not running
-    color_degraded: Pomodoro break
-    color_good: Pomodoro active
+    color_bad:      Pomodoro/Break [stopped]
+    color_degraded: Break [active]
+    color_good:     Pomodoro/Break [active]
 
-i3status.conf example:
+Color thresholds:
+    xxx: print a color based on the value of `xxx` placeholder
+
+Examples:
 ```
+# specify a number or 3-tuples of numbers for progress_bars and timers
 pomodoro {
-    format = "{mmss} {bar}"
+    progress_bars = (5, 1, 3)     # pomodoro, break, long break
+    progress_bars = 5             # 5 becomes (5, 5, 5)
+
+    timers = (1500, 300, 900)     # pomodoro, break, long break
+    timers = 300                  # 300 becomes (300, 300, 300)
+}
+
+# add sounds
+pomodoro {
+    sounds = {
+        'pomodoro_start': '~/Music/Pomodoro_is_starting.mp3',
+        'pomodoro_end': '~/Music/Pomodoro_is_ending.mp3',
+        'break_start': '~/Music/Break_is_starting.mp3',
+        'break_end': '~/Music/Break_is_ending.mp3',
+        'long_break_start': '~/Music/Long_break_is_starting.mp3',
+        'long_break_end': '~/Music/Long_break_is_ending.mp3',
+    }
+    # The songs for break* will also be playing for long_break* so we do
+    # not have to specify same songs for long_break*... only when we want
+    # to use different songs. You may also want to install ffplay.
+}
+
+# disable notifications, urgents
+pomodoro {
+    format_notification = ''
+    allow_urgent = False
+
+    # with urgent disabled, we can add "ALARM!" or an icon, eg...
+    format = '[\?if=alarm&color=bad ALARM! ]'
+        # OR
+    format = '[\?if=alarm&color=gold \u23f0 {name}]'
+}
+
+# show notifications only on Pomodoro
+pomodoro {
+    format_notification = '\?if=name=Pomodoro You did '
+    format_notification += '{pomodoro}/{pomodoros}.'
+}
+
+# our first pomodoro theme, make it look like a clock
+pomodoro {
+    format = '[\?color=state [{progress_bar} ]{time} ][\?max_length=1 {name}]'
+    format += '[\?if=name=Pomodoro {pomodoro}|{break}]'
+}
+
+# monochrome theme
+pomodoro {
+    allow_urgent = False
+    format_notification = ''
+    progress_bars = 5
+    thresholds = []
+}
+
+# rainbowize the legacy theme
+pomodoro {
+    format = '\?color=time_seconds [\?if=name=Pomodoro Pomodoro|Break #{break}] '
+    format += '[\?if=state \[{total_seconds:ceil}\]|({total_seconds:ceil})]'
+    format += '[ {progress_bar}]'
+
+    format_notification = '[\?if=name=Pomodoro Pomodoro|[\?if=name=Break '
+    format_notification += 'Break #{break}|Long Break]] time is up !'
+    progress_bars = (25, 5, 15)
+
+    thresholds = {
+        'time_seconds': [
+            (0, '#ffb3ba'), (10, '#ffdfba'), (20, '#ffffba'),
+            (30, '#baffc9'), (40, '#bae1ff'), (50, '#bab3ff'),
+        ],
+    }
+}
+
+# minimal theme using total_minutes + ceil
+pomodoro {
+    format = '\?color=state [\?max_length=1 {name}]{total_minutes:ceil}'
+}
+
+# fewer cycles, less distracting, more relaxing
+pomodoro {
+    cache_timeout = 10
+}
+
+# show percent instead of running clock, more relaxing
+pomodoro {
+    format = '\?color=state [{progress_bar} ]{name} '
+    format += '[\?if=name=Pomodoro {pomodoro} ][\?if=name=Break {break} ]'
+    format += '[\?if=state ({progress}%)|\[{progress}%\]]'
+}
+
+# you can also use percent to accurately colorize the thresholds
+pomodoro {
+    format = '\?color=progress [{progress_bar} ]{name} '
+    format += '[\?if=name=Pomodoro {pomodoro} ][\?if=name=Break {break} ]'
+    format += '[\?if=state ({time})|\[{time}\]]'
+    thresholds = [
+        (100, 'darkgray'), (99, 'lightgreen'), (80, 'lime'),
+        (60, 'orange'), (40,'degraded'), (20, 'bad')
+    ]
+    gradients = True  # show more colors
+}
+
+# show differences between time/length, total time, and ceil total time
+pomodoro {
+    format = 'Time: {time} ..... Length: {length} ..... Total Time: '
+    format += '{total_hours}h, {total_minutes}m, {total_seconds}s'
+    format += ' ..... Ceil Total Time: '
+    format += '{total_hours:ceil}h, {total_minutes:ceil}m, {total_seconds:ceil}s'
+    format_notification = ''
+}
+
+# display alarm bell icon instead of urgent, display PAUSED on paused
+pomodoro {
+    format = '[\?if=alarm&color=gold \u23f0 ]'
+    format += '[\?if=state&color=state [{progress_bar} ]{time} ]'
+    format += '[\?if=started [\?if=!state PAUSED ]]'
+    format += '[\?max_length=1 {name}][\?if=name=Pomodoro {pomodoro}|{break}]'
+    allow_urgent = False
 }
 ```
 
-@author Fandekasp (Adrien Lemaire), rixx, FedericoCeratto, schober-ch, ricci
+@author Fandekasp (Adrien Lemaire), rixx, FedericoCeratto, schober-ch, ricci,
+lasers
 
 SAMPLE OUTPUT
-{'color': '#FF0000', 'full_text': u'Pomodoro (1500)'}
+[
+    {'full_text': u'◼◼◼◼', 'color': '#FF0000'},
+    {'full_text': u'◼ Pomodoro 1 [25:00]', 'color': '#FF0000'}
+]
 
-running
-{'color': '#00FF00', 'full_text': u'Pomodoro [1483]'}
+pomodoro
+[
+    {'full_text': u'◼', 'color': '#808080'},
+    {'full_text': u'◼◼◼◼ Pomodoro 2 (19:59)', 'color': '#00FF00'}
+]
+
+break
+[
+    {'full_text': u'◼◼', 'color': '#808080'},
+    {'full_text': u'◼◼◼ Break 3 (2:59)', 'color': '#FFFF00'}
+]
+
+long_break
+[
+    {'full_text': u'◼◼◼', 'color': '#808080'},
+    {'full_text': u'◼◼ Long Break (5:59)', 'color': '#FFA500'}
+]
 """
 
-from math import ceil
 from threading import Timer
 from time import time
-import os
-
-try:
-    from pygame import mixer as pygame_mixer
-except ImportError:
-    pygame_mixer = None
-
-try:
-    import pyglet
-except ImportError:
-    pyglet = None
-
-
-class Player(object):
-    _default = '_silence'
-
-    def __init__(self):
-        if pyglet is not None:
-            pyglet.options['audio'] = ('pulse', 'silent')
-            self._player = pyglet.media.Player()
-            self._default = '_pyglet'
-        elif pygame_mixer is not None:
-            pygame_mixer.init()
-            self._default = '_pygame'
-
-    def _silence(self, sound_fname):
-        pass
-
-    def _pygame(self, sound_fname):
-        pygame_mixer.music.load(sound_fname)
-        pygame_mixer.music.play()
-
-    def _pyglet(self, sound_fname):
-        res_dir, f = os.path.split(sound_fname)
-
-        if res_dir not in pyglet.resource.path:
-            pyglet.resource.path = [res_dir]
-            pyglet.resource.reindex()
-
-        self._player.queue(pyglet.resource.media(f, streaming=False))
-        self._player.play()
-
-    @property
-    def available(self):
-        return self._default != '_silence'
-
-    def __call__(self, sound_fname):
-        getattr(self, self._default)(os.path.expanduser(sound_fname))
-
-
-PROGRESS_BAR_ITEMS = u"▏▎▍▌▋▊▉"
 
 
 class Py3status:
     """
     """
     # available configuration parameters
-    display_bar = False
-    format = u'{ss}'
-    format_active = u'Pomodoro [{format}]'
-    format_break = u'Break #{breakno} [{format}]'
-    format_break_stopped = u'Break #{breakno} ({format})'
-    format_separator = u":"
-    format_stopped = u'Pomodoro ({format})'
-    num_progress_bars = 5
+    button_advance = 3
+    button_reset = 2
+    button_toggle = 1
+    cache_timeout = None
+    format = ('[\?color=state [{progress_bar} ]{name} '
+              '[\?if=name=Pomodoro {pomodoro} ][\?if=name=Break {break} ]'
+              '[\?if=state ({time})|\[{time}\]]]')
+    format_notification = 'End of {name}.'
     pomodoros = 4
-    sound_break_end = None
-    sound_pomodoro_end = None
-    sound_pomodoro_start = None
-    timer_break = 5 * 60
-    timer_long_break = 15 * 60
-    timer_pomodoro = 25 * 60
+    progress_bars = (0, 0, 0)
+    sounds = {}
+    thresholds = [(0, 'bad'), (1, 'good'), (2, 'degraded'), (3, 'orange')]
+    timers = (1500, 300, 900)  # 25min, 5min, 15min
 
     class Meta:
+        def deprecate_sounds(config):
+            return {
+                'sounds': {
+                    'break_end': config.get('sound_break_end'),
+                    'pomodoro_end': config.get('sound_pomodoro_end'),
+                    'pomodoro_start': config.get('sound_pomodoro_start'),
+                }
+            }
+
+        def deprecate_timers(config):
+            return {
+                'timers': (
+                    config.get('timer_pomodoro', 1500),
+                    config.get('timer_break', 300),
+                    config.get('timer_long_break', 900)
+                ),
+            }
+
         deprecated = {
+            'function': [
+                {'function': deprecate_sounds},
+                {'function': deprecate_timers},
+            ],
+            'substitute_by_value': [
+                {
+                    'param': 'display_bar',
+                    'value': False,
+                    'substitute': {
+                        'param': 'progress_bars',
+                        'value': 0,
+                    },
+                    'msg': 'obsolete parameter: use {progress_bar}',
+                },
+                {
+                    'param': 'display_bar',
+                    'value': True,
+                    'substitute': {
+                        'param': 'progress_bars',
+                        'value': 10,
+                    },
+                    'msg': 'obsolete parameter: use {progress_bar}',
+                },
+                {
+                    'param': 'display_bar',
+                    'value': True,
+                    'substitute': {
+                        'param': 'format',
+                        'value': '\?show&color=state {progress_bar}'
+                    },
+                    'msg': 'obsolete parameter: use {progress_bar}',
+                },
+            ],
             'rename': [
                 {
                     'param': 'max_breaks',
                     'new': 'pomodoros',
                     'msg': 'obsolete parameter use `pomodoros`',
                 },
-            ]
+                {
+                    'param': 'num_progress_bars',
+                    'new': 'progress_bars',
+                    'msg': 'obsolete parameter use `progress_bars`',
+                },
+            ],
+            'remove': [
+                {
+                    'param': 'display_bar',
+                    'msg': 'obsolete placeholder: use {progress_bar}',
+                },
+                {
+                    'param': 'format_separator',
+                    'msg': 'deprecated placeholder',
+                },
+            ],
+            'rename_placeholder': [
+                {
+                    'placeholder': 'bar',
+                    'new': 'progress_bar',
+                    'format_strings': ['format'],
+                },
+                {
+                    'placeholder': 'mm',
+                    'new': 'total_minutes:ceil',
+                    'format_strings': ['format'],
+                },
+                {
+                    'placeholder': 'ss',
+                    'new': 'total_seconds',
+                    'format_strings': ['format'],
+                },
+                {
+                    'placeholder': 'mmss',
+                    'new': 'time',
+                    'format_strings': ['format'],
+                },
+            ],
+        }
+        update_config = {
+            'update_placeholder_format': [
+                {
+                    'placeholder_formats': {
+                        'progress': ':.0f',
+                        'time_hours': ':d',
+                        'time_minutes': ':d',
+                        'time_seconds': ':d',
+                        'total_hours': ':d',
+                        'total_minutes': ':d',
+                        'total_seconds': ':d',
+                        'length_hours': ':d',
+                        'length_minutes': ':02d',
+                        'length_seconds': ':02d',
+                    },
+                    'format_strings': ['format'],
+                }
+            ],
         }
 
     def post_config_hook(self):
-        self._initialized = False
+        # support new, old (timers, progress_bars)
+        for name in ['timers', 'progress_bars']:
+            value = getattr(self, name)
+            error_string = 'invalid ' + name
+            if isinstance(value, tuple):
+                if len(value) != 3:
+                    raise Exception(error_string)
+            elif isinstance(value, (list, str)):
+                raise Exception(error_string)
+            else:
+                setattr(self, name, [value] * 3)
 
-    def _init(self):
-        self._break_number = 0
-        self._active = True
-        self._running = False
-        self._time_left = self.timer_pomodoro
-        self._section_time = self.timer_pomodoro
-        self._timer = None
-        self._end_time = None
-        self._player = Player()
-        self._alert = False
-        if self.display_bar is True:
-            self.format = u'{bar}'
-        self._initialized = True
+        # convert timers to dict
+        self.name_list = ['Pomodoro', 'Break', 'Long Break']
+        self.timers = dict(zip(self.name_list, self.timers))
 
-    def _time_up(self):
-        if self._active:
-            self.py3.notify_user('Pomodoro time is up !')
+        # support new, old sounds - drop the Nones first
+        self.sounds = {k: v for k, v in self.sounds.items() if v}
+
+        # set cache_timeout automagically
+        if self.cache_timeout is None:
+            self.cache_timeout = 10
+            if any(x <= 60 for x in self.timers.values()):
+                self.cache_timeout = 0
+            time_periods = [
+                ('*hours*', 3600), ('*minutes*', 60),
+                ('*seconds*', 0), ('time', 0)
+            ]
+            for unit in time_periods:
+                if self.py3.format_contains(self.format, unit[0]):
+                    self.cache_timeout = unit[1]
+
+        # init methods
+        names = ['progress_bar', 'total', 'length']
+        placeholders = ['progress_bar', 'total*', 'length*']
+        self.init = {'methods': ['time'], 'thresholds': []}
+        for name, placeholder in zip(names, placeholders):
+            if self.py3.format_contains(self.format, placeholder):
+                self.init['methods'].append(name)
+
+        # init pomodoro
+        self.init['methods'] = list(set(self.init['methods']))
+        self._timer_reset()
+
+        # init thresholds - partial future helper code
+        for x in self.format.replace('&', ' ').split('color=')[1::1]:
+            self.init['thresholds'].append(x.split()[0])
+        self.init['thresholds'] = list(set(self.init['thresholds']))
+
+    def _advance(self):
+        if self.name == 'Pomodoro':
+            self.name = 'Break'  # start break/long break soon
+            self.break_count += 1
+            if self.break_count >= self.pomodoros:
+                self.name = 'Long Break'
         else:
-            self.py3.notify_user('Break #{} time is up !'.format(self._break_number))
-        self._alert = True
-        self._advance()
+            if self.name == 'Long Break':  # start pomodoro soon
+                self.break_count = 0
+            self.name = 'Pomodoro'
+        self.time_left = self.timers[self.name]  # set new timer
+        self.time_total = self.timers[self.name]
+        self._is_running = False
 
-    def _advance(self, user_action=False):
-        self._running = False
-        if self._active:
-            if not user_action:
-                self._play_sound(self.sound_pomodoro_end)
-            # start break
-            self._time_left = self.timer_break
-            self._section_time = self.timer_break
-            self._break_number += 1
-            if self._break_number >= self.pomodoros:
-                self._time_left = self.timer_long_break
-                self._section_time = self.timer_long_break
-                self._break_number = 0
-            self._active = False
+    def _make_length(self, name, state, data, time):
+        return self._make_time(name, state, data, self.time_total)
+
+    def _make_total(self, name, state, data, time):
+        return self._pack_time(name, data, (time / 3600), (time / 60), time)
+
+    def _make_time(self, name, state, data, time):
+        hours, remainder = divmod(time, 3600)
+        minutes, seconds = divmod(remainder, 60)
+        return self._pack_time(name, data, hours, minutes, seconds)
+
+    def _pack_time(self, name, data, hours, minutes, seconds):
+        if hours < 0:  # we print accurate, sometimes -1:59:59
+            hours, minutes, seconds = (0, 0, 0)
+        if int(hours):  # remove zero?
+            data[name] = '%d:%02d:%02d' % (hours, minutes, seconds)
         else:
-            if not user_action:
-                self._play_sound(self.sound_break_end)
-            self._time_left = self.timer_pomodoro
-            self._section_time = self.timer_pomodoro
-            self._active = True
+            data[name] = '%d:%02d' % (minutes, seconds)
+        data[name + '_hours'] = hours
+        data[name + '_minutes'] = minutes
+        data[name + '_seconds'] = seconds
+        return data
 
-    def kill(self):
-        """
-        cancel any timer
-        """
+    def _make_progress_bar(self, name, state, data, time):
+        bar = u''
+        icon = u'\u25fc'
+        width = self.progress_bars[self.name_list.index(self.name)]
+        bar_time = time / self.time_total * width
+        while bar_time > 0:
+            bar += icon
+            bar_time -= 1
+        expired_bar = '[\?color=gray&show %s]' % icon * (width - len(bar))
+        data['progress_bar'] = self.py3.safe_format(expired_bar + bar)
+        return data
+
+    def _make_sound(self, name):
+        if self.sounds:
+            if self.name in ['Pomodoro', 'Break']:
+                name = '{}_{}'.format(self.name.lower(), name)
+            else:
+                for x in ['long_break', 'break']:
+                    name = '{}_{}'.format(x, name)
+                    if name in self.sounds:
+                        break
+            if name in self.sounds:
+                self.py3.play_sound(self.sounds[name])
+
+    def _timer_cancel(self):
         if self._timer:
             self._timer.cancel()
+            self.py3.stop_sound()
 
-    def on_click(self, event):
-        """
-        Handles click events:
-            - left click starts an inactive counter and pauses a running
-              Pomodoro
-            - middle click resets everything
-            - right click starts (and ends, if needed) a break
-        """
-        if event['button'] == 1:
-            if self._running:
-                self._running = False
-                self._time_left = self._end_time - time()
-                if self._timer:
-                    self._timer.cancel()
-            else:
-                self._running = True
-                self._end_time = time() + self._time_left
-                if self._timer:
-                    self._timer.cancel()
-                self._timer = Timer(self._time_left, self._time_up)
-                self._timer.start()
-                if self._active:
-                    self._play_sound(self.sound_pomodoro_start)
+    def _timer_end(self):
+        self._make_sound('end')
+        if self.format_notification:
+            self.py3.notify_user(self.py3.safe_format(
+                self.format_notification, {
+                    'name': self.name,
+                    'pomodoro': self.break_count + 1,
+                    'break': self.break_count,
+                    'pomodoros': self.pomodoros,
+                }))
+        self.alarm = True
+        self._advance()
+        self.py3.update()
 
-        elif event['button'] == 2:
-            # reset
-            self._init()
-            if self._timer:
-                self._timer.cancel()
-
-        elif event['button'] == 3:
-            # advance
-            self._advance(user_action=True)
-            if self._timer:
-                self._timer.cancel()
-
-    def _setup_bar(self):
-        """
-        Setup the process bar.
-        """
-        bar = u''
-        items_cnt = len(PROGRESS_BAR_ITEMS)
-        bar_val = float(self._time_left) / self._section_time * \
-            self.num_progress_bars
-        while bar_val > 0:
-            selector = int(bar_val * items_cnt)
-            selector = min(selector, items_cnt - 1)
-            bar += PROGRESS_BAR_ITEMS[selector]
-            bar_val -= 1
-
-        bar = bar.ljust(self.num_progress_bars)
-        return bar
+    def _timer_reset(self):
+        self.name = 'Pomodoro'
+        self.alarm = False
+        self.break_count = 0
+        self.time_left = self.timers[self.name]
+        self.time_total = self.timers[self.name]
+        self._is_running = False
+        self._end_time = None
+        self._timer = None
 
     def pomodoro(self):
-        """
-        Pomodoro response handling and countdown
-        """
-        if not self._initialized:
-            self._init()
-
-        cached_until = self.py3.time_in(0)
-        if self._running:
-            self._time_left = ceil(self._end_time - time())
-            time_left = ceil(self._time_left)
+        if self._is_running:
+            cached_until = self.cache_timeout
+            state = self.name_list.index(self.name) + 1
+            self.time_left = self._end_time - time()
         else:
-            time_left = ceil(self._time_left)
+            cached_until = self.py3.CACHE_FOREVER  # tobes, tyvm for this.
+            state = 0  # stopped
 
-        vals = {
-            'ss': int(time_left),
-            'mm': int(ceil(time_left / 60)),
+        tomato_data = {
+            'name': self.name,
+            'state': state,
+            'pomodoro': self.break_count + 1,
+            'break': self.break_count,
+            'pomodoros': self.pomodoros,
+            'progress': self.time_left / self.time_total * 100.0,
+            'started': self.time_left != self.timers[self.name],
+            'alarm': self.alarm,
         }
 
-        if self.py3.format_contains(self.format, 'mmss'):
-            hours, rest = divmod(time_left, 3600)
-            mins, seconds = divmod(rest, 60)
+        # make times and/or progress_bar
+        for method_name in self.init['methods']:
+            tomato_data = getattr(self, '_make_' + method_name)(
+                method_name, state, tomato_data, self.time_left
+            )
 
-            if hours:
-                vals['mmss'] = u'%d%s%02d%s%02d' % (hours,
-                                                    self.format_separator,
-                                                    mins,
-                                                    self.format_separator,
-                                                    seconds)
-            else:
-                vals['mmss'] = u'%d%s%02d' % (mins,
-                                              self.format_separator,
-                                              seconds)
-
-        if self.py3.format_contains(self.format, 'bar'):
-            vals['bar'] = self._setup_bar()
-
-        formatted = self.format.format(**vals)
-
-        if self._running:
-            if self._active:
-                format = self.format_active
-            else:
-                format = self.format_break
-        else:
-            if self._active:
-                format = self.format_stopped
-            else:
-                format = self.format_break_stopped
-            cached_until = self.py3.CACHE_FOREVER
+        # make thresholds
+        for x in self.init['thresholds']:
+            if x in tomato_data:
+                self.py3.threshold_get_color(tomato_data[x], x)
 
         response = {
-            'full_text': format.format(breakno=self._break_number, format=formatted, **vals),
-            'cached_until': cached_until,
+            'cached_until': self.py3.time_in(cached_until),
+            'full_text': self.py3.safe_format(self.format, tomato_data)
         }
-
-        if self._alert:
+        if self.alarm:
             response['urgent'] = True
-            self._alert = False
-
-        if not self._running:
-            response['color'] = self.py3.COLOR_BAD
-        else:
-            if self._active:
-                response['color'] = self.py3.COLOR_GOOD
-            else:
-                response['color'] = self.py3.COLOR_DEGRADED
-
+            self.alarm = False
         return response
 
-    def _play_sound(self, sound_fname):
-        """Play sound if required
-        """
-        if not sound_fname:
-            return
+    def kill(self):
+        self._timer_cancel()
 
-        if not self._player.available:
-            self.py3.log("pomodoro module: the pyglet or pygame "
-                         "library are required to play sounds")
-            return
-
-        try:
-            self._player(sound_fname)
-        except Exception:
-            return
+    def on_click(self, event):
+        button = event['button']
+        buttons = [self.button_advance, self.button_reset, self.button_toggle]
+        if button in buttons:
+            self._timer_cancel()
+        if button == self.button_toggle:
+            if self._is_running:
+                self.time_left = self._end_time - time()  # pause now
+            else:
+                self._end_time = time() + self.time_left  # start now
+                self._timer = Timer(self.time_left, self._timer_end)
+                self._timer.start()
+                self._make_sound('start')
+            self._is_running = not self._is_running  # toggle boolean
+        elif button == self.button_reset:
+            self._timer_reset()
+        elif button == self.button_advance:
+            self._advance()
+        else:
+            self.py3.prevent_refresh()
 
 
 if __name__ == "__main__":

--- a/tests/test_formatter.py
+++ b/tests/test_formatter.py
@@ -1368,6 +1368,20 @@ def test_trailing_zeroes_2():
     })
 
 
+def test_ceiling_numbers_1():
+    run_formatter({
+        'format': '{pi} becomes {pi:ceil}',
+        'expected': '3.14159265359 becomes 4'
+    })
+
+
+def test_ceiling_numbers_2():
+    run_formatter({
+        'format': '{zero_almost} becomes {zero_almost:ceil}',
+        'expected': '0.0001 becomes 1'
+    })
+
+
 if __name__ == '__main__':
     # run tests
     import sys


### PR DESCRIPTION
![pomodoro_1](https://user-images.githubusercontent.com/852504/37482853-4db51c8a-2853-11e8-92b4-fb516e667f5a.png)

![pomodoro_2](https://user-images.githubusercontent.com/852504/37482855-4dd1a972-2853-11e8-96d4-c43c74a82eb2.png)

![pomodoro_3](https://user-images.githubusercontent.com/852504/37482856-4e08568e-2853-11e8-8795-37ddb325d760.png)

Hi. With the new formats merged in `pomodoro`, I act fast to unify the multiple `format_*` into single `format` (deprecation not included) before the `3.8` release. I deprecate the older configs okay. For reference, the list consists of `pomodoro`, `break`, and `long_break`... and is not likely to change.

Deprecation! 
* I remove `format_separator`. Is slightly incorrect. Is stupid too for no gain, I think.
* I remove `display_bar` config in favor of adding `{progress_bar}` in the `format`. 
* Timer and sound configs. (Explanation below).

New! 
* I simplify timer-related configs into one `timers` config. Need to be a list or number.
    * `timers = [1500, 300, 900]`... (or `timers = 5` for debugging purposes). Is very nice. :+1: 
* I simplify sound-related configs into one `sounds` config. Need to be a dict.
    * I add new sound configs too for `break_start`, `long_break_start` and `long_break_end`.
    * Now we use one dict to support up to ~~3~~ 6 sound configs.
* I expand `progress_bars` to support different numbers eg, `progress_bars = [25, 5, 15]` to signify 25min, 5min, 15min for the list. If `25` is too long for your tastes, then you can adjust one or all three accordingly to your preferences.
* Bar style. Is hardcoded for now too. Reason: The old `pomodoro` is inconsistent, create empty spaces that does not convey the message well. Also, the bar shifts left or right periodically based on the icon. It's more stable to use different colors.
* Customizable new `format_notificaiton`. With a pending PR, we can turn it off with `''` too.
* Multiple new placeholders to allow users to play with `pomodoro` format. 
* Multiple new thresholds to allow users to play with `pomodoro` colors.
    * Long break gets its own color too! `orange`!
* Multiple new buttons to allow users to play with `pomodoro` buttons.
* New `format` to quietly support the `progress_bar` and the current count. 


Issues!
* Other than incorrect/confusing `max_break` number (PR pending) and broken `format_separator` (deprecated in favor of hardcoded times), I have `None` to report.

Things to do before the merge!
* Merge the PR regarding the incorrect/confusing `max_break` number.
    * Incompatible due to `break` and the `long_break`. 
* Merge the PR regarding the sound issues with `paplay`. Use `ffplay` instead.
* (Optional) Set `progress_bars` back to `0` before the merge to keep it clean.
* (Optional) Remove the count and put it in the examples instead. Less `format` noise?
* (OCD) Rename the list to the tuple? eg `xxx = (1500, 300, 900)`? 

Thank you for reading.