### PR TITLE
Handle output device changes in volume_status when using pactl.

### DIFF
--- a/py3status/modules/volume_status.py
+++ b/py3status/modules/volume_status.py
@@ -224,10 +224,10 @@ class PactlBackend(AudioBackend):
 
     def get_volume(self):
         output = self.command_output(['pactl', 'list', self.device_type_pl]).strip()
-
         output_matches = self.re_volume.search(output)
-        if output_matches is None:
-            # This happens when device changed. Try again.
+        if output_matches is None and self.parent.device is None:
+            # This happens when device changed and no device was specified explictly.
+            # Try again.
             self.device = None
             self.setup(self.parent)
             output_matches = self.re_volume.search(output)
@@ -237,7 +237,6 @@ class PactlBackend(AudioBackend):
             muted = (muted == 'yes')
         else:
             muted = False
-
         return perc, muted
 
     def volume_up(self, delta):

--- a/py3status/modules/volume_status.py
+++ b/py3status/modules/volume_status.py
@@ -184,6 +184,7 @@ class PamixerBackend(AudioBackend):
 
 class PactlBackend(AudioBackend):
     def setup(self, parent):
+        self.parent = parent
         # get available device number if not specified
         self.device_type = 'source' if self.is_input else 'sink'
         self.device_type_pl = self.device_type + 's'
@@ -223,8 +224,14 @@ class PactlBackend(AudioBackend):
 
     def get_volume(self):
         output = self.command_output(['pactl', 'list', self.device_type_pl]).strip()
-        muted, perc = self.re_volume.search(output).groups()
 
+        output_matches = self.re_volume.search(output)
+        if output_matches is None:
+            # This happens when device changed. Try again.
+            self.device = None
+            self.setup(self.parent)
+            output_matches = self.re_volume.search(output)
+        muted, perc = output_matches.groups()
         # muted should be 'on' or 'off'
         if muted in ['yes', 'no']:
             muted = (muted == 'yes')


### PR DESCRIPTION
When using pactl, volume_status basically stops working when switching output devices. The drawback of this commit is that it will keep failing and trying to reinitialize on get_volume in the case when no device is found. But this makes it no worse visually than the current behavior.

I'm using ubuntu 18.04 with i3.