### PR TITLE
command_output: do not treat text on stderr as failure, rely on exit code

### DIFF
--- a/py3status/modules/external_script.py
+++ b/py3status/modules/external_script.py
@@ -13,6 +13,8 @@ Configuration parameters:
     cache_timeout: how often we refresh this module in seconds
         (default 15)
     format: see placeholders below (default '{output}')
+    ignore_stderr: do not treat output on stderr as failure
+        (defaut True)
     localize: should script output be localized (if available)
         (default True)
     script_path: script you want to show output of (compulsory)
@@ -51,6 +53,7 @@ class Py3status:
     # available configuration parameters
     cache_timeout = 15
     format = '{output}'
+    ignore_stderr = True
     localize = True
     script_path = None
     strip_output = False
@@ -64,7 +67,7 @@ class Py3status:
         response = {}
         response['cached_until'] = self.py3.time_in(self.cache_timeout)
         try:
-            output = self.py3.command_output(self.script_path, shell=True, localized=self.localize)
+            output = self.py3.command_output(self.script_path, shell=True, localized=self.localize, ignore_stderr=self.ignore_stderr)
             output_lines = output.splitlines()
             if len(output_lines) > 1:
                 output_color = output_lines[1]

--- a/py3status/modules/external_script.py
+++ b/py3status/modules/external_script.py
@@ -13,8 +13,6 @@ Configuration parameters:
     cache_timeout: how often we refresh this module in seconds
         (default 15)
     format: see placeholders below (default '{output}')
-    ignore_stderr: do not treat output on stderr as failure
-        (defaut True)
     localize: should script output be localized (if available)
         (default True)
     script_path: script you want to show output of (compulsory)
@@ -53,7 +51,6 @@ class Py3status:
     # available configuration parameters
     cache_timeout = 15
     format = '{output}'
-    ignore_stderr = True
     localize = True
     script_path = None
     strip_output = False
@@ -67,7 +64,7 @@ class Py3status:
         response = {}
         response['cached_until'] = self.py3.time_in(self.cache_timeout)
         try:
-            output = self.py3.command_output(self.script_path, shell=True, localized=self.localize, ignore_stderr=self.ignore_stderr)
+            output = self.py3.command_output(self.script_path, shell=True, localized=self.localize)
             output_lines = output.splitlines()
             if len(output_lines) > 1:
                 output_color = output_lines[1]

--- a/py3status/py3.py
+++ b/py3status/py3.py
@@ -933,7 +933,7 @@ class Py3:
             msg = 'Command `{cmd}` {error}'.format(cmd=pretty_cmd, error=e.errno)
             raise exceptions.CommandError(msg, error_code=e.errno)
 
-    def command_output(self, command, shell=False, capture_stderr=False, localized=False):
+    def command_output(self, command, shell=False, capture_stderr=False, localized=False, ignore_stderr=False):
         """
         Run a command and return its output as unicode.
         The command can either be supplied as a sequence or string.
@@ -942,6 +942,7 @@ class Py3:
         :param shell: if `True` then command is run through the shell
         :param capture_stderr: if `True` then STDERR is piped to STDOUT
         :param localized: if `False` then command is forced to use its default (English) locale
+        :param ignore_stderr: if `False` then any output on STDERR (unless captured) will fail the command
 
         A CommandError is raised if an error occurs
         """
@@ -987,7 +988,7 @@ class Py3:
                 raise exceptions.CommandError(
                     msg, error_code=retcode, error=error, output=output
                 )
-        if error:
+        if error and not ignore_stderr:
             msg = "Command '{cmd}' had error {error}".format(
                 cmd=pretty_cmd, error=error
             )

--- a/py3status/py3.py
+++ b/py3status/py3.py
@@ -933,7 +933,7 @@ class Py3:
             msg = 'Command `{cmd}` {error}'.format(cmd=pretty_cmd, error=e.errno)
             raise exceptions.CommandError(msg, error_code=e.errno)
 
-    def command_output(self, command, shell=False, capture_stderr=False, localized=False, ignore_stderr=False):
+    def command_output(self, command, shell=False, capture_stderr=False, localized=False):
         """
         Run a command and return its output as unicode.
         The command can either be supplied as a sequence or string.
@@ -942,7 +942,6 @@ class Py3:
         :param shell: if `True` then command is run through the shell
         :param capture_stderr: if `True` then STDERR is piped to STDOUT
         :param localized: if `False` then command is forced to use its default (English) locale
-        :param ignore_stderr: if `False` then any output on STDERR (unless captured) will fail the command
 
         A CommandError is raised if an error occurs
         """
@@ -988,13 +987,6 @@ class Py3:
                 raise exceptions.CommandError(
                     msg, error_code=retcode, error=error, output=output
                 )
-        if error and not ignore_stderr:
-            msg = "Command '{cmd}' had error {error}".format(
-                cmd=pretty_cmd, error=error
-            )
-            raise exceptions.CommandError(
-                msg, error_code=retcode, error=error, output=output
-            )
         return output
 
     def _storage_init(self):


### PR DESCRIPTION
Often scripts put some diagnostic information on stderr, so having some text on stderr doesn't necessarily mean the command has failed. In fact, this is true in most cases — exit code is an indicator of whether command failed or not.

This PR allows to ignore stderr and thus not failing the command. This PR also changes the default behavior of `external_script` because I believe it is more correct this way.

Not sure on the name of the property. Maybe reversing is better, like `fail_on_stderr`?