### PR TITLE
formatter: add {:ceil} to return x or x+1

### DIFF
--- a/py3status/formatter.py
+++ b/py3status/formatter.py
@@ -2,6 +2,7 @@
 import re
 import sys
 
+from math import ceil
 from numbers import Number
 
 from py3status.composite import Composite
@@ -249,6 +250,8 @@ class Placeholder:
                 # no remaining digits following it.  If the parameter cannot
                 # be successfully converted then the format will be removed.
                 try:
+                    if 'ceil' in self.format:
+                        value = int(ceil(float(value)))
                     if 'f' in self.format:
                         value = float(value)
                     if 'g' in self.format:

--- a/tests/test_formatter.py
+++ b/tests/test_formatter.py
@@ -1368,6 +1368,20 @@ def test_trailing_zeroes_2():
     })
 
 
+def test_ceiling_numbers_1():
+    run_formatter({
+        'format': '{pi} becomes {pi:ceil}',
+        'expected': '3.14159265359 becomes 4'
+    })
+
+
+def test_ceiling_numbers_2():
+    run_formatter({
+        'format': '{zero_almost} becomes {zero_almost:ceil}',
+        'expected': '0.0001 becomes 1'
+    })
+
+
 if __name__ == '__main__':
     # run tests
     import sys


### PR DESCRIPTION
This is for `pomodoro`. Other modules can take advantage of this.

We use `{remaining_minutes:ceil}` to print `1` instead of `0.5324243` in pomodoro.
If `{remaining_seconds}` is in the format too, then we shouldn't use `:ceil` on the minute.

This is not a big concern because most users would be using new placeholder `{remaining}` or `{progress}` as both basically print nice `[\?not_zero {hours}:]{minutes}:{seconds}`.

This is here to support pomodoro's old placeholder `{mm}`... total minutes.

