### PR TITLE
Allow module to use the general "markup" config

### DIFF
--- a/py3status/module.py
+++ b/py3status/module.py
@@ -349,6 +349,13 @@ class Module:
 
             self.i3s_module_options["separator_block_width"] = sep_block_width
 
+        # if markup is set on the module or globally we add it to the module
+        # output for pango support
+        fn = self._py3_wrapper.get_config_attribute
+        param = fn(self.module_full_name, 'markup')
+        if not hasattr(param, 'none_setting'):
+            self.i3s_module_options['markup'] = param
+
     def process_composite(self, response):
         """
         Process a composite response.


### PR DESCRIPTION
Not sure if that's the right way to do this, but here's what I use for my setup.

In lots of my module config `format` string I use pango markup.
But it isn't interpreted (and instead display the ugly xml in my i3bar) unless I use the following patch.

Here's an example extracted from my setup that needs this to work and properly display the font awesome icons:
```
general {
    color_good = "#3EC2FF"
    color_bad = "#FF0000"
    colors = true
    output_format = "i3bar"
    markup = "pango"
}

order += "volume_status"

volume_status {
    format = "<span font='Font Awesome 5 Free Solid'></span> {percentage}%"
    format_muted = "<span font='Font Awesome 5 Free Solid'></span>"
    color_muted = "#FFFF00"
}
```