### PR TITLE
Add support for setting background

### DIFF
--- a/py3status/modules/xrandr.py
+++ b/py3status/modules/xrandr.py
@@ -109,7 +109,8 @@ single
 
 """
 
-from collections import OrderedDict, deque
+from collections import deque
+from collections import OrderedDict
 from itertools import combinations
 from time import sleep
 
@@ -233,8 +234,8 @@ class Py3status:
 
         # Preserve the order in which user defined the output combinations
         if whitelist:
-            available = reversed(
-                [comb for comb in whitelist if comb in available])
+            available = reversed([comb for comb in whitelist
+                                  if comb in available])
 
         self.available_combinations = deque(available)
         self.combinations_map = combinations_map
@@ -256,8 +257,8 @@ class Py3status:
         we display the last selected combination.
         """
         for _ in range(len(self.available_combinations)):
-            if (self.displayed is None
-                    and self.available_combinations[0] == self.active_layout):
+            if (self.displayed is None and
+                    self.available_combinations[0] == self.active_layout):
                 self.displayed = self.available_combinations[0]
                 break
             else:
@@ -304,24 +305,24 @@ class Py3status:
                 pos = getattr(self, '{}_pos'.format(output), '0x0')
                 rotation = getattr(self, '{}_rotate'.format(output), 'normal')
                 resolution = getattr(self, '{}_mode'.format(output), None)
-                resolution = '--mode {}'.format(
-                    resolution) if resolution else '--auto'
+                resolution = '--mode {}'.format(resolution) if resolution else '--auto'
                 if rotation not in ['inverted', 'left', 'normal', 'right']:
-                    self.py3.log(
-                        'configured rotation {} is not valid'.format(rotation))
+                    self.py3.log('configured rotation {} is not valid'.format(
+                        rotation))
                     rotation = 'normal'
                 #
                 if mode == 'clone' and previous_output is not None:
                     cmd += ' {} --same-as {}'.format(resolution,
                                                      previous_output)
                 else:
-                    if ('above' in pos or 'below' in pos or 'left-of' in pos
-                            or 'right-of' in pos):
-                        cmd += ' {} --{} --rotate {}'.format(
-                            resolution, pos, rotation)
+                    if ('above' in pos or 'below' in pos or 'left-of' in pos or
+                            'right-of' in pos):
+                        cmd += ' {} --{} --rotate {}'.format(resolution, pos,
+                                                             rotation)
                     else:
-                        cmd += ' {} --pos {} --rotate {}'.format(
-                            resolution, pos, rotation)
+                        cmd += ' {} --pos {} --rotate {}'.format(resolution,
+                                                                 pos,
+                                                                 rotation)
                 previous_output = output
             else:
                 cmd += ' --off'
@@ -432,8 +433,8 @@ class Py3status:
         self._set_available_combinations()
         self._choose_what_to_display()
 
-        if (len(self.available_combinations) < 2
-                and self.hide_if_single_combination):
+        if (len(self.available_combinations) < 2 and
+                self.hide_if_single_combination):
             full_text = self.py3.safe_format(self.format, {'output': ''})
         else:
             if self.fixed_width is True:

--- a/py3status/modules/xrandr.py
+++ b/py3status/modules/xrandr.py
@@ -18,6 +18,8 @@ For convenience, this module also proposes some added features:
 
 Configuration parameters:
     cache_timeout: how often to (re)detect the outputs (default 10)
+    command: a custom command to be run after display configuration changes
+        (default None)
     fallback: when the current output layout is not available anymore,
         fallback to this layout if available. This is very handy if you
         have a laptop and switched to an external screen for presentation
@@ -119,8 +121,8 @@ class Py3status:
     """
     """
     # available configuration parameters
-    background_command = None
     cache_timeout = 10
+    command = None
     fallback = True
     fixed_width = True
     force_on_start = None
@@ -334,13 +336,11 @@ class Py3status:
             self.active_mode = mode
         self.py3.log('command "{}" exit code {}'.format(cmd, code))
 
-        self._apply_background()
+        if self.command:
+            self.py3.command_run(self.command)
+
         # move workspaces to outputs as configured
         self._apply_workspaces(combination, mode)
-
-    def _apply_background(self):
-        if self.background_command:
-            self.py3.command_run(self.background_command)
 
     def _apply_workspaces(self, combination, mode):
         """
@@ -377,7 +377,6 @@ class Py3status:
         on your laptop by switching back to the integrated screen
         automatically !
         """
