### PR TITLE
allow executing shell code in the config (e.g. safely store passwords)

### DIFF
--- a/py3status/parse_config.py
+++ b/py3status/parse_config.py
@@ -106,6 +106,18 @@ class ConfigParser:
             }
         }
 
+    * execute shell code
+
+        order += exec(pass show git|head -n1)
+        my_module {
+            my_guessed_type = env(MY_VAR)
+            my_str = exec(pass show git|head -n1, str)
+            my_int = exec(pass show git|head -n1, int)
+            my_bool = exec(pass show git|head -n1, bool)
+        }
+
+        (shell code may not include any parenthesis!)
+
     * quality feedback on parse errors.
         details include error description, line number, position.
 
@@ -115,6 +127,7 @@ class ConfigParser:
         '#.*$'  # comments
         # environment variables
         '|(?P<env_var>env\(\s*([0-9a-zA-Z_]+)(\s*,\s*[a-zA-Z_]+)?\s*\))'
+        '|(?P<shell>exec\(.+?(\s*,\s*(int|float|str|bool|auto))?\))'  # shell code
         '|(?P<operator>[()[\]{},:]|\+?=)'  # operators
         '|(?P<literal>'
         r'("(?:[^"\\]|\\.)*")'  # double quoted string
@@ -232,6 +245,8 @@ class ConfigParser:
                 t_type = 'newline'
             elif token.group('env_var'):
                 t_type = 'env_var'
+            elif token.group('shell'):
+                t_type = 'shell'
             elif token.group('unknown'):
                 t_type = 'unknown'
             else:
@@ -348,6 +363,31 @@ class ConfigParser:
         except ValueError:
             self.error('Bad conversion')
 
+    def make_value_from_exec(self, value):
+        conversion_options = {
+            'int': int,
+            'float': float,
+            'str': str,
+
+            'bool': (lambda val: val.lower() in ('', 'true', '1')),
+            'auto': self.make_value,
+        }
+
+        match = re.match('exec\((.+?)(\s*,\s*(int|float|str|bool|auto))?\)'  , value)
+        shell, _, var_type = match.groups()
+        try:
+            shell_stdout = str(check_output(shell, shell=True).rstrip(), encoding='utf-8')
+        except CalledProcessError:
+            if var_type is not None and var_type.lower() == 'bool':
+                return False
+            self.error('shell script exited with an error')
+        if var_type is None:
+            return shell_stdout
+        try:
+            return conversion_options[var_type](shell_stdout)
+        except ValueError:
+            self.error('Bad conversion')
+
     def separator(self, separator=',', end_token=None):
         '''
         Read through tokens till the required separator is found.  We ignore
@@ -428,6 +468,8 @@ class ConfigParser:
                 return self.make_value(t_value)
             if token['type'] == 'env_var':
                 return self.make_value_from_env(t_value)
+            if token['type'] == 'shell':
+                return self.make_value_from_exec(t_value)
             elif t_value == '[':
                 return self.make_list()
             elif t_value == '{':
@@ -517,6 +559,8 @@ class ConfigParser:
                     self.error('Invalid name')
                 name.append(value)
             elif t_type == 'env_var':
+                self.error('Name expected')
+            elif t_type == 'shell':
                 self.error('Name expected')
             elif t_type == 'operator':
                 name = ' '.join(name)

--- a/py3status/parse_config.py
+++ b/py3status/parse_config.py
@@ -373,7 +373,7 @@ class ConfigParser:
             'auto': self.make_value,
         }
 
-        match = re.match('exec\((.+?)(\s*,\s*(int|float|str|bool|auto))?\)'  , value)
+        match = re.match('exec\((.+?)(\s*,\s*(int|float|str|bool|auto))?\)', value)
         shell, _, var_type = match.groups()
         try:
             shell_stdout = str(check_output(shell, shell=True).rstrip(), encoding='utf-8')


### PR DESCRIPTION
similar to `env()` (#1149), `exec()` allows you to capture the output of a shell
script. This is useful for example when you need to store a password in
a relatively safe manner.

Example:

    imap 0 {
        password = exec(pass show email/foobar|head -n1)
        # ...
    }


you can also force casting to `str` (no-op), `int`,`float` or `bool`. Bool behaves differently compared to `env()`: it returns a true value when the output is `1` or `true`, or when the script returns nothing on stdout and its exit code is zero. (meaning, when your script exits with a non-zero exit code and you've forced casting to bool, it'll be falsy)

also see https://github.com/ultrabug/py3status/pull/1210#issuecomment-376587858, where it was brought to my attention. 

**caveat**: it is parsed via a regex; parsing stops at the first `)`. (but parens aren't that common in filenames, so that shouldn't be too much of an issue)