### PR TITLE
keyboard_locks: rearrange locks

### DIFF
--- a/py3status/modules/keyboard_locks.py
+++ b/py3status/modules/keyboard_locks.py
@@ -1,17 +1,17 @@
 # -*- coding: utf-8 -*-
 """
-Display CapsLock, NumLock, and ScrLock keys.
+Display NumLock, CapsLock, and ScrLock keys.
 
 Configuration parameters:
     cache_timeout: refresh interval for this module (default 1)
     format: display format for this module
-        *(default '[\?if=caps_lock&color=good CAPS|\?color=bad CAPS] '
-        '[\?if=num_lock&color=good NUM|\?color=bad NUM] '
+        *(default '[\?if=num_lock&color=good NUM|\?color=bad NUM] '
+        '[\?if=caps_lock&color=good CAPS|\?color=bad CAPS] '
         '[\?if=scroll_lock&color=good SCR|\?color=bad SCR]')*
 
 Control placeholders:
-    {caps_lock} a boolean based on xset data
     {num_lock} a boolean based on xset data
+    {caps_lock} a boolean based on xset data
     {scroll_lock} a boolean based on xset data
 
 Color options:
@@ -22,18 +22,18 @@ Color options:
 
 Examples:
 ```
-# hide CAPS, NUM, SCR
+# hide NUM, CAPS, SCR
 keyboard_locks {
-    format = '\?color=good [\?if=caps_lock CAPS][\?soft  ]'
-    format += '[\?if=num_lock NUM][\?soft  ][\?if=scroll_lock SCR]'
+    format = '\?color=good [\?if=num_lock NUM][\?soft  ]'
+    format += '[\?if=caps_lock CAPS][\?soft  ][\?if=scroll_lock SCR]'
 }
 ```
 
 SAMPLE OUTPUT
-{'color': '#00FF00', 'full_text': 'CAPS NUM'}
+{'color': '#00FF00', 'full_text': 'NUM CAPS SCR'}
 
 no_locks
-{'color': '#FF0000', 'full_text': 'CAPS NUM SCR'}
+{'color': '#FF0000', 'full_text': 'NUM CAPS SCR'}
 """
 
 
@@ -42,25 +42,29 @@ class Py3status:
     """
     # available configuration parameters
     cache_timeout = 1
-    format = ('[\?if=caps_lock&color=good CAPS|\?color=bad CAPS] '
-              '[\?if=num_lock&color=good NUM|\?color=bad NUM] '
+    format = ('[\?if=num_lock&color=good NUM|\?color=bad NUM] '
+              '[\?if=caps_lock&color=good CAPS|\?color=bad CAPS] '
               '[\?if=scroll_lock&color=good SCR|\?color=bad SCR]')
 
     def post_config_hook(self):
-        items = ['icon_caps_on', 'icon_caps_off', 'icon_num_on',
-                 'icon_num_off', 'icon_scr_on', 'icon_scr_off']
+        items = [
+            'icon_num_on', 'icon_num_off', 'icon_caps_on',
+            'icon_caps_off', 'icon_scr_on', 'icon_scr_off'
+        ]
         if self.py3.format_contains(self.format, ['caps', 'num', 'scr']) or (
                 any(getattr(self, v, None) is not None for v in items)):
             raise Exception('please update the config for this module')
-        # END DEPRECATION
+        # end deprecation
         self.locks = {}
         self.keyring = {
-            'caps_lock': 'Caps', 'num_lock': 'Num', 'scroll_lock': 'Scroll'}
+            'num_lock': 'Num', 'caps_lock': 'Caps', 'scroll_lock': 'Scroll'
+        }
 
     def keyboard_locks(self):
         xset_data = self.py3.command_output('xset q')
         for k, v in self.keyring.items():
             self.locks[k] = 'on' in xset_data.split('%s Lock:' % v)[1][0:6]
+
         return {
             'cached_until': self.py3.time_in(self.cache_timeout),
             'full_text': self.py3.safe_format(self.format, self.locks)


### PR DESCRIPTION
Cosemitc bugfix for `1.8` to address locks in wrong order and minor coding standards. Additionally, I added lock toggle support too via `xdotool` in this [branch](https://github.com/lasers/py3status/tree/keyboard_locks-add_xdotool) if you want to try it out. Ty.