### PR TITLE
update documentation to include the pacman-contrib requirement.

### DIFF
--- a/py3status/modules/arch_updates.py
+++ b/py3status/modules/arch_updates.py
@@ -21,6 +21,7 @@ Format placeholders:
     {total} Total updates pending
 
 Requires:
+    pacman-contrib: Needed for 'checkupdates' command line utility
     cower: Needed to display pending 'aur' updates
 
 @author Iain Tatch <iain.tatch@gmail.com>


### PR DESCRIPTION
Seems that the command line utility 'checkupdates' was moved from the pacman package to pacman-contrib.  I've updated the documentation to reflect the new dependency.