### PR TITLE
whatismyip: repair module, py3status useragent currently blacklisted

### DIFF
--- a/py3status/modules/whatismyip.py
+++ b/py3status/modules/whatismyip.py
@@ -17,7 +17,6 @@ Configuration parameters:
     hide_when_offline: hide the module output when offline (default False)
     icon_off: what to display when offline (default '■')
     icon_on: what to display when online (default '●')
-    ignore_warnings: ignore negative_cache_timeout warnings (default False)
     mode: default mode to display is 'ip' or 'status' (click to toggle)
         (default 'ip')
     negative_cache_timeout: how often to check again when offline (default 60)
@@ -68,7 +67,6 @@ class Py3status:
     hide_when_offline = False
     icon_off = u'■'
     icon_on = u'●'
-    ignore_warnings = False
     mode = 'ip'
     negative_cache_timeout = 60
     timeout = 5
@@ -103,7 +101,7 @@ class Py3status:
             self.expected = {}
 
         # Alert about negative_cache_timeout
-        if self.negative_cache_timeout < 60 and self.ignore_warnings is False:
+        if self.negative_cache_timeout < 60:
             self.py3.error(
                 'warning, negative_cache_timeout should be > 60 to prevent ' +
                 'from being blacklisted by API')

--- a/py3status/modules/whatismyip.py
+++ b/py3status/modules/whatismyip.py
@@ -97,6 +97,8 @@ class Py3status:
         }
 
     def post_config_hook(self):
+        self.headers = {'User-Agent': UA}
+
         if self.expected is None:
             self.expected = {}
 
@@ -130,8 +132,6 @@ class Py3status:
     def _get_my_ip_info(self):
         """
         """
-        self.headers = {'User-Agent': UA}
-
         try:
             info = self.py3.request(
                 self.url_geo,


### PR DESCRIPTION
Hi,

whatismyip module with default params is re-die.
We must be more cool with api.

* Change negative_cache_timeout default value from 2 to 60. This prevent burst on api when no reply.
if api is sleepy or lazy we can click to refresh maybe, i prefer prevent to being blacklisted.
* To repair module, i forced another User-Agent same as coinmarket module.
* Also raise error in log if negative_cache_timeout is overrided with a lower value and ignore_warnings not set.