### PR TITLE
py3-cmd: allow sending events with more options 

### DIFF
--- a/doc/py3-cmd.rst
+++ b/doc/py3-cmd.rst
@@ -18,16 +18,16 @@ To refresh all modules use the ``all`` keyword.
 
 .. code-block:: shell
 
-    # refresh any wifi modules
+    # refresh all instances of the wifi module
     py3-cmd refresh wifi
 
-    # refresh wifi module instance eth0
-    py3-cmd refresh "wifi eth0"
+    # refresh multiple modules
+    py3-cmd refresh coin_market github weather_yahoo
 
-    # refresh any wifi or whatismyip modules
-    py3-cmd refresh wifi whatismyip
+    # refresh module with instance name
+    py3-cmd refresh "weather_yahoo chicago"
 
-    # refresh all py3status modules
+    # refresh all modules
     py3-cmd refresh all
 
 
@@ -39,22 +39,27 @@ You can specify the button to simulate.
 
 .. code-block:: shell
 
-    # send a click event to the whatismyip module (button 1)
-    py3-cmd click whatismyip
+    # send a left/middle/right click
+    py3-cmd click --button 1 dpms      # left
+    py3-cmd click --button 2 sysdata   # middle
+    py3-cmd click --button 3 pomodoro  # right
 
-    # send a click event to the backlight module with button 5
-    py3-cmd click 5 backlight
-
-You can also specify the button using one of the named shortcuts
-``leftclick``, ``rightclick``, ``middleclick``, ``scrollup``, ``scrolldown``.
+    # send a up/down click
+    py3-cmd click --button 4 volume_status  # up
+    py3-cmd click --button 5 volume_status  # down
 
 .. code-block:: shell
 
-    # send a click event to the whatismyip module (button 1)
-    py3-cmd leftclick whatismyip
+    # toggle button in frame module
+    py3-cmd click --button 1 --index button frame  # left
 
-    # send a click event to the backlight module with button 5
-    py3-cmd scrolldown backlight
+    # change modules in group module
+    py3-cmd click --button 5 --index button group  # down
+
+    # change time units in timer module
+    py3-cmd click --button 4 --index hours timer    # up
+    py3-cmd click --button 4 --index minutes timer  # up
+    py3-cmd click --button 4 --index seconds timer  # up
 
 
 Calling commands from i3

--- a/doc/py3-cmd.rst
+++ b/doc/py3-cmd.rst
@@ -14,7 +14,6 @@ refresh
 ^^^^^^^
 
 Cause named module(s) to have their output refreshed.
-To refresh all modules use the ``all`` keyword.
 
 .. code-block:: shell
 
@@ -28,7 +27,7 @@ To refresh all modules use the ``all`` keyword.
     py3-cmd refresh "weather_yahoo chicago"
 
     # refresh all modules
-    py3-cmd refresh all
+    py3-cmd refresh --all
 
 
 click

--- a/py3status/command.py
+++ b/py3status/command.py
@@ -263,7 +263,7 @@ def send_command():
     py3status instances.
     """
 
-    def output(msg):
+    def verbose(msg):
         """
         print output if verbose is set.
         """
@@ -295,23 +295,23 @@ def send_command():
 
     msg = msg.encode('utf-8')
     if len(msg) > MAX_SIZE:
-        output('Message length too long, max length (%s)' % MAX_SIZE)
+        verbose('Message length too long, max length (%s)' % MAX_SIZE)
 
     # find all likely socket addresses
     uds_list = glob.glob('{}.[0-9]*'.format(SERVER_ADDRESS))
 
-    output('message "%s"' % msg)
+    verbose('message "%s"' % msg)
     for uds in uds_list:
         # Create a UDS socket
         sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
 
         # Connect the socket to the port where the server is listening
-        output('connecting to %s' % uds)
+        verbose('connecting to %s' % uds)
         try:
             sock.connect(uds)
         except socket.error:
             # this is a stale socket so delete it
-            output('stale socket deleting')
+            verbose('stale socket deleting')
             try:
                 os.unlink(uds)
             except OSError:
@@ -319,9 +319,9 @@ def send_command():
             continue
         try:
             # Send data
-            output('sending')
+            verbose('sending')
             sock.sendall(msg)
 
         finally:
-            output('closing socket')
+            verbose('closing socket')
             sock.close()

--- a/py3status/command.py
+++ b/py3status/command.py
@@ -3,21 +3,73 @@ import glob
 import json
 import os
 import socket
-import sys
 import threading
-
-from py3status.version import version
 
 SERVER_ADDRESS = '/tmp/py3status_uds'
 MAX_SIZE = 1024
 
-BUTTONS = {
-    'leftclick': 1,
-    'middleclick': 2,
-    'rightclick': 3,
-    'scrollup': 4,
-    'scrolldown': 5,
-}
+REFRESH_EPILOG = """
+examples:
+    refresh:
+        # refresh all instances of the wifi module
+        py3-cmd refresh wifi
+
+        # refresh multiple modules
+        py3-cmd refresh coin_market github weather_yahoo
+
+        # refresh a module with instance name
+        py3-cmd refresh "weather_yahoo chicago"
+
+        # refresh all modules
+        py3-cmd refresh all
+"""
+CLICK_EPILOG = """
+examples:
+    button:
+        # send a left/middle/right click
+        py3-cmd click --button 1 dpms      # left
+        py3-cmd click --button 2 sysdata   # middle
+        py3-cmd click --button 3 pomodoro  # right
+
+        # send a up/down click
+        py3-cmd click --button 4 volume_status  # up
+        py3-cmd click --button 5 volume_status  # down
+
+    index:
+        # toggle button in frame module
+        py3-cmd click --button 1 --index button frame  # left
+
+        # change modules in group module
+        py3-cmd click --button 5 --index button group  # down
+
+        # change time units in timer module
+        py3-cmd click --button 4 --index hours timer    # up
+        py3-cmd click --button 4 --index minutes timer  # up
+        py3-cmd click --button 4 --index seconds timer  # up
+
+    width, height, relative_x, relative_y, x, y:
+        # py3-cmd allows users to specify click events with
+        # more options. however, there are no modules that
+        # uses the aforementioned options.
+"""
+INFORMATION = [
+    ('V', 'version', 'show version number and exit'),
+    ('v', 'verbose', 'enable verbose mode'),
+]
+SUBPARSERS = [
+    ('click', 'click modules'),
+    ('refresh', 'refresh modules'),
+]
+CLICK_OPTIONS = [
+    ('button', 'specify a button number (default %(default)s)'),
+    ('height', 'specify a height of the block, in pixel'),
+    ('index', 'specify an index value often found in modules'),
+    ('relative_x', 'specify relative X on the block, from the top left'),
+    ('relative_y', 'specify relative Y on the block, from the top left'),
+    ('width', 'specify a width of the block, in pixel'),
+    ('x', 'specify absolute X on the bar, from the top left'),
+    ('y', 'specify absolute Y on the bar, from the top left'),
+]
 
 
 class CommandRunner:
@@ -75,9 +127,7 @@ class CommandRunner:
         """
         send a click event to the module(s)
         """
-        button = data.get('button')
         modules = data.get('module')
-
         for module_name in self.find_modules(modules):
             module = self.py3_wrapper.output_modules[module_name]
             if module['type'] == 'py3status':
@@ -86,14 +136,11 @@ class CommandRunner:
             else:
                 name = module['module'].name
                 instance = module['module'].instance
-            # our fake event, we do not know x, y so set to None
-            event = {
-                'y': None,
-                'x': None,
-                'button': button,
-                'name': name,
-                'instance': instance,
-            }
+            # make an event
+            event = {'name': name, 'instance': instance}
+            for name, message in CLICK_OPTIONS:
+                event[name] = data.get(name)
+
             if self.debug:
                 self.py3_wrapper.log(event)
             # trigger the event
@@ -127,10 +174,7 @@ class CommandServer(threading.Thread):
         self.py3_wrapper = py3_wrapper
 
         self.command_runner = CommandRunner(py3_wrapper)
-
-        pid = os.getpid()
-
-        server_address = '{}.{}'.format(SERVER_ADDRESS, pid)
+        server_address = '{}.{}'.format(SERVER_ADDRESS, os.getpid())
         self.server_address = server_address
 
         # Make sure the socket does not already exist
@@ -142,7 +186,6 @@ class CommandServer(threading.Thread):
 
         # Create a UDS socket
         sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
-
         sock.bind(server_address)
 
         if self.debug:
@@ -199,64 +242,117 @@ def command_parser():
     """
     build and return our command parser
     """
+    class Parser(argparse.ArgumentParser):
+        # print usages and exit on errors
+        def error(self, message):
+            print('\x1b[1;31merror: \x1b[0m{}'.format(message))
+            self.print_help()
+            self.exit(1)
 
-    parser = argparse.ArgumentParser(
-        description='Send commands to running py3status instances'
-    )
-    parser = argparse.ArgumentParser(add_help=True)
-    parser.add_argument(
-        '-v',
-        '--verbose',
-        action='store_true',
-        default=False,
-        dest='verbose',
-        help='print information',
-    )
-    parser.add_argument(
-        '--version',
-        action='store_true',
-        default=False,
-        dest='version',
-        help='print version information',
-    )
+        # hide aliases on errors
+        def _check_value(self, action, value):
+            if action.choices is not None and value not in action.choices:
+                raise argparse.ArgumentError(
+                    action, "invalid choice: '{}'".format(value)
+                )
 
-    subparsers = parser.add_subparsers(dest='command', help='commands')
-    subparsers.required = False
+    # make parser
+    parser = Parser(formatter_class=argparse.RawTextHelpFormatter)
 
-    # Refresh
-    refresh_parser = subparsers.add_parser(
-        'refresh', help='refresh named module(s)'
-    )
-    refresh_parser.add_argument(nargs='+', dest='module', help='module(s)')
+    # parser: add verbose, version
+    for short, name, msg in INFORMATION:
+        short = '-%s' % short
+        arg = '--%s' % name
+        parser.add_argument(short, arg, action='store_true', help=msg)
 
-    # Click
-    click_parser = subparsers.add_parser(
-        'click', help='simulate click on named module(s)'
-    )
-    click_parser.add_argument(
-        nargs='?',
-        type=int,
-        default=1,
-        dest='button',
-        help='button number to use',
-    )
-    click_parser.add_argument(nargs='+', dest='module', help='module(s)')
+    # make subparsers // ALIAS_DEPRECATION: remove metavar later
+    subparsers = parser.add_subparsers(dest='command', metavar='{click,refresh}')
+    sps = {}
 
-    # add shortcut commands for named buttons
-    for k in sorted(BUTTONS, key=BUTTONS.get):
-        click_parser = subparsers.add_parser(
-            k, help='simulate %s on named module(s)' % k
+    # subparsers: add refresh, click
+    for name, msg in SUBPARSERS:
+        sps[name] = subparsers.add_parser(
+            name,
+            epilog=eval('{}_EPILOG'.format(name.upper())),
+            formatter_class=argparse.RawTextHelpFormatter,
+            add_help=False,
+            help=msg
         )
+        sps[name].add_argument(nargs='+', dest='module', help='module name')
 
-        click_parser.add_argument(nargs='+', dest='module', help='module(s)')
+    # ALIAS_DEPRECATION: subparsers: add click (aliases)
+    buttons = {
+        'leftclick': 1, 'middleclick': 2, 'rightclick': 3,
+        'scrollup': 4, 'scrolldown': 5
+    }
+    for name in sorted(buttons):
+        sps[name] = subparsers.add_parser(name)
+        sps[name].add_argument(nargs='+', dest='module', help='module name')
 
-    return parser
+    # click subparser: add button, index, width, height, relative_{x,y}, x, y
+    sp = sps['click']
+    for name, msg in CLICK_OPTIONS:
+        arg = '--{}'.format(name)
+        if name == 'button':
+            sp.add_argument(arg, metavar='INT', type=int, help=msg, default=1)
+        elif name == 'index':
+            sp.add_argument(arg, metavar='INDEX', help=msg)
+        else:
+            sp.add_argument(arg, metavar='INT', type=int, help=msg)
+
+    # parse args, post-processing
+    options = parser.parse_args()
+
+    if options.command == 'click':
+        # cast string index to int
+        if options.index:
+            try:
+                options.index = int(options.index)
+            except:
+                pass
+    elif options.command == 'refresh':
+        # refresh all
+        if 'all' in options.module:
+            options.command = 'refresh_all'
+            options.module = []
+    elif options.version:
+        # print version
+        from platform import python_version
+        from py3status.version import version
+        print('py3status {} (python {})'.format(version, python_version()))
+        parser.exit()
+    elif not options.command:
+        parser.error('too few arguments')
+
+    # ALIAS_DEPRECATION
+    alias = options.command in buttons
+
+    # py3-cmd click 3 dpms ==> py3-cmd click --button 3 dpms
+    new_modules = []
+    for index, name in enumerate(options.module):
+        if name.isdigit():
+            if alias:
+                continue
+            if not index:  # zero index
+                options.button = int(name)
+        else:
+            new_modules.append(name)
+
+    # ALIAS_DEPRECATION: Convert (click) aliases to buttons
+    if alias:
+        options.button = buttons[options.command]
+        options.command = 'click'
+
+    if options.command == 'click' and not new_modules:
+        sps[options.command].error('too few arguments')
+    options.module = new_modules
+
+    return options
 
 
 def send_command():
     """
-    Run a remote command.
-    This is called via the py3status-command utility.
+    Run a remote command. This is called via py3-cmd utility.
 
     We look for any uds sockets with the correct name prefix and send our
     command to all that we find.  This allows us to communicate with multiple
@@ -270,30 +366,8 @@ def send_command():
         if options.verbose:
             print(msg)
 
-    parser = command_parser()
-    options = parser.parse_args()
-
-    # convert named buttons to click command for processing
-    if options.command in BUTTONS:
-        options.button = BUTTONS[options.command]
-        options.command = 'click'
-
-    if options.command == 'refresh' and 'all' in options.module:
-        options.command = 'refresh_all'
-
-    if options.version:
-        import platform
-        print('py3status-command version {} (python {})'.format(
-            version, platform.python_version()
-        ))
-        sys.exit(0)
-
-    if options.command:
-        msg = json.dumps(vars(options))
-    else:
-        sys.exit(1)
-
-    msg = msg.encode('utf-8')
+    options = command_parser()
+    msg = json.dumps(vars(options)).encode('utf-8')
     if len(msg) > MAX_SIZE:
         verbose('Message length too long, max length (%s)' % MAX_SIZE)
 
@@ -321,7 +395,6 @@ def send_command():
             # Send data
             verbose('sending')
             sock.sendall(msg)
-
         finally:
             verbose('closing socket')
             sock.close()

--- a/py3status/command.py
+++ b/py3status/command.py
@@ -52,6 +52,7 @@ examples:
         # more options. however, there are no modules that
         # uses the aforementioned options.
 """
+# EXEC_EPILOG = ''
 INFORMATION = [
     ('V', 'version', 'show version number and exit'),
     ('v', 'verbose', 'enable verbose mode'),
@@ -59,6 +60,7 @@ INFORMATION = [
 SUBPARSERS = [
     ('click', 'click modules', '+'),
     ('refresh', 'refresh modules', '*'),
+    # ('exec', 'execute methods', '+'),
 ]
 CLICK_OPTIONS = [
     ('button', 'specify a button number (default %(default)s)'),

--- a/py3status/modules/timer.py
+++ b/py3status/modules/timer.py
@@ -100,7 +100,7 @@ class Py3status:
         # Hours
         hours, t = divmod(t, 3600)
         # Minutes
-        mins, t = divmod(t, 60)
+        minutes, t = divmod(t, 60)
         # Seconds
         seconds = t
 
@@ -119,9 +119,9 @@ class Py3status:
                 'full_text': ':',
             },
             {
-                'full_text': make_2_didget(mins),
+                'full_text': make_2_didget(minutes),
                 'color': self.color,
-                'index': 'mins',
+                'index': 'minutes',
             },
             {
                 'full_text': ':',
@@ -146,7 +146,7 @@ class Py3status:
     def on_click(self, event):
         deltas = {
             'hours': 3600,
-            'mins': 60,
+            'minutes': 60,
             'seconds': 1
         }
         index = event['index']


### PR DESCRIPTION
Making it an official PR for @ultrabug to test it.

This is an alternative to https://github.com/ultrabug/py3status/pull/1358 to resolve py3-cmd issue https://github.com/ultrabug/py3status/issues/1349. Additionally, this should close insufficient documentation issue too https://github.com/ultrabug/py3status/issues/1245.

Changelog:
* I added documentation everywhere. Closes an issue (imo).
* In timer, I rename `mins` to `minutes` for cleaner example in `py3-cmd` docs.
* Unrelated. I rename `output` to `verbose` making it less vague.
* I understand why we didn't have aliases or button number in first place. If we work with `argparse`, it tends to sort stuffs and give us args to use. Some things are done after processing arguments. To keep it clean/simple, we would want to try having `argparse` deal with all arguments.
* All old arguments should still work. The only difference is that I stopped documenting aliases and button number and start documenting things the way `argparse` would want it documented (ie explicitly). Aliases are usually done via loop and the button number is really a module name in argparse eyes... which we convert it later to a button.
* EDIT: If there are an error, I'll print `help` right away to reduce steps.

~~Don't merge. Let me know first. I have (`delay` and `prevent_refresh`) placebos in there that should be removed first.~~ Ready.