### PR TITLE
weather_yahoo: date bugfix and a series of changes

### DIFF
--- a/py3status/modules/weather_yahoo.py
+++ b/py3status/modules/weather_yahoo.py
@@ -261,20 +261,26 @@ class Py3status:
                     channel['item_pubDate'] = self.py3.safe_format(
                         datetime.strftime(datetime.strptime(
                             channel['item_pubDate'], DATETIME_GENERAL),
-                            self.format_datetime['format']))
+                            self.format_datetime['format']
+                        )
+                    )
 
                 if self.datetime_init['format_today']:
                     today['date'] = self.py3.safe_format(
                         datetime.strftime(datetime.strptime(
                             today['date'], DATETIME_GENERAL),
-                            self.format_datetime['format_today']))
+                            self.format_datetime['format_today']
+                        )
+                    )
 
                 if self.datetime_init['format_forecast']:
                     for forecast in forecasts:
                         forecast['date'] = self.py3.safe_format(
                             datetime.strftime(datetime.strptime(
                                 forecast['date'], DATETIME_FORECAST),
-                                self.format_datetime['format_forecast']))
+                                self.format_datetime['format_forecast']
+                            )
+                        )
 
             if today:
                 if self.thresholds:
@@ -285,7 +291,8 @@ class Py3status:
                         icon=self._get_icon(today),
                         unit=self.unit,
                         **today
-                    ))
+                    )
+                )
 
             if forecasts:
                 for forecast in forecasts:
@@ -293,12 +300,15 @@ class Py3status:
                         self.py3.threshold_get_color(forecast['high'], 'high')
                         self.py3.threshold_get_color(forecast['low'], 'low')
 
-                    new_data.append(self.py3.safe_format(
-                        self.format_forecast, dict(
-                            icon=self._get_icon(forecast),
-                            unit=self.unit,
-                            **forecast
-                        )))
+                    new_data.append(
+                        self.py3.safe_format(
+                            self.format_forecast, dict(
+                                icon=self._get_icon(forecast),
+                                unit=self.unit,
+                                **forecast
+                            )
+                        )
+                    )
 
             format_separator = self.py3.safe_format(self.format_separator)
             format_forecast = self.py3.composite_join(format_separator, new_data)

--- a/py3status/modules/weather_yahoo.py
+++ b/py3status/modules/weather_yahoo.py
@@ -211,30 +211,22 @@ class Py3status:
 
     def _get_weather_data(self):
         try:
-            query = self.py3.request(self.url, timeout=self.request_timeout)
+            return self.py3.request(
+                self.url, timeout=self.request_timeout).json()
         except self.py3.RequestException:
             return {}
-        if query.status_code != 200:
-            self.py3.log('HTTP response returned code %s' % query.status_code)
-            return {}
-        return query.json()
 
     def _organize(self, data):
-        try:
-            today = data['query']['results']['channel']['item']['condition']
-            forecasts = data['query']['results']['channel']['item']['forecast']
-            # skip today?
-            if not self.forecast_today:
-                forecasts.pop(0)
-            # set number of forecast_days
-            forecasts = forecasts[:self.forecast_days]
-            # add extras
-            channel = data['query']['results']['channel']
-            channel = self.py3.flatten_dict(channel, delimiter='_')
-        except:
-            today = {}
-            forecasts = {}
-            channel = {}
+        today = data['query']['results']['channel']['item']['condition']
+        forecasts = data['query']['results']['channel']['item']['forecast']
+        # skip today?
+        if not self.forecast_today:
+            forecasts.pop(0)
+        # set number of forecast_days
+        forecasts = forecasts[:self.forecast_days]
+        # add extras
+        channel = data['query']['results']['channel']
+        channel = self.py3.flatten_dict(channel, delimiter='_')
         return today, forecasts, channel
 
     def _get_icon(self, forecast):

--- a/py3status/modules/weather_yahoo.py
+++ b/py3status/modules/weather_yahoo.py
@@ -27,8 +27,8 @@ Configuration parameters:
     woeid: specify Yahoo! WOEID to use, required (default None)
 
 Note:
-    The placeholder `{format_today}` will show the current conditions in `format`.
-    The config `forecast_today` will show today's forecast in `format_forecast`.
+    The placeholder `{format_today}` shows the current conditions in `format`.
+    The config `forecast_today` shows today's forecast in `format_forecast`.
 
 Format placeholders:
     {atmosphere_humidity}   humidity, eg 96
@@ -76,10 +76,10 @@ format_forecast placeholders:
 
 Color thresholds:
     format:
-        temp: a color based on current temperature
+        temp: print a color based on the value of current temperature
     format_forecast:
-        high: a color based on high temperature
-        low: a color based on low temperature
+        high: print a color based on the value of high temperature
+        low: print a color based on the value of low temperature
 
 Examples:
 ```
@@ -95,12 +95,12 @@ weather_yahoo {
     format = '[{format_today} ][{format_forecast}][ {item_pubDate}]'
     format_today = '{date} {icon}'
     format_forecast = '{date} {icon}'
-    format_separator = '\?color=bad  - '
+    format_separator = '\?color=violet  \| '
 
     format_datetime = {
-        'format_today': '\?color=bad&show %A',
+        'format': '\?color=darkgray %-I%P',
+        'format_today': '\?color=violet %A',
         'format_forecast': '%a %b %d',
-        'format': '%-I%P'
     }
 }
 
@@ -115,6 +115,15 @@ weather_yahoo {
 
 SAMPLE OUTPUT
 {'full_text': u'\u2602 \u2601 \u2601 \u2601'}
+
+example_weather
+[
+    {'full_text': u'Wednesday', 'color': '#ee82ee'},
+    {'full_text': u' \u2601 Thu Mar 08 \u2600'},
+    {'full_text': u' | ', 'color': '#ee82ee'},
+    {'full_text': u'Fri Mar 09 \u2601'},
+    {'full_text': u' 3am', 'color': '#a9a9a9'},
+]
 """
 
 from datetime import datetime

--- a/py3status/modules/weather_yahoo.py
+++ b/py3status/modules/weather_yahoo.py
@@ -119,7 +119,7 @@ SAMPLE OUTPUT
 
 from datetime import datetime
 DATETIME_FORECAST = '%d %b %Y'
-DATETIME_GENERAL = '%a, %d %b %Y %H:%M %p %Z'
+DATETIME_GENERAL = '%a, %d %b %Y %I:%M %p %Z'
 
 URL = 'https://query.yahooapis.com/v1/public/yql?q='
 URL += 'select * from weather.forecast where woeid='


### PR DESCRIPTION
Minor bugfix for `3.8` release. Assigned to @ultrabug. 
* Bug 1: Printed wrong dates for me. `2am` instead of `2pm`. Ooh so close.
    * Replaced `%H` with `%I` in `DATETIME_GENERAL`. Ok now.
* Removing `self.py3.log()` and `try/except`.
    * I have been using this for weeks. No issues.
* Cleanups.
    * Minor QA to follow coding standards.
   * Simplfying `init` lines in `psc` via looping.
    * Better example for users. Use Yahoo! color instead of `bad` color.
    * Add extra screenshot.
 