### PR TITLE
formatter: hide block on 'None' string too

### DIFF
--- a/py3status/formatter.py
+++ b/py3status/formatter.py
@@ -268,11 +268,11 @@ class Placeholder:
                 value = value_ = output.format(**{self.key: value})
 
             if block.commands.not_zero:
-                valid = value_ not in ['', None, False, '0', '0.0', 0, 0.0]
+                valid = value_ not in ['', 'None', None, False, '0', '0.0', 0, 0.0]
             else:
                 # '', None, and False are ignored
                 # numbers like 0 and 0.0 are not.
-                valid = not (value_ in ['', None] or value_ is False)
+                valid = not (value_ in ['', 'None', None] or value_ is False)
             enough = False
         except:
             # Exception raised when we don't have the param

--- a/tests/test_formatter.py
+++ b/tests/test_formatter.py
@@ -27,6 +27,7 @@ param_dict = {
     'no': False,
     'empty': '',
     'None': None,
+    'None_str': 'None',
     '?bad name': 'evil',
     u'☂ Very bad name ': u'☂ extremely evil',
     'long_str': 'I am a long string though not too long',
@@ -296,6 +297,10 @@ def test_26():
 
 def test_27():
     run_formatter({'format': '{None}', 'expected': '', })
+
+
+def test_27a():
+    run_formatter({'format': '[Hi, my name is {None_str}]', 'expected': '', })
 
 
 def test_28():


### PR DESCRIPTION
`'[Hi, my name is {name}]'` does not work when `name` is a string `'None'`. This PR fixes it.