### PR TITLE
add py3-cmd to Control section of README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -185,3 +185,8 @@ Note that this will also send a SIGUSR1 signal to i3status.
 ::
 
     killall -USR1 py3status
+
+To refresh individual modules, the `py3-cmd <http://py3status.readthedocs.io/en/latest/py3-cmd.html>`_ utility can be used, e.g.:
+::
+
+   py3-cmd refresh wifi


### PR DESCRIPTION
Update README with a reference to the new `py3-cmd` util so users are aware they don't have to send `USR1` for bar updates.