### PR TITLE
py3: add new helper: get_control_placeholders_list

### DIFF
--- a/py3status/py3.py
+++ b/py3status/py3.py
@@ -662,6 +662,25 @@ class Py3:
         self._format_placeholders_cache[format_string][key] = False
         return False
 
+    def get_control_placeholders_list(self, format_string):
+        """
+        Returns a list of conditional placeholders in ``format_string``.
+
+        :param format_string: accepts a string or a list of strings
+        """
+        if isinstance(format_string, basestring):
+            format_string = [format_string]
+        names = []
+        for string in format_string:
+            for character in '!&=<>~[]':
+                if character in string:
+                    string = string.replace(character, ' ')
+            malformed_list = string.split('\?if')[1::1]
+            for malformed_string in malformed_list:
+                placeholder = malformed_string.split()[0]
+                names.append(placeholder)
+        return names
+
     def get_placeholders_list(self, format_string, match=None):
         """
         Returns a list of placeholders in ``format_string``.


### PR DESCRIPTION
This addresses https://github.com/ultrabug/py3status/issues/1059 for me. Got a different name in mind?

We need to remove the following characters first before parsing: `'!&=<>~[]'`
* Remove `[`, `]` because users can make mistakes. Also, `..][\?if=` thing.
* Remove  `<`, `>` because it is possible to support `<=`, `>=` too if we want to.
* Remove  `~` because that is a possible substitute for `in`.

We could support this in other methods too to simplify things a bit. Woo.