### PR TITLE
Fixes #1377 - Handle non-existent interfaces better

### DIFF
--- a/py3status/modules/net_rate.py
+++ b/py3status/modules/net_rate.py
@@ -161,7 +161,7 @@ class Py3status:
             # get the deltas into variable
             delta = deltas[interface] if interface else None
 
-        except TypeError:
+        except (TypeError, ValueError):
             delta = None
             interface = None
             hide = self.hide_if_zero


### PR DESCRIPTION
If an interface is specified, but has no statistics, handle the
exception more gracefully.