### PR TITLE
Module simplify

### DIFF
--- a/py3status/core.py
+++ b/py3status/core.py
@@ -521,7 +521,7 @@ class Py3statusWrapper:
             try:
                 my_m = Module(module, user_modules, self)
                 # only handle modules with available methods
-                if my_m.methods:
+                if my_m.method:
                     self.modules[module] = my_m
                 elif self.config['debug']:
                     self.log(

--- a/py3status/module.py
+++ b/py3status/module.py
@@ -1,7 +1,6 @@
 import os
 import imp
 
-from collections import OrderedDict
 from time import time
 
 from py3status.composite import Composite


### PR DESCRIPTION
This PR clears out some legacy cruft.

* remove support for multiple methods for a module - this add complexity and is no longer used by any modules for some time.

* remove legacy calling for modules

This is a first push on a fresh round of code cleaning.  It removes complexity from the modules which is no longer needed.  As part of this cleanup I have added a `while True/break` to reduce the diff for this PR.  If accepted then I will make another PR just to remove that.

There is still much room for further cleanups\simplification here but this feels like a good first step