### PR TITLE
modules/volume_status : Prioritize default sound system with higher a…

### DIFF
--- a/py3status/modules/volume_status.py
+++ b/py3status/modules/volume_status.py
@@ -303,7 +303,7 @@ class Py3status:
     def post_config_hook(self):
         if not self.command:
             self.command = self.py3.check_commands(
-                ['amixer', 'pamixer', 'pactl'])
+                ['pamixer', 'pactl', 'amixer'])
         elif self.command not in ['amixer', 'pamixer', 'pactl']:
             raise Exception(STRING_ERROR % self.command)
         elif not self.py3.check_commands(self.command):


### PR DESCRIPTION
…bstraction.

Background
====================

PulseAudio provide abstration for ALSA[1]. Bypassing PulseAudio by
using `amixer` resulted in incorrect volume.

Example
--------------------

````
$ pactl list sinks
...
	Volume: front-left: 16380 /  25% / -36.13 dB,   front-right:
16380 /  25% / -36.13 dB
...

$ amixer
...
  Front Left: Playback 16380 [25%] [on]
  Front Right: Playback 16380 [25%] [on]
...

$ amixer -D default -c 0 sget Master
...
  Mono: Playback 39 [45%] [-36.00dB] [on]

````

Fix
====================

Guessing PulseAudio before alsamixer when user didn't provide
`command` argument.

Reference
====================
[1]:https://askubuntu.com/questions/581128/what-is-the-relation-between-alsa-and-pulseaudio-sound-architecture