### PR TITLE
xrandr: parse mode properly

### DIFF
--- a/py3status/modules/xrandr.py
+++ b/py3status/modules/xrandr.py
@@ -172,17 +172,20 @@ class Py3status:
         for line in current.splitlines():
             try:
                 s = line.split(' ')
+                infos = line[line.find('('):]
                 if s[1] == 'connected':
-                    output, state = s[0], s[1]
-                    if s[2][0] == '(':
-                        mode, infos = None, ' '.join(s[2:]).strip('\n')
-                    else:
-                        mode, infos = s[2], ' '.join(s[3:]).strip('\n')
-                        active_layout.append(output)
+                    output, state, mode = s[0], s[1], None
+                    for index, x in enumerate(s[2:], 2):
+                        if 'x' in x and '+' in x:
+                            mode = x
+                            active_layout.append(output)
+                            infos = line[line.find(s[index + 1]):]
+                            break
+                        elif '(' in x:
+                            break
                     connected.append(output)
                 elif s[1] == 'disconnected':
-                    output, state = s[0], s[1]
-                    mode, infos = None, ' '.join(s[2:]).strip('\n')
+                    output, state, mode = s[0], s[1], None
                     disconnected.append(output)
                 else:
                     continue


### PR DESCRIPTION
Assigned to @ultrabug 

Hi. For first commit... If we defined a primary output, xrandr will put "primary" in `mode` instead of a mode (resolution). This avoids that and will give mode instead (code borrowed from `xrandr_rotate`). It seems that we're not using `mode`, `state` for anything (other than one-off logging) so it could be ~~simplified~~ removed. Also, I think we don't need try/except too.

The second commit addresses #623 for me. It turns out that if you assign multiple outputs to `--pos 0x0` (which was what happened here with no `xrandr` configs), you get weird clone behaviors. The solution is to add a `{}_pos` config in `xrandr` to assign a position. This commit will set the `0x0` for first output then `--right-of {previous_output}` repeatedly.... preventing multiple `0x0` outputs. That's all. 

EDIT: Second commit removed. No guarantee it'll not cause issues due to lack of `pos` and/or a combination of other arguments (such as --right-of... and --same-as). 

P.S. Please close the other `xrandr` issue too. Ty.