### PR TITLE
volume_status: skip pamixer if no pulseaudio

### DIFF
--- a/py3status/modules/volume_status.py
+++ b/py3status/modules/volume_status.py
@@ -302,12 +302,11 @@ class Py3status:
 
     def post_config_hook(self):
         if not self.command:
-            self.command = self.py3.check_commands(
-                ['pamixer', 'pactl', 'amixer'])
-            # pactl may be automatically installed, check for pulseaudio too
-            if self.command == 'pactl':
-                if not self.py3.check_commands('pulseaudio'):
-                    self.command = self.py3.check_commands('amixer')
+            commands = ['pamixer', 'pactl', 'amixer']
+            # pamixer, pactl requires pulseaudio to work
+            if not self.py3.check_commands('pulseaudio'):
+                commands = ['amixer']
+            self.command = self.py3.check_commands(commands)
         elif self.command not in ['amixer', 'pamixer', 'pactl']:
             raise Exception(STRING_ERROR % self.command)
         elif not self.py3.check_commands(self.command):


### PR DESCRIPTION
Skip `pamixer` if `pulseaudio` is not installed. Addresses #1393.