### PR TITLE
git-hooks: run flake8 tests first before pushing

### DIFF
--- a/.git-hooks/pre-push
+++ b/.git-hooks/pre-push
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+# run flake8 tests first before pushing
+
+# $ git config core.hooksPath .git-hooks  # (in dir) to add hooks
+# $ git config --unset core.hooksPath  # (in dir) to remove hooks
+
+if command -v py.test &>/dev/null; then
+    py.test --flake8
+else
+    echo 'hooks/pre-push: command "py.test" not found, skipping flake8 tests'
+fi


### PR DESCRIPTION
Helpful `pre-push` hook for everybody... to run flake8 tests first before pushing.

Note: Please wait until we `black` py3status first before adding the hooks. Otherwise, errors.