### PR TITLE
air_quality: replace error format with error helper

### DIFF
--- a/py3status/modules/backlight.py
+++ b/py3status/modules/backlight.py
@@ -85,7 +85,7 @@ class Py3status:
             raise Exception(STRING_NOT_AVAILABLE)
 
         self.format = self.py3.update_placeholder_formats(
-                self.format, {'level': ':d'}
+            self.format, {'level': ':d'}
         )
         # check for an error code and an output
         self.xbacklight = False


### PR DESCRIPTION
Hi. We talked about errors briefly in #1310. I brought up the possibilities of supporting errors in `format` like the one I did in `air_quality`... for bad modem state `MM_MODEM_STATE_FAILED`. I later realize/review that this is not the ideal way to deal with non-common errors. I go ahead and replace error format with error helper here... and added missing `request_timeout` config to test this error.

We still can take advantage of error formats in some modules such as `mpd_status` to ignore common  `is_authenticated`, `is_connected` errors because we don't always run or want to run `music player daemon` on startup. Many thanks. :baby_chick: 