### PR TITLE
formatter: don't strip whitespace

### DIFF
--- a/py3status/formatter.py
+++ b/py3status/formatter.py
@@ -590,9 +590,8 @@ class Block:
                 text += conversion(item)
                 continue
             elif text:
-                if (not first and (
-                        text.strip() == '' or out and
-                        out[-1].get('color') == color)):
+                if (not first and (text == '' or out and
+                   out[-1].get('color') == color)):
                     out[-1]['full_text'] += text
                 else:
                     part = {'full_text': text}


### PR DESCRIPTION
A prelude bugfix to https://github.com/ultrabug/py3status/pull/1395's "invalid format" error.