### PR TITLE
py3: add new helper: get_color_names_list

### DIFF
--- a/py3status/py3.py
+++ b/py3status/py3.py
@@ -673,6 +673,29 @@ class Py3:
         self._format_placeholders_cache[format_string][key] = False
         return False
 
+    def get_color_names_list(self, format_strings):
+        """
+        Returns a list of color names in ``format_string``.
+
+        :param format_strings: Accepts a format string or a list of format strings.
+        """
+        if not getattr(self._py3status_module, 'thresholds', None):
+            return []
+        if isinstance(format_strings, basestring):
+            format_strings = [format_strings]
+        names = set()
+        for string in format_strings:
+            for color in string.replace('&', ' ').split('color=')[1::1]:
+                color = color.split()[0]
+                if '#' in color:
+                    continue
+                if color in ['good', 'bad', 'degraded', 'None', 'threshold']:
+                    continue
+                if color in COLOR_NAMES:
+                    continue
+                names.add(color)
+        return list(names)
+
     def get_placeholders_list(self, format_string, match=None):
         """
         Returns a list of placeholders in ``format_string``.


### PR DESCRIPTION
Hi, I made a new helper to assist with thresholds. This is optimized and could be partially tokenized too. 

Adding this in `post_config_hook` will simplify things by ensuring that all variables in the data can be colorized (via loops) and that no cpu cycles would be wasted on unnecessary thresholds.


I'm merging this now so I can fix the other pull requests and/or modules.

I chose `get_color_names_list` over `get_colors_list` because I made this to fetch placeholder names. We can modify this to get css color names, color rgb or special color names too, but I don't see what for... so I go with the name `get_color_names_list`. Thank you.