### PR TITLE
taskwarrior: module enhancement

### DIFF
--- a/py3status/modules/taskwarrior.py
+++ b/py3status/modules/taskwarrior.py
@@ -45,7 +45,7 @@ class Py3status:
     def _get_context(self):
         context = "none"
         task_context = self.py3.command_output('task context show')
-        if not task_context.startswith("No context") :
+        if not task_context.startswith("No context"):
             context = task_context.split('\'')[1]
         return context
 
@@ -60,7 +60,9 @@ class Py3status:
 
         return {
             'cached_until': self.py3.time_in(self.cache_timeout),
-            'full_text': self.py3.safe_format(self.format, {'task': task_result, 'context': self._get_context(), 'nb_tasks': nb_tasks})
+            'full_text': self.py3.safe_format(self.format, {'task': task_result,
+                                                            'context': self._get_context(),
+                                                            'nb_tasks': nb_tasks})
         }
 
 

--- a/py3status/modules/taskwarrior.py
+++ b/py3status/modules/taskwarrior.py
@@ -72,6 +72,6 @@ if __name__ == "__main__":
     """
     from py3status.module_test import module_test
     config = {
-            "format": "{task} {context} {nb_tasks}"
-            }
+        "format": "{task} {context} {nb_tasks}"
+    }
     module_test(Py3status, config=config)


### PR DESCRIPTION
This pull request intends to allow for more customization in the Taskwarrior module
The current implementation is quite limited as it only allows to specify a task filter. All tasks are then displayed which can lead to a lot of text.

For background, my Taskwarrior workflow consist in having different context (home, work ...) consisting of multiple tasks. When a context is set, only tasks passing context definition (A tag +work for example) will be displayed. The tasks are also ranked by urgency which helps me decide what to do next.

I'd want to be able to print my current defined context, the number of remaining tasks and the description of either the most urgent task or the one i am working on (started task).

The target functionalities are as follow, please add your own if you have other ideas :
- [x] Context placeholder
- [x] Number of tasks placeholder
- [ ] Only display the most urgent task
- [ ] Display a configurable number of tasks
- [ ] Display started tasks

I took inspiration from other modules for the coding styles but would gladly take comments !
