### PR TITLE
gitignore: ignore .pytest_cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ dist
 *.egg-info
 .tox/
 .cache/
+.pytest_cache
 
 # sphinx build system
 doc/screenshots


### PR DESCRIPTION
When we `py.test --flake8`, we get this cache directory. Make it go away.