### PR TITLE
Fixes #1373 - Fix disk stats computation in diskdata

### DIFF
--- a/py3status/modules/diskdata.py
+++ b/py3status/modules/diskdata.py
@@ -165,13 +165,12 @@ class Py3status:
         write = 0
         with open('/proc/diskstats', 'r') as fd:
             for line in fd:
+                data = line.split()
                 if disk:
-                    if " "+disk+" " in line:
-                        data = line.split()
+                    if data[2] == disk:
                         read += int(data[5]) * self.sector_size
                         write += int(data[9]) * self.sector_size
                 else:
-                    data = line.split()
                     if data[1] == '0':
                         read += int(data[5]) * self.sector_size
                         write += int(data[9]) * self.sector_size

--- a/py3status/modules/diskdata.py
+++ b/py3status/modules/diskdata.py
@@ -165,10 +165,11 @@ class Py3status:
         write = 0
         with open('/proc/diskstats', 'r') as fd:
             for line in fd:
-                if disk and disk in line:
-                    data = line.split()
-                    read += int(data[5]) * self.sector_size
-                    write += int(data[9]) * self.sector_size
+                if disk:
+                    if " "+disk+" " in line:
+                        data = line.split()
+                        read += int(data[5]) * self.sector_size
+                        write += int(data[9]) * self.sector_size
                 else:
                     data = line.split()
                     if data[1] == '0':


### PR DESCRIPTION
When a disk was specified, _get_io_stats() was summing statistics
for all drives, not just the selected device name.