### PR TITLE
formatter: parse placeholders with periods

### DIFF
--- a/py3status/formatter.py
+++ b/py3status/formatter.py
@@ -255,8 +255,8 @@ class Placeholder:
                         value = float(value)
                     if 'd' in self.format:
                         value = int(float(value))
-                    output = u'{%s%s}' % (self.key, self.format)
-                    value = output.format(**{self.key: value})
+                    output = u'{[%s]%s}' % (self.key, self.format)
+                    value = output.format({self.key: value})
                     value_ = float(value)
                 except ValueError:
                     pass


### PR DESCRIPTION
Splitting them up at @ultrabug's request.

I need this to support nvidia_smi's custom `memory.used_percent` placeholder. We can parse that placeholder okay, but not `{memory.used_percent:.2f}`. This makes it okay. Resolves #1302 

master: `0.7, {test.abc}`
this: `0.7, 123.5`


```diff
diff --git a/py3status/modules/static_string.py b/py3status/modules/static_string.py
index dbcec8c6..c2755866 100644
--- a/py3status/modules/static_string.py
+++ b/py3status/modules/static_string.py
@@ -16,12 +16,29 @@ class Py3status:
     """
     """
     # available configuration parameters
-    format = 'Hello, world!'
+    format = '{test}, {test.abc}'
+
+    class Meta:
+        update_config = {
+            'update_placeholder_format': [
+                {
+                    'placeholder_formats': {
+                        'test': ':.1f',
+                        'test.abc': ':.1f',
+                    },
+                    'format_strings': ['format']
+                },
+            ],
+        }
 
     def static_string(self):
+        data = {
+            'test': 000.700000,
+            'test.abc': 123.4567,
+        }
         return {
             'cached_until': self.py3.CACHE_FOREVER,
-            'full_text': self.py3.safe_format(self.format),
+            'full_text': self.py3.safe_format(self.format, data)
         }
 
 
```