### PR TITLE
Module for xfce4-notifyd do-not-disturb status

### DIFF
--- a/py3status/modules/xfce4_notifyd.py
+++ b/py3status/modules/xfce4_notifyd.py
@@ -34,6 +34,13 @@ Requires:
 
 import dbus
 
+bus_name = 'org.xfce.Xfconf'
+channel = 'xfce4-notifyd'
+interface_name = 'org.xfce.Xfconf'
+object_path = '/org/xfce/Xfconf'
+setting = '/do-not-disturb'
+
+
 class Py3status:
     """
     """
@@ -43,21 +50,14 @@ class Py3status:
     dnd_on = "On"
     format = 'DND: {status}'
 
-    # not intended to be overriden
-    bus_name = 'org.xfce.Xfconf'
-    channel = 'xfce4-notifyd'
-    interface_name = 'org.xfce.Xfconf'
-    object_path = '/org/xfce/Xfconf'
-    setting = '/do-not-disturb'
-
     def post_config_hook(self):
         self.session_bus = dbus.SessionBus()
-        self.dnd_object = self.session_bus.get_object(self.bus_name, self.object_path) 
-        self.interface = dbus.Interface(self.dnd_object, self.interface_name)
+        self.dnd_object = self.session_bus.get_object(bus_name, object_path)
+        self.interface = dbus.Interface(self.dnd_object, interface_name)
 
     def xfce4_notifyd(self):
 
-        self.status = self.dnd_object.GetProperty(self.channel, self.setting)
+        self.status = self.dnd_object.GetProperty(channel, setting)
 
         status = self.dnd_off
         color = self.py3.COLOR_GOOD
@@ -80,7 +80,8 @@ class Py3status:
         if self.status:
             new_status = 0
 
-        self.interface.SetProperty(self.channel, self.setting, new_status)
+        self.interface.SetProperty(channel, setting, new_status)
+
 
 if __name__ == "__main__":
     """

--- a/py3status/modules/xfce4_notifyd.py
+++ b/py3status/modules/xfce4_notifyd.py
@@ -1,0 +1,90 @@
+# -*- coding: utf-8 -*-
+"""
+Display and toggle the DND (do-not-disturb) status of xfce4-notifyd
+
+Toggles DND status on click
+
+Configuration parameters:
+    cache_timeout: refresh interval for this module (default 5)
+    format: display format for this module (default 'DND: {status}')                    
+    dnd_off: status string when DND is off (default 'Off')
+    dnd_on: status string when DND is on (default 'On')
+
+Format of status string placeholders:
+    {status} replaced with dnd_off when DND is off, dnd_on when it is on
+
+Color options:
+    color_good: DND off
+    color_bad: DND on
+
+Examples:
+```
+xfce4_notifyd {
++     dnd_off = "🙉"                                                                       
++     dnd_on = "🙈" 
+}
+```
+
+Requires:
+    dbus: python bindings for dbus
+
+@author Robert Ricci <robert.ricci@gmail.com>
+@license BSD
+"""
+
+import dbus
+
+class Py3status:
+    """
+    """
+    # available configuration parameters
+    cache_timeout = 5
+    format = 'DND: {status}'
+    dnd_off = "Off"
+    dnd_on = "On"
+
+    # not intended to be overriden
+    interface_name = bus_name = 'org.xfce.Xfconf'
+    object_path = '/org/xfce/Xfconf'
+    channel = 'xfce4-notifyd'
+    setting = '/do-not-disturb'
+
+
+    def post_config_hook(self):
+        self.session_bus = dbus.SessionBus()
+        self.dnd_object = self.session_bus.get_object(self.bus_name, self.object_path) 
+        self.interface = dbus.Interface(self.dnd_object, self.interface_name)
+
+    def xfce4_notifyd(self):
+
+        self.status = self.dnd_object.GetProperty(self.channel, self.setting)
+
+        status = self.dnd_off
+        color = self.py3.COLOR_GOOD
+        if self.status:
+            color = self.py3.COLOR_BAD
+            status = self.dnd_on
+
+        return {
+            'cached_until': self.py3.time_in(self.cache_timeout),
+            'color': color,
+            'full_text': self.py3.safe_format(
+                self.format, {'status': status})
+        }
+
+    def on_click(self, event):
+        """
+        Toggle status
+        """
+        new_status = 1
+        if self.status:
+            new_status = 0
+
+        self.interface.SetProperty(self.channel, self.setting, new_status)
+
+if __name__ == "__main__":
+    """
+    Run module in test mode.
+    """
+    from py3status.module_test import module_test
+    module_test(Py3status)

--- a/py3status/modules/xfce4_notifyd.py
+++ b/py3status/modules/xfce4_notifyd.py
@@ -6,9 +6,9 @@ Toggles DND status on click
 
 Configuration parameters:
     cache_timeout: refresh interval for this module (default 5)
-    format: display format for this module (default 'DND: {status}')                    
     dnd_off: status string when DND is off (default 'Off')
     dnd_on: status string when DND is on (default 'On')
+    format: display format for this module (default 'DND: {status}')
 
 Format of status string placeholders:
     {status} replaced with dnd_off when DND is off, dnd_on when it is on
@@ -20,8 +20,8 @@ Color options:
 Examples:
 ```
 xfce4_notifyd {
-+     dnd_off = "🙉"                                                                       
-+     dnd_on = "🙈" 
+     dnd_off = "🙉"
+     dnd_on = "🙈"
 }
 ```
 
@@ -39,16 +39,16 @@ class Py3status:
     """
     # available configuration parameters
     cache_timeout = 5
-    format = 'DND: {status}'
     dnd_off = "Off"
     dnd_on = "On"
+    format = 'DND: {status}'
 
     # not intended to be overriden
-    interface_name = bus_name = 'org.xfce.Xfconf'
-    object_path = '/org/xfce/Xfconf'
+    bus_name = 'org.xfce.Xfconf'
     channel = 'xfce4-notifyd'
+    interface_name = 'org.xfce.Xfconf'
+    object_path = '/org/xfce/Xfconf'
     setting = '/do-not-disturb'
-
 
     def post_config_hook(self):
         self.session_bus = dbus.SessionBus()


### PR DESCRIPTION
This module adds support for the xfce4 notification daemon: it shows the current do-not-disturb status, and toggles it on click