### PR TITLE
allow glob (wildcard *) in path params

### DIFF
--- a/py3status/modules/file_status.py
+++ b/py3status/modules/file_status.py
@@ -25,7 +25,8 @@ missing
 {'color': '#FF0000', 'full_text': u'\u25a0'}
 """
 
-from os.path import expanduser, exists
+from glob import glob
+from os.path import exists, expanduser
 
 ERR_NO_PATH = 'no path given'
 
@@ -58,7 +59,7 @@ class Py3status:
 
     def post_config_hook(self):
         if self.path:
-            self.path = expanduser(self.path)
+            self.path = map(expanduser, glob(self.path))
 
     def file_status(self):
         if self.path is None:
@@ -68,12 +69,12 @@ class Py3status:
                 'cached_until': self.py3.CACHE_FOREVER,
             }
 
-        if exists(self.path):
-            icon = self.icon_available
-            color = self.py3.COLOR_GOOD
-        else:
-            icon = self.icon_unavailable
-            color = self.py3.COLOR_BAD
+        icon = self.icon_unavailable
+        color = self.py3.COLOR_BAD
+        for path in self.path:
+            if exists(path):
+                icon = self.icon_available
+                color = self.py3.COLOR_GOOD
 
         response = {
             'cached_until': self.py3.time_in(self.cache_timeout),


### PR DESCRIPTION
I have a usecase where I want to check a path with wildcard, eg

```
file_status VPN {                                                                                                                                                                                                                         
  cache_timeout = -1
  path = '/proc/sys/net/ipv4/conf/tun-vpn*'
  format = 'vpn: UP'
 }
```
I want the test success if `/proc/sys/net/ipv4/conf/tun-vpn1` or `/proc/sys/net/ipv4/conf/tun-vpn2` is present for example.

Think this could be usefull.