### PR TITLE
formatter: show values instead of faking nonexistent keys

### DIFF
--- a/py3status/formatter.py
+++ b/py3status/formatter.py
@@ -238,6 +238,7 @@ class Placeholder:
         """
         return the correct value for the placeholder
         """
+        value = '{%s}' % self.key
         try:
             value = value_ = get_params(self.key)
             if self.format.startswith(':'):
@@ -278,7 +279,6 @@ class Placeholder:
             # Exception raised when we don't have the param
             enough = True
             valid = False
-            value = '{%s}' % self.key
 
         return valid, value, enough
 


### PR DESCRIPTION
The difference between showing values and faking nonexistent keys....
`{real}` (before) vs `None` (after).

We enter wrong formats, we get fake nonexistent keys instead of values.
This changes so we see more values even if we made mistakes somewhere.

Different scenario: Sometimes we can't avoid mistakes, but do want values anyway.

```diff
diff --git a/py3status/modules/static_string.py b/py3status/modules/static_string.py
index dbcec8c6..3bba265e 100644
--- a/py3status/modules/static_string.py
+++ b/py3status/modules/static_string.py
@@ -16,12 +16,17 @@ class Py3status:
     """
     """
     # available configuration parameters
-    format = 'Hello, world!'
+    format = '{round:.2f} // {real:.2f} // {nonexistent}'
 
     def static_string(self):
+        data = {
+            'round': 123.456,
+            'real': None,
+        }
+
         return {
             'cached_until': self.py3.CACHE_FOREVER,
-            'full_text': self.py3.safe_format(self.format),
+            'full_text': self.py3.safe_format(self.format, data),
         }
 
 
```