-
         if len(self.active_comb) == 1:
             self._choose_what_to_display(force_refresh=True)
             self._apply()

--- a/py3status/modules/xrandr.py
+++ b/py3status/modules/xrandr.py
@@ -109,8 +109,7 @@ single
 
 """
 
-from collections import deque
-from collections import OrderedDict
+from collections import OrderedDict, deque
 from itertools import combinations
 from time import sleep
 
@@ -119,6 +118,7 @@ class Py3status:
     """
     """
     # available configuration parameters
+    background_command = None
     cache_timeout = 10
     fallback = True
     fixed_width = True
@@ -233,8 +233,8 @@ class Py3status:
 
         # Preserve the order in which user defined the output combinations
         if whitelist:
-            available = reversed([comb for comb in whitelist
-                                  if comb in available])
+            available = reversed(
+                [comb for comb in whitelist if comb in available])
 
         self.available_combinations = deque(available)
         self.combinations_map = combinations_map
@@ -256,8 +256,8 @@ class Py3status:
         we display the last selected combination.
         """
         for _ in range(len(self.available_combinations)):
-            if (self.displayed is None and
-                    self.available_combinations[0] == self.active_layout):
+            if (self.displayed is None
+                    and self.available_combinations[0] == self.active_layout):
                 self.displayed = self.available_combinations[0]
                 break
             else:
@@ -304,24 +304,24 @@ class Py3status:
                 pos = getattr(self, '{}_pos'.format(output), '0x0')
                 rotation = getattr(self, '{}_rotate'.format(output), 'normal')
                 resolution = getattr(self, '{}_mode'.format(output), None)
-                resolution = '--mode {}'.format(resolution) if resolution else '--auto'
+                resolution = '--mode {}'.format(
+                    resolution) if resolution else '--auto'
                 if rotation not in ['inverted', 'left', 'normal', 'right']:
-                    self.py3.log('configured rotation {} is not valid'.format(
-                        rotation))
+                    self.py3.log(
+                        'configured rotation {} is not valid'.format(rotation))
                     rotation = 'normal'
                 #
                 if mode == 'clone' and previous_output is not None:
                     cmd += ' {} --same-as {}'.format(resolution,
                                                      previous_output)
                 else:
-                    if ('above' in pos or 'below' in pos or 'left-of' in pos or
-                            'right-of' in pos):
-                        cmd += ' {} --{} --rotate {}'.format(resolution, pos,
-                                                             rotation)
+                    if ('above' in pos or 'below' in pos or 'left-of' in pos
+                            or 'right-of' in pos):
+                        cmd += ' {} --{} --rotate {}'.format(
+                            resolution, pos, rotation)
                     else:
-                        cmd += ' {} --pos {} --rotate {}'.format(resolution,
-                                                                 pos,
-                                                                 rotation)
+                        cmd += ' {} --pos {} --rotate {}'.format(
+                            resolution, pos, rotation)
                 previous_output = output
             else:
                 cmd += ' --off'
@@ -333,8 +333,13 @@ class Py3status:
             self.active_mode = mode
         self.py3.log('command "{}" exit code {}'.format(cmd, code))
 
+        self._apply_background()
         # move workspaces to outputs as configured
         self._apply_workspaces(combination, mode)
+
+    def _apply_background(self):
+        if self.background_command:
+            self.py3.command_run(self.background_command)
 
     def _apply_workspaces(self, combination, mode):
         """
@@ -371,6 +376,7 @@ class Py3status:
         on your laptop by switching back to the integrated screen
         automatically !
         """
+
         if len(self.active_comb) == 1:
             self._choose_what_to_display(force_refresh=True)
             self._apply()
@@ -426,8 +432,8 @@ class Py3status:
         self._set_available_combinations()
         self._choose_what_to_display()
 
-        if (len(self.available_combinations) < 2 and
-                self.hide_if_single_combination):
+        if (len(self.available_combinations) < 2
+                and self.hide_if_single_combination):
             full_text = self.py3.safe_format(self.format, {'output': ''})
         else:
             if self.fixed_width is True:


### PR DESCRIPTION
This PR adds support for running a configurable command to set desktop background when display configuration is updated.

Whenever display configuration changes the desktop background isn't updated, causing white boxes to show. I would have the plugin have rerun my preferred command to configure the desktop background again, so I don't have to do so manually.