### PR TITLE
py3.request adds a default User-Agent header when none is provided

### DIFF
--- a/py3status/py3.py
+++ b/py3status/py3.py
@@ -11,6 +11,7 @@ from math import log10
 from pprint import pformat
 from subprocess import Popen, PIPE, STDOUT
 from time import time
+from uuid import uuid4
 
 from py3status import exceptions
 from py3status.constants import COLOR_NAMES
@@ -18,6 +19,7 @@ from py3status.formatter import Formatter, Composite
 from py3status.request import HttpResponse
 from py3status.storage import Storage
 from py3status.util import Gradiants
+from py3status.version import version
 
 
 PY3_CACHE_FOREVER = -1
@@ -114,6 +116,7 @@ class Py3:
         self._report_exception_cache = set()
         self._thresholds = None
         self._threshold_gradients = {}
+        self._uid = uuid4()
 
         if module:
             self._i3s_config = module._py3_wrapper.config['py3_config']['general']
@@ -1156,6 +1159,11 @@ class Py3:
 
         if headers is None:
             headers = {}
+
+        if 'User-Agent' not in headers:
+            headers['User-Agent'] = 'py3status/{} {}'.format(
+                version, self._uid
+            )
 
         return HttpResponse(url,
                             params=params,


### PR DESCRIPTION
User-Agent is composed like this: py3status/VERSION UUID

VERSION is the current py3status version
UUID is a unique uuid4() of the running instance, will change at every restart of py3status

This will fix #1401 and replace #1398 