### PR TITLE
New module: speedtest

### DIFF
--- a/py3status/modules/speedtest.py
+++ b/py3status/modules/speedtest.py
@@ -6,7 +6,7 @@ Configuration parameters:
     button_refresh: button to run the check (default 2)
     button_share: button to open the result link (default None)
     format: display format for this module, {download} and/or {upload} required
-        (default '● [{ping} ms] [↑ {upload} {upload_unit}] [↓ {download} {download_unit}]')
+        (default 'Speedtest [Up {upload} {upload_unit}] [Down {download} {download_unit}]')
     server_id: speedtest server to use, `speedtest-cli --list` to get id (default None)
     si_units: use SI units (default False)
     sleep_timeout: when speedtest-cli is allready running, this interval will be used
@@ -25,42 +25,42 @@ Configuration parameters:
     unit_size: unit for bytes_received/bytes_sent (default 'MB')
 
 Format placeholders:
-    {bytes_sent} bytes sent during test, human readable
-    {bytes_sent_unit} unit used for bytes_sent, eg 'MB'
-    {bytes_sent_raw} bytes sent during test, for format comparation
-    {bytes_received} bytes received during test, human readable
-    {bytes_received_raw} bytes received during test, for format comparation
-    {bytes_received_unit} unit used for bytes_received, eg 'MB'
-    {client_country} client country code, eg 'FR'
-    {client_ip} client ip, eg '78.194.13.7'
-    {client_isp} client isp, eg 'Free SAS'
-    {client_ispdlavg} client isp download average, eg '0'
-    {client_isprating} client isp rating, eg 3.7
-    {client_ispulavg} client isp upload average, eg '0'
-    {client_lat} client latitude, eg '48.8534'
-    {client_loggedin} client logged in, eg '0'
-    {client_lon} client longitude, eg '2.3487999999999998'
-    {client_rating} client rating, eg '0'
-    {download} download rate from speedtest server, human readable
-    {download_raw} download rate from speedtest server, for format comparation
-    {download_unit} unit used as , eg 'MB/s'
-    {ping} ping time in ms to speedtest server
-    {quality} quality of the connection, eg ok, bad, faster, slower
-    {timestamp} timestamp of the run
-    {server_cc} server country code, eg 'FR'
-    {server_country} server country, eg 'France'
-    {server_d} server distance, eg '2.316599376968091'
-    {server_host} server host, eg 'speedtest.telecom-paristech.fr:8080'
-    {server_id} server id, eg '11977'
-    {server_lat} server latitude, eg '48.8742'
-    {server_latency} server latency, eg 8.265
-    {server_lon} server longitude, eg 2.3470
-    {server_name} server name, eg 'Paris'
-    {server_sponsor} server sponsor, eg 'Télécom ParisTech'
-    {server_url} server url, eg 'http://speedtest.telecom-paristech.fr/upload.php'
-    {upload} upload rate to speedtest server, human readable
-    {upload_raw} upload rate to speedtest server, for format comparation
-    {upload_unit} unit used for upload, eg 'MB/s'
+    {bytes_sent}            bytes sent during test, human readable
+    {bytes_sent_unit}       unit used for bytes_sent, eg 'MB'
+    {bytes_sent_raw}        bytes sent during test, for format comparation
+    {bytes_received}        bytes received during test, human readable
+    {bytes_received_raw}    bytes received during test, for format comparation, eg
+    {bytes_received_unit}   unit used for bytes_received, eg 'MB'
+    {client_country}        client country code, eg 'FR'
+    {client_ip}             client ip, eg '78.194.13.7'
+    {client_isp}            client isp, eg 'Free SAS'
+    {client_ispdlavg}       client isp download average, eg '0'
+    {client_isprating}      client isp rating, eg 3.7
+    {client_ispulavg}       client isp upload average, eg '0'
+    {client_lat}            client latitude, eg '48.8534'
+    {client_loggedin}       client logged in, eg '0'
+    {client_lon}            client longitude, eg '2.3487999999999998'
+    {client_rating}         client rating, eg '0'
+    {download}              download rate from speedtest server, human readable
+    {download_raw}          download rate from speedtest server, for format comparation
+    {download_unit}         unit used as , eg 'MB/s'
+    {ping}                  ping time in ms to speedtest server
+    {quality}               quality of the connection, eg ok, bad, faster, slower
+    {timestamp}             timestamp of the run, eg 'TODO'
+    {server_cc}             server country code, eg 'FR'
+    {server_country}        server country, eg 'France'
+    {server_d}              server distance, eg '2.316599376968091'
+    {server_host}           server host, eg 'speedtest.telecom-paristech.fr:8080'
+    {server_id}             server id, eg '11977'
+    {server_lat}            server latitude, eg '48.8742'
+    {server_latency}        server latency, eg 8.265
+    {server_lon}            server longitude, eg 2.3470
+    {server_name}           server name, eg 'Paris'
+    {server_sponsor}        server sponsor, eg 'Télécom ParisTech'
+    {server_url}            server url, eg 'http://speedtest.telecom-paristech.fr/upload.php'
+    {upload}                upload rate to speedtest server, human readable
+    {upload_raw}            upload rate to speedtest server, for format comparation
+    {upload_unit}           unit used for upload, eg 'MB/s'
 
 Color thresholds:
     format:
@@ -73,6 +73,8 @@ This can be usefull to compare two runs.
 
 Requires:
     speedtest-cli: Command line interface for testing internet bandwidth using speedtest.net
+
+@author Cyril Levis (@cyrinux)
 
 Examples:
 ```
@@ -90,13 +92,14 @@ speedtest {
         ],
         "upload": [(0, "bad"), (1024, "degraded"), (1024 * 1024, "good")],
     }
-    format = '[\?color=ping {ping} ms] [\?color=upload ↑ {upload} {upload_unit}]'
-    format += ' [\?color=download ↓ {download} {download_unit}]'
+    format = '[\?color=ping {ping} ms] [\?color=upload Up {upload} {upload_unit}]'
+    format += ' [\?color=download Down {download} {download_unit}]'
 }
 
 # colored based on comparation between two last runs
 speedtest {
-    format = ' [[\?if=download_raw<previous_download_raw&color=degraded ↓]|[\?color=ok ↑]]'
+    format = '[[\?if=download_raw<previous_download_raw&color=degraded Faster]'
+    format += '|[\?color=ok Slower]]'
 }
 
 # compare only download
@@ -105,14 +108,12 @@ speedtest {
     format += '[\?if=quality=faster&color=download_raw ↑ {download} {download_unit}]'
     format += '[\?if=quality=ok&color=download_raw -> {download} {download_unit}]'
     format += '[\?if=quality=bad&color=download_raw x {download} {download_unit}]]'
-    format += '|'
+    format += '|speedtest'
 }
 ```
 
-@author Cyril Levis (@cyrinux)
-
 SAMPLE OUTPUT
-{'full_text': u'\u25cf 208.18 ms \u2191 0.247 MB/s \u2193 0.453 MB/s'}
+{'full_text': u'Speedtest Down 0.247 MB/s Up 0.453 MB/s'}
 """
 
 from json import loads
@@ -130,7 +131,7 @@ class Py3status:
     button_refresh = 2
     button_share = None
     format = (
-        u"\u25cf [{ping} ms] [↑ {upload} {upload_unit}] [↓ {download} {download_unit}]"
+        u"Speedtest [Up {upload} {upload_unit}] [Down {download} {download_unit}]"
     )
     server_id = None
     si_units = False
@@ -159,33 +160,29 @@ class Py3status:
 
         self.placeholders = self.py3.get_placeholders_list(self.format)
 
+        self.command = ["speedtest-cli --json --secure"]
+
         # if download* or upload* missing, run complete test
-        no_upload = ""
-        no_download = ""
         if any(
             key.startswith(x)
             for x in ["download", "upload"]
             for key in self.placeholders
         ):
             if not any(key.startswith("upload") for key in self.placeholders):
-                no_upload = "--no-upload"
+                self.command += ["--no-upload"]
 
             if not any(key.startswith("download") for key in self.placeholders):
-                no_download = " --no-download"
+                self.command += ["--no-download"]
 
-        server = ""  # if not specified, nearest server is use
         if self.server_id and int(self.server_id):
-            server = "--server {}".format(self.server_id)
+            self.command += ["--server {}".format(self.server_id)]
 
-        share = ""
         if self.button_share and all(
             x in self.placeholders for x in ["download", "upload"]
         ):
-            share = "--share"
+            self.command += ["--share"]
 
-        self.command = "speedtest-cli --json --secure --timeout {} {} {} {} {}".format(
-            self.timeout, no_upload, no_download, server, share
-        )
+        self.command += ["--timeout {}".format(self.timeout)]
 
     def _is_running(self):
         try:
@@ -195,7 +192,8 @@ class Py3status:
             return False
 
     def _get_speedtest_data(self):
-        return loads(self.py3.command_output(self.command)) or None
+        command = ' '.join(self.command)
+        return loads(self.py3.command_output(command)) or None
 
     def speedtest(self):
         speedtest_data = {}
@@ -253,8 +251,7 @@ class Py3status:
             self.py3.storage_set("speedtest_data", current_data)
 
             # get speedtest result url
-            if current_data and "share" in current_data:
-                self.url = current_data["share"]
+            self.url = current_data.get("share")
 
             # create placeholders
             speedtest_data.update(current_data)
@@ -286,7 +283,7 @@ class Py3status:
         button = event["button"]
         if button == self.button_share and self.url:
             self.py3.command_run("xdg-open %s" % self.url)
-        elif button != self.button_refresh:
+        if button != self.button_refresh:
             self.py3.prevent_refresh()
 
 

--- a/py3status/modules/speedtest.py
+++ b/py3status/modules/speedtest.py
@@ -12,9 +12,9 @@ Configuration parameters:
     server_id: speedtest server to use, `speedtest-cli --list` to get id (default None)
     si_units: use SI units (default False)
     thresholds: specify color thresholds to use *(default {
-                'download': [(0, 'bad'), (1024, 'degraded'), (1024 * 1024, 'good')],
-                'ping': [(200, 'bad'), (150, 'orange'), (100, 'degraded'), (10, 'good')],
-                'upload': [(0, 'bad'), (1024, 'degraded'), (1024 * 1024, 'good')]})*
+                'download': [(0, '#6afff3'), (1024, '#6afff3'), (1024 * 1024, '#6afff3')],
+                'ping': [(200, '#6afff3'), (150, '#6afff3'), (100, '#6afff3'), (10, '#6afff3')],
+                'upload': [(0, '#6afff3'), (1024, '#6afff3'), (1024 * 1024, '#6afff3')]})*
     timeout: timeout when communicating with speedtest.net servers (default None)
     unit_bitrate: unit for download/upload rate (default 'MB/s')
     unit_size: unit for bytes_received/bytes_sent (default 'MB')
@@ -73,7 +73,7 @@ Examples:
 speedtest {
     thresholds = {
         "download": [(0, "bad"), (1024, "degraded"), (1024 * 1024, "good")],
-        "ping": [(200, "bad"), (150, "orange"), (100, "degraded"), (10, "good")],
+        "ping": [(200, "bad"), (150, "oranged"), (100, "degraded"), (10, "good")],
         "upload": [(0, "bad"), (1024, "degraded"), (1024 * 1024, "good")],
     }
     format = '[\?color=ping {ping} ms] [\?color=upload Up {upload} {upload_unit}]'
@@ -98,12 +98,12 @@ speedtest {
 SAMPLE OUTPUT
 [
     {"full_text": "Speedtest " },
-    {"full_text": "ping ", "color": "#a9a9a9"},
-    {"full_text": "9.498 ms", "color": "#ebdbb2"},
-    {"full_text": " up ", "color": "#a9a9a9"},
-    {"full_text": "78.42 MB/s", "color": "#fb4934"},
-    {"full_text": " down ", "color": "#a9a9a9"},
-    {"full_text": "39.58 MB/s", "color": "#fb4934"}
+    {"full_text": "ping ", "color": "#6afff3"},
+    {"full_text": "9.498 ms", "color": "#6afff3"},
+    {"full_text": " up ", "color": "#6afff3"},
+    {"full_text": "78.42 MB/s", "color": "#6afff3"},
+    {"full_text": " down ", "color": "#6afff3"},
+    {"full_text": "39.58 MB/s", "color": "#6afff3"}
 ]
 """
 
@@ -137,12 +137,17 @@ class Py3status:
             'update_placeholder_format': [
                 {
                     'placeholder_formats': {
+                        'bytes_sent': ':.2f',
+                        'bytes_received': ':.2f',
+                        'previous_bytes_sent': ':.2f',
+                        'previous_bytes_received': ':.2f',
                         'download': ':.1f',
                         'previous_download': ':.1f',
                         'upload': ':.1f',
                         'previous_upload': ':.1f',
                         'ping': ':.1f',
                         'elapsed_time': ':.0f',
+                        'server_d': ':.2f'
                     },
                     'format_strings': ['format'],
                 }
@@ -159,9 +164,9 @@ class Py3status:
     server_id = None
     si_units = False
     thresholds = {
-        "download": [(0, "bad"), (1024, "degraded"), (1024 * 1024, "good")],
-        "ping": [(200, "bad"), (150, "orange"), (100, "degraded"), (10, "good")],
-        "upload": [(0, "bad"), (1024, "degraded"), (1024 * 1024, "good")],
+        "download": [(0, "#6afff3"), (1024, "#6afff3"), (1024 * 1024, "#6afff3")],
+        "ping": [(200, "#6afff3"), (150, "#6afff3"), (100, "#6afff3"), (10, "#6afff3")],
+        "upload": [(0, "#6afff3"), (1024, "#6afff3"), (1024 * 1024, "#6afff3")],
     }
     timeout = None
     unit_bitrate = "MB/s"

--- a/py3status/modules/speedtest.py
+++ b/py3status/modules/speedtest.py
@@ -116,6 +116,7 @@ SAMPLE OUTPUT
 """
 
 from json import loads
+from numbers import Number
 
 STRING_NOT_INSTALLED = "not installed"
 MISSING_PLACEHOLDER = "{download} or {upload} placeholder required"
@@ -211,7 +212,7 @@ class Py3status:
                 previous_data = self.py3.storage_get("speedtest_data")
                 current_data = self._get_speedtest_data()
                 cached_until = self.py3.CACHE_FOREVER
-                
+
                 if current_data and len(current_data) > 1:
                     # create a "total" for know if cnx is better or not
                     # between two run
@@ -265,16 +266,17 @@ class Py3status:
             speedtest_data.update(current_data)
             if previous_data:
                 speedtest_data.update(
-                    {"previous_" + k:v for (k,v) in previous_data.items()}
+                    {"previous_" + k: v for (k, v) in previous_data.items()}
                 )
 
             # # cast
-            for x in speedtest_data:
-                try:
-                    value = float(speedtest_data[x])
-                except:
-                    value = speedtest_data[x]
-                speedtest_data[x] = value
+            speedtest_data.update(
+                {
+                    k: float(v)
+                    for (k, v) in speedtest_data.items()
+                    if isinstance(v, Number)
+                }
+            )
 
             # thresholds
             for x in self.thresholds:

--- a/py3status/modules/speedtest.py
+++ b/py3status/modules/speedtest.py
@@ -25,11 +25,11 @@ Configuration parameters:
     unit_size: unit for bytes_received/bytes_sent (default 'MB')
 
 Format placeholders:
-    {bytes_sent}            bytes sent during test, human readable, eg 'TODO'
+    {bytes_sent}            bytes sent during test, human readable, eg '52.45'
     {bytes_sent_unit}       unit used for bytes_sent, eg 'MB'
-    {bytes_sent_raw}        bytes sent during test, for format comparation, eg 'TODO'
-    {bytes_received}        bytes received during test, human readable, eg 'TODO'
-    {bytes_received_raw}    bytes received during test, for format comparation, eg 'TODO'
+    {bytes_sent_raw}        bytes sent during test, for format comparation, eg '52445184.0'
+    {bytes_received}        bytes received during test, human readable, eg '70.23'
+    {bytes_received_raw}    bytes received during test, for format comparation, eg '70229556.0'
     {bytes_received_unit}   unit used for bytes_received, eg 'MB'
     {client_country}        client country code, eg 'FR'
     {client_ip}             client ip, eg '78.194.13.7'
@@ -47,7 +47,7 @@ Format placeholders:
     {ping}                  ping time in ms to speedtest server
     {quality}               quality code of the connection, eg 0, 1, 2, 3, 4
     {quality_name}          quality name of the connection, eg failed, bad, good, slower, faster
-    {timestamp}             timestamp of the run, eg 'TODO'
+    {timestamp}             timestamp of the run, eg '2018-08-30T16:27:25.318212Z'
     {server_cc}             server country code, eg 'FR'
     {server_country}        server country, eg 'France'
     {server_d}              server distance, eg '2.316599376968091'
@@ -176,16 +176,20 @@ class Py3status:
         self.url = None
 
         self.quality = {
-            -1: 'failed',
-            0: 'unknow',
-            1: 'bad',
-            2: 'good',
-            3: 'slower',
-            4: 'faster'
+            -1: "failed",
+            0: "unknow",
+            1: "bad",
+            2: "good",
+            3: "slower",
+            4: "faster",
         }
 
         # if download* or upload* missing, run complete test
-        if any(key.startswith(x) for x in ["download", "upload"] for key in self.placeholders):
+        if any(
+            key.startswith(x)
+            for x in ["download", "upload"]
+            for key in self.placeholders
+        ):
             if not any(key.startswith("upload") for key in self.placeholders):
                 self.command += " --no-upload"
 
@@ -243,7 +247,7 @@ class Py3status:
 
         # zero-ing if not fetched, raw version and units convertion
         for x in ["download", "upload", "bytes_received", "bytes_sent"]:
-            unit = self.unit_size if 'bytes' in x else self.unit_bitrate
+            unit = self.unit_size if "bytes" in x else self.unit_bitrate
             current_data[x] = current_data.get(x, 0)
             current_data[x + "_raw"] = current_data[x]
             current_data[x], current_data[x + "_unit"] = self.py3.format_units(

--- a/py3status/modules/speedtest.py
+++ b/py3status/modules/speedtest.py
@@ -215,7 +215,7 @@ class Py3status:
 
         class SpeedTestCliThread(Thread):
             def run(this):
-                if self.running.wait():
+                while self.running.wait():
                     # start timer
                     self.start_time = time()
 
@@ -233,9 +233,6 @@ class Py3status:
 
                     # extra data, not sure we want to expose
                     current_data = self.py3.flatten_dict(current_data, delimiter='_')
-
-                    # store last data fetched
-                    self.py3.storage_set("speedtest_data", current_data)
 
                     # get speedtest result url
                     self.url = current_data.get("share")
@@ -258,14 +255,16 @@ class Py3status:
                         }
                     )
 
+                    # store last data fetched
+                    self.py3.storage_set("speedtest_data", current_data)
+
                     # thresholds
                     for x in self.thresholds_init:
                         if x in self.speedtest_data:
                             self.py3.threshold_get_color(self.speedtest_data[x], x)
 
                     self.py3.update()
-
-                    self._start_thread()
+                    self.running.clear()
 
         SpeedTestCliThread().start()
 

--- a/py3status/modules/speedtest.py
+++ b/py3status/modules/speedtest.py
@@ -201,8 +201,7 @@ class Py3status:
             return False
 
     def _get_speedtest_data(self):
-        command = ' '.join(self.command)
-        return loads(self.py3.command_output(command)) or None
+        return loads(self.py3.command_output(self.command)) or None
 
     def speedtest(self):
         speedtest_data = {}

--- a/py3status/modules/speedtest.py
+++ b/py3status/modules/speedtest.py
@@ -191,7 +191,7 @@ class Py3status:
         try:
             self.py3.command_output(["pgrep", "speedtest-cli"])
             return True
-        except:
+        except self.py3.CommandError:
             return False
 
     def _get_speedtest_data(self):

--- a/py3status/modules/speedtest.py
+++ b/py3status/modules/speedtest.py
@@ -109,7 +109,7 @@ SAMPLE OUTPUT
 
 from json import loads
 import threading
-import time
+from time import time
 
 
 STRING_NOT_INSTALLED = "not installed"
@@ -210,16 +210,6 @@ class Py3status:
         except self.py3.CommandError:
             return False
 
-    def _cast_number(self, value):
-        try:
-            value = float(value)
-        except ValueError:
-            try:
-                value = int(value)
-            except ValueError:
-                pass
-        return value
-
     def _get_speedtest_data(self):
         try:
             return loads(self.py3.command_output(self.command))
@@ -232,7 +222,7 @@ class Py3status:
             return
 
         # start timer
-        self.start_time = time.time()
+        self.start_time = time()
 
         # get values
         previous_data = self.py3.storage_get("speedtest_data") or {}
@@ -265,14 +255,6 @@ class Py3status:
         self.start_time = None
         self.cached_until = self.py3.CACHE_FOREVER
 
-        # cast number
-        self.speedtest_data.update(
-            {
-                k: self._cast_number(self.speedtest_data[k])
-                for k in self.placeholders
-            }
-        )
-
         # thresholds
         for x in self.thresholds_init:
             if x in self.speedtest_data:
@@ -282,7 +264,7 @@ class Py3status:
         # calculate elapsed time since start
         elapsed_time = None
         if self.start_time:
-            elapsed_time = self._cast_number(time.time() - self.start_time)
+            elapsed_time = time() - self.start_time
             self.py3.log(type(elapsed_time))
         self.speedtest_data['elapsed_time'] = elapsed_time
 

--- a/py3status/modules/speedtest.py
+++ b/py3status/modules/speedtest.py
@@ -64,8 +64,7 @@ Format placeholders:
     {upload_unit}           unit used for upload, eg 'MB/s'
 
 Color thresholds:
-    format:
-        xxx: print a color based on the value of `xxx` placeholder
+    xxx: print a color based on the value of `xxx` placeholder
 
 The module will be triggered on clic only. Not at start.
 

--- a/py3status/modules/speedtest.py
+++ b/py3status/modules/speedtest.py
@@ -234,18 +234,12 @@ class Py3status:
                     current_data["quality"] = quality
 
             # zero-ing if not fetched, raw version and units convertion
-            for x in ["download", "upload"]:
+            for x in ["download", "upload", "bytes_received", "bytes_sent"]:
+                unit = self.unit_size if 'bytes' in x else self.unit_bitrate
                 current_data[x] = current_data.get(x, 0)
                 current_data[x + "_raw"] = current_data[x]
                 current_data[x], current_data[x + "_unit"] = self.py3.format_units(
-                    current_data[x], unit=self.unit_bitrate, si=self.si_units
-                )
-
-            for x in ["bytes_received", "bytes_sent"]:
-                current_data[x] = current_data.get(x, 0)
-                current_data[x + "_raw"] = current_data[x]
-                current_data[x], current_data[x + "_unit"] = self.py3.format_units(
-                    current_data[x], unit=self.unit_size, si=self.si_units
+                    current_data[x], unit=unit, si=self.si_units
                 )
 
             # extra data, not sure we want to expose

--- a/py3status/modules/speedtest.py
+++ b/py3status/modules/speedtest.py
@@ -108,7 +108,7 @@ SAMPLE OUTPUT
 """
 
 from json import loads
-from threading import Thread, Event
+from threading import Thread
 from time import time, sleep
 
 
@@ -188,8 +188,6 @@ class Py3status:
         if self.button_share and all(x in self.placeholders for x in tests):
             self.command += " --share"
 
-        self._start_thread()
-
     def _cast_number(self, value):
         try:
             value = float(value)
@@ -206,30 +204,20 @@ class Py3status:
         except self.py3.CommandError:
             return None
 
-    def _start_thread(self):
-        self.running = Event()
-        self.killed = Event()
-        self.running.clear()
-
+    def _start(self):
         class SpeedTestCliThread(Thread):
             def run(this):
-                while not self.killed.is_set():
-                    while not self.running.wait():
-                        return
+                # start timer
+                self.start_time = time()
 
-                    # start timer
-                    self.start_time = time()
+                # run speedtest
+                current_data = self._get_speedtest_data()
 
-                    # get values
+                # on no internet connection
+                if not current_data:
+                    self.start_time = None
+                else:
                     previous_data = self.py3.storage_get("speedtest_data") or {}
-                    current_data = self._get_speedtest_data()
-
-                    # on no internet connection restart the dead thread
-                    if not current_data:
-                        self.start_time = None
-                        self.cached_until = self.py3.CACHE_FOREVER
-                        self.kill()
-                        self._start_thread()
 
                     # zero-ing if not fetched and units convertion
                     for x in ["download", "upload", "bytes_received", "bytes_sent"]:
@@ -250,29 +238,27 @@ class Py3status:
                     self.speedtest_data.update(
                         {"previous_" + k: v for (k, v) in previous_data.items()}
                     )
-
                     # stop timer / stop refreshing
                     self.start_time = None
                     self.cached_until = self.py3.CACHE_FOREVER
 
-                    # cast number
-                    self.speedtest_data.update(
-                        {
-                            k: self._cast_number(self.speedtest_data[k])
-                            for k in self.placeholders
-                        }
-                    )
-
                     # store last data fetched
                     self.py3.storage_set("speedtest_data", current_data)
 
-                    # thresholds
-                    for x in self.thresholds_init:
-                        if x in self.speedtest_data:
-                            self.py3.threshold_get_color(self.speedtest_data[x], x)
+                # cast number
+                self.speedtest_data.update(
+                    {
+                        k: self._cast_number(self.speedtest_data[k])
+                        for k in self.placeholders
+                    }
+                )
 
-                    self.py3.update()
-                    self.running.clear()
+                # thresholds
+                for x in self.thresholds_init:
+                    if x in self.speedtest_data:
+                        self.py3.threshold_get_color(self.speedtest_data[x], x)
+
+                self.py3.update()
 
         SpeedTestCliThread().start()
 
@@ -294,19 +280,14 @@ class Py3status:
     def on_click(self, event):
         button = event["button"]
         if button == self.button_share and self.url:
-            self.py3.command_run("xdg-open %s" % self.url)
+            Thread(target=self.py3.command_run("xdg-open %s" % self.url))
         if button == self.button_refresh:
             # start speedtest-cli thread
             # dont cache while thread working
-            self.running.set()
+            self._start()
             self.cached_until = self.py3.time_in(0)
-            self.py3.update()
         else:
             self.py3.prevent_refresh()
-
-    def kill(self):
-        self.killed.set()
-        self.running.set()
 
 
 if __name__ == "__main__":

--- a/py3status/modules/speedtest.py
+++ b/py3status/modules/speedtest.py
@@ -1,116 +1,133 @@
 # -*- coding: utf-8 -*-
 """
-Do a bandwidth test with speedtest-cli.
+Perform a bandwidth test with speedtest-cli.
 
 Configuration parameters:
-    button_share: button to open the result link (default None)
-    format: display format for this module, {download} and/or {upload} required
-        *(default 'Speedtest[\?color=darkgray  time [\?color=degraded {elapsed_time} s]]'
-                    '[\?color=darkgray  ping [\?color=ping {ping} ms ]'
-                    'up [\?color=upload {upload} {upload_unit}] '
-                    'down [\?color=download {download} {download_unit}]]')*
-    server_id: speedtest server to use, `speedtest-cli --list` to get id (default None)
-    si_units: use SI units (default False)
-    thresholds: specify color thresholds to use *(default {
-                'download': [(0, '#6afff3'), (1024, '#6afff3'), (1024 * 1024, '#6afff3')],
-                'ping': [(200, '#6afff3'), (150, '#6afff3'), (100, '#6afff3'), (10, '#6afff3')],
-                'upload': [(0, '#6afff3'), (1024, '#6afff3'), (1024 * 1024, '#6afff3')]})*
-    timeout: timeout when communicating with speedtest.net servers (default None)
-    unit_bitrate: unit for download/upload rate (default 'MB/s')
-    unit_size: unit for bytes_received/bytes_sent (default 'MB')
+    button_share: mouse button to share an URL (default None)
+    format: display format for this module
+        *(default "Speedtest[\?if=elapsed&color=elapsed_time  "
+        "{elapsed_time} s][ [\?color=download {download} Mbps] "
+        "[\?color=upload {upload} Mbps]]")*
+    thresholds: specify color thresholds to use
+        *(default {"upload": [(0, "violet")], "ping": [(0, "#fff381")],
+        "download": [(0, "cyan")], "elapsed_time": [(0, "#1cbfff")]})*
+
+Control placeholders:
+    {elapsed}          elapsed time state, eg False, True
 
 Format placeholders:
-    {bytes_sent}            bytes sent during test, human readable, eg '52.45'
-    {bytes_sent_unit}       unit used for bytes_sent, eg 'MB'
-    {bytes_received}        bytes received during test, human readable, eg '70.23'
-    {bytes_received_unit}   unit used for bytes_received, eg 'MB'
-    {client_country}        client country code, eg 'FR'
-    {client_ip}             client ip, eg '78.194.13.7'
-    {client_isp}            client isp, eg 'Free SAS'
-    {client_ispdlavg}       client isp download average, eg '0'
-    {client_isprating}      client isp rating, eg 3.7
-    {client_ispulavg}       client isp upload average, eg '0'
-    {client_lat}            client latitude, eg '48.8534'
-    {client_loggedin}       client logged in, eg '0'
-    {client_lon}            client longitude, eg '2.3487999999999998'
-    {client_rating}         client rating, eg '0'
-    {download}              download rate from speedtest server, human readable
-    {download_unit}         unit used as , eg 'MB/s'
-    {elapsed_time}          elapsed time since speedtest start
-    {ping}                  ping time in ms to speedtest server
-    {timestamp}             timestamp of the run, eg '2018-08-30T16:27:25.318212Z'
-    {server_cc}             server country code, eg 'FR'
-    {server_country}        server country, eg 'France'
-    {server_d}              server distance, eg '2.316599376968091'
-    {server_host}           server host, eg 'speedtest.telecom-paristech.fr:8080'
-    {server_id}             server id, eg '11977'
-    {server_lat}            server latitude, eg '48.8742'
-    {server_latency}        server latency, eg 8.265
-    {server_lon}            server longitude, eg 2.3470
-    {server_name}           server name, eg 'Paris'
-    {server_sponsor}        server sponsor, eg 'Télécom ParisTech'
-    {server_url}            server url, eg 'http://speedtest.telecom-paristech.fr/upload.php'
-    {upload}                upload rate to speedtest server, human readable
-    {upload_unit}           unit used for upload, eg 'MB/s'
-
+    {bytes_sent}       bytes sent during test (in MB), eg 52.45
+    {bytes_received}   bytes received during test (in MB), eg 70.23
+    {client_country}   client country code, eg FR
+    {client_ip}        client ip, eg 78.194.13.7
+    {client_isp}       client isp, eg Free SAS
+    {client_ispdlavg}  client isp download average, eg 0
+    {client_isprating} client isp rating, eg 3.7
+    {client_ispulavg}  client isp upload average, eg 0
+    {client_lat}       client latitude, eg 48.8534
+    {client_loggedin}  client logged in, eg 0
+    {client_lon}       client longitude, eg 2.3487999999999998
+    {client_rating}    client rating, eg 0
+    {download}         download speed (in MB), eg 20.23
+    {elapsed_time}     elapsed time since speedtest start
+    {ping}             ping time in ms to speedtest server
+    {server_cc}        server country code, eg FR
+    {server_country}   server country, eg France
+    {server_d}         server distance, eg 2.316599376968091
+    {server_host}      server host, eg speedtest.telecom-paristech.fr:8080
+    {server_id}        server id, eg 11977
+    {share}            share, eg share url
+    {timestamp}        timestamp, eg 2018-08-30T16:27:25.318212Z
+    {server_lat}       server latitude, eg 48.8742
+    {server_latency}   server latency, eg 8.265
+    {server_lon}       server longitude, eg 2.3470
+    {server_name}      server name, eg Paris
+    {server_sponsor}   server sponsor, eg Télécom ParisTech
+    {server_url}       server url, eg http://speedtest.telecom-paristech...
+    {upload}           upload speed (in MB), eg 20.23
 
 Color thresholds:
     xxx: print a color based on the value of `xxx` placeholder
 
-The module will be triggered on click only. Not at start.
-
-Note that all placeholders have a version prefixed by `previous_`, eg `previous_download`.
-This can be usefull to compare two runs.
-
 Requires:
-    speedtest-cli: Command line interface for testing internet bandwidth using speedtest.net
+    speedtest-cli: Command line interface for testing Internet bandwidth
 
 @author Cyril Levis (@cyrinux)
 
 Examples:
 ```
-# colored based on thresholds
+# show detailed elapsed_time|download/upload
 speedtest {
-    thresholds = {
-        "download": [(0, "bad"), (1024, "degraded"), (1024 * 1024, "good")],
-        "ping": [(200, "bad"), (150, "oranged"), (100, "degraded"), (10, "good")],
-        "upload": [(0, "bad"), (1024, "degraded"), (1024 * 1024, "good")],
-    }
-    format = '[\?color=ping {ping} ms] [\?color=upload Up {upload} {upload_unit}]'
-    format += ' [\?color=download Down {download} {download_unit}]'
+    format = "Speedtest[\?soft  ][\?if=elapsed [\?color=darkgray [time "
+    format += "[\?color=elapsed_time {elapsed_time} s]]]|[\?color=darkgray "
+    # format += "ping [\?color=ping {ping} ms] "
+    format += "download [\?color=download {download} Mbps] "
+    format += "upload [\?color=upload {upload} Mbps]]]"
 }
 
-# colored based on comparation between two last runs
+# show everything
 speedtest {
-    format = '[[\?if=download<previous_download&color=degraded Faster]'
-    format += '|[\?color=good Slower]]'
+    format = "Speedtest[\?soft  ][\?color=darkgray "
+    format += "[time [\?color=elapsed_time {elapsed_time} s]][\?soft  ]"
+    format += "[ping [\?color=ping {ping} ms] "
+    format += "download [\?color=download {download} Mbps] "
+    format += "upload [\?color=upload {upload} Mbps]]]"
 }
 
-# compare only download
+# minimal
 speedtest {
-    format = '[[\?if=download<previous_download ↓ {download} {download_unit}]'
-    format += '[\?if=download<previous_download ↑ {download} {download_unit}]'
-    format += '[\?if=download=previous_download -> {download} {download_unit}]'
-    format += '|speedtest'
+    format = "Speedtest[\?soft  ][\?if=elapsed "
+    format += "[\?color=elapsed_time {elapsed_time}]|"
+    # format += "[\?color=ping {ping}] "
+    format += "[[\?color=download {download}] [\?color=upload {upload}]]]"
+}
+
+# don't hide data on reset
+speedtest {
+    format = "Speedtest[\?soft  ][\?color=darkgray time "
+    format += "[\?color=elapsed_time {elapsed_time} s] "
+    # format += "ping [\?color=ping {ping} ms] "
+    format += "download [\?color=download {download} Mbps] "
+    format += "upload [\?color=upload {upload} Mbps]]"
+}
+
+# don't hide data on reset, minimal
+speedtest {
+    format = "Speedtest[\?soft  ][[\?color=elapsed_time {elapsed_time}] "
+    # format += "[\?color=ping {ping}] "
+    format += "[\?color=download {download}] [\?color=upload {upload}]]"
 }
 ```
-
 SAMPLE OUTPUT
+bandwidth
 [
-    {"full_text": "Speedtest " },
-    {"full_text": "ping ", "color": "#6afff3"},
-    {"full_text": "9.498 ms", "color": "#6afff3"},
-    {"full_text": " up ", "color": "#6afff3"},
-    {"full_text": "78.42 MB/s", "color": "#6afff3"},
-    {"full_text": " down ", "color": "#6afff3"},
-    {"full_text": "39.58 MB/s", "color": "#6afff3"}
+    {"full_text": "Speedtest "},
+    {"full_text": "19.76 Mbps ", "color": "#00ffff"},
+    {"full_text": "3.86 Mbps", "color": "#ee82ee"},
+]
+
+time+ping
+[
+    {"full_text": "Speedtest "},
+    {"full_text": "time ", "color": "#a9a9a9"},
+    {"full_text": "24.65 s ", "color": "#1cbfff"},
+    {"full_text": "ping ", "color": "#a9a9a9"},
+    {"full_text": "28.27 ms", "color": "#ffff00"},
+]
+
+details
+[
+    {"full_text": "Speedtest "},
+    {"full_text": "download ", "color": "#a9a9a9"},
+    {"full_text": "18.2 Mbps ", "color": "#00ffff"},
+    {"full_text": "upload ", "color": "#a9a9a9"},
+    {"full_text": "19.2 Mbps", "color": "#ee82ee"},
 ]
 """
 
 from json import loads
-from threading import Thread, Event
-from time import time, sleep
-
+from threading import Thread
+from time import time
 
 STRING_NOT_INSTALLED = "not installed"
 
@@ -119,189 +136,122 @@ class Py3status:
     """
     """
 
-    class Meta:
-        update_config = {
-            'update_placeholder_format': [
-                {
-                    'placeholder_formats': {
-                        'bytes_sent': ':.2f',
-                        'bytes_received': ':.2f',
-                        'previous_bytes_sent': ':.2f',
-                        'previous_bytes_received': ':.2f',
-                        'download': ':.1f',
-                        'previous_download': ':.1f',
-                        'upload': ':.1f',
-                        'previous_upload': ':.1f',
-                        'ping': ':.1f',
-                        'elapsed_time': ':.0f',
-                        'server_d': ':.2f'
-                    },
-                    'format_strings': ['format'],
-                }
-            ],
-        }
     # available configuration parameters
     button_share = None
     format = (
-        u"Speedtest[\?color=darkgray  time [\?color=degraded {elapsed_time} s]]"
-        "[\?color=darkgray  ping [\?color=ping {ping} ms ]"
-        "up [\?color=upload {upload} {upload_unit}] "
-        "down [\?color=download {download} {download_unit}]]"
+        "Speedtest[\?if=elapsed&color=elapsed_time  "
+        "{elapsed_time} s][ [\?color=download {download} Mbps] "
+        "[\?color=upload {upload} Mbps]]"
     )
-    server_id = None
-    si_units = False
     thresholds = {
-        "download": [(0, "#6afff3"), (1024, "#6afff3"), (1024 * 1024, "#6afff3")],
-        "ping": [(200, "#6afff3"), (150, "#6afff3"), (100, "#6afff3"), (10, "#6afff3")],
-        "upload": [(0, "#6afff3"), (1024, "#6afff3"), (1024 * 1024, "#6afff3")],
+        "upload": [(0, "violet")],
+        "ping": [(0, "#fff381")],
+        "download": [(0, "cyan")],
+        "elapsed_time": [(0, "#1cbfff")],
     }
-    timeout = None
-    unit_bitrate = "MB/s"
-    unit_size = "MB"
+
+    class Meta:
+        update_config = {
+            "update_placeholder_format": [
+                {
+                    "placeholder_formats": {
+                        "bytes_sent": ":.2f",
+                        "bytes_received": ":.2f",
+                        "download": ":.2f",
+                        "upload": ":.2f",
+                        "ping": ":.2f",
+                        "elapsed_time": ":.2f",
+                        "server_d": ":.2f",
+                    },
+                    "format_strings": ["format"],
+                }
+            ]
+        }
 
     def post_config_hook(self):
-        if not self.py3.check_commands("speedtest-cli"):
+        self.speedtest_command = "speedtest-cli --json --secure"
+        if not self.py3.check_commands(self.speedtest_command.split()[0]):
             raise Exception(STRING_NOT_INSTALLED)
 
+        # init
         self.button_refresh = 2
-        self.cached_until = self.py3.CACHE_FOREVER
-        self.command = "speedtest-cli --json --secure"
         self.placeholders = self.py3.get_placeholders_list(self.format)
-        self.speedtest_data = {}
-        self.start_time = None
+        self.speedtest_data = self.py3.storage_get("speedtest_data") or {}
+        self.thread = None
         self.thresholds_init = self.py3.get_color_names_list(self.format)
-        self.url = None
 
+        # remove elapsed_time
+        if "elapsed_time" in self.placeholders:
+            self.placeholders.remove("elapsed_time")
+
+        # share
+        if self.button_share:
+            self.speedtest_command += " --share"
+
+        # perform download/upload based on placeholders
         tests = ["download", "upload"]
-        # if download* or upload* missing, run complete test
         if any(x in tests for x in self.placeholders):
             for x in tests:
                 if x not in self.placeholders:
-                    self.command += " --no-{}".format(x)
+                    self.speedtest_command += " --no-{}".format(x)
 
-        if self.server_id:
-            self.command += " --server {}".format(self.server_id)
+    def _set_speedtest_data(self):
+        # start
+        self.start_time = time()
+        self.speedtest_data["elapsed"] = True
 
-        if self.timeout:
-            self.command += " --timeout {}".format(self.timeout)
-
-        if self.button_share and all(x in self.placeholders for x in tests):
-            self.command += " --share"
-
-    def _cast_number(self, value):
         try:
-            value = float(value)
-        except ValueError:
-            try:
-                value = int(value)
-            except ValueError:
-                pass
-        return value
-
-    def _get_speedtest_data(self):
-        try:
-            return loads(self.py3.command_output(self.command))
+            self.speedtest_data = self.py3.flatten_dict(
+                loads(self.py3.command_output(self.speedtest_command)),
+                delimiter="_"
+            )
+            for x in ["download", "upload", "bytes_received", "bytes_sent"]:
+                if x not in self.placeholders or x not in self.speedtest_data:
+                    continue
+                si = False if "bytes" in x else True
+                self.speedtest_data[x], unit = self.py3.format_units(
+                    self.speedtest_data[x], unit="MB", si=si
+                )
         except self.py3.CommandError:
-            return None
+            pass
 
-    def _start_thread(self):
-        self.running = Event()
-        self.killed = Event()
-        self.running.set()
-
-        class SpeedTestCliThread(Thread):
-            def run(this):
-                while not self.killed.is_set():
-                    while not self.running.wait():
-                        return
-
-                    # start timer
-                    self.start_time = time()
-
-                    # get values
-                    current_data = self._get_speedtest_data()
-
-                    # on no internet connection
-                    if not current_data:
-                        self.start_time = None
-                        self.cached_until = self.py3.CACHE_FOREVER
-                    else:
-                        previous_data = self.py3.storage_get("speedtest_data") or {}
-
-                        # zero-ing if not fetched and units convertion
-                        for x in ["download", "upload", "bytes_received", "bytes_sent"]:
-                            unit = self.unit_size if "bytes" in x else self.unit_bitrate
-                            current_data[x] = current_data.get(x, 0)
-                            current_data[x], current_data[x + "_unit"] = self.py3.format_units(
-                                current_data[x], unit=unit, si=self.si_units
-                            )
-
-                        # extra data, not sure we want to expose
-                        current_data = self.py3.flatten_dict(current_data, delimiter='_')
-
-                        # get speedtest result url
-                        self.url = current_data.get("share")
-
-                        # create placeholders
-                        self.speedtest_data.update(current_data)
-                        self.speedtest_data.update(
-                            {"previous_" + k: v for (k, v) in previous_data.items()}
-                        )
-
-                        # stop timer / stop refreshing
-                        self.start_time = None
-                        self.cached_until = self.py3.CACHE_FOREVER
-
-                        # store last data fetched
-                        self.py3.storage_set("speedtest_data", current_data)
-
-                    # cast number
-                    self.speedtest_data.update(
-                        {
-                            k: self._cast_number(self.speedtest_data[k])
-                            for k in self.placeholders
-                        }
-                    )
-
-                    # thresholds
-                    for x in self.thresholds_init:
-                        if x in self.speedtest_data:
-                            self.py3.threshold_get_color(self.speedtest_data[x], x)
-
-                    self.running.clear()
-                    self.py3.update()
-
-        SpeedTestCliThread().start()
+        # end
+        self.speedtest_data["elapsed"] = False
+        self.speedtest_data["elapsed_time"] = time() - self.start_time
 
     def speedtest(self):
-        # calculate elapsed time since start
-        elapsed_time = None
-        if self.start_time:
-            elapsed_time = time() - self.start_time
-        self.speedtest_data['elapsed_time'] = elapsed_time
+        if self.speedtest_data.get("elapsed"):
+            cached_until = 0
+            self.speedtest_data["elapsed_time"] = time() - self.start_time
+        else:
+            cached_until = self.py3.CACHE_FOREVER
+            self.py3.storage_set("speedtest_data", self.speedtest_data)
 
-        # prevent crazy refresh
-        sleep(1)
+        # thresholds
+        for x in self.thresholds_init:
+            if x in self.speedtest_data:
+                self.py3.threshold_get_color(self.speedtest_data[x], x)
 
         return {
-            "cached_until": self.cached_until,
-            "full_text": self.py3.safe_format(self.format, self.speedtest_data),
+            "cached_until": self.py3.time_in(cached_until),
+            "full_text": self.py3.safe_format(
+                self.format, self.speedtest_data
+            )
         }
 
     def on_click(self, event):
         button = event["button"]
-        if button == self.button_share and self.url:
-            Thread(target=self.py3.command_run("xdg-open %s" % self.url))
+        if button == self.button_share:
+            share = self.speedtest_data.get("share")
+            if share:
+                self.py3.command_run("xdg-open {}".format(share))
         if button == self.button_refresh:
-            self._start_thread()
-            self.cached_until = self.py3.time_in(0)
-            self.py3.update()
-        else:
-            self.py3.prevent_refresh()
-
-    def kill(self):
-        self.killed.set()
-        self.running.set()
+            if self.thread and not self.thread.isAlive():
+                self.thread = None
+            if self.thread is None:
+                self.thread = Thread(target=self._set_speedtest_data)
+                self.thread.daemon = True
+                self.thread.start()
 
 
 if __name__ == "__main__":

--- a/py3status/modules/speedtest_cli.py
+++ b/py3status/modules/speedtest_cli.py
@@ -11,16 +11,15 @@ Configuration parameters:
     si_units: use SI units (default False)
     sleep_timeout: when speedtest-cli is allready running, this interval will be used
         to allow faster retry refreshes (default 5)
-    thresholds: specify color thresholds to use (default [
-                'download': [(0, 'bad'), (1024, 'degraded'), (1048576, 'good')],
+    thresholds: specify color thresholds to use *(default {
+                'download': [(0, 'bad'), (1024, 'degraded'), (1024 * 1024, 'good')],
                 'ping': [(200, 'bad'), (150, 'orange'), (100, 'degraded'), (10, 'good')],
                 'quality':
                     [
                         ('ok', 'good'), ('bad', 'degraded'),
                         ('faster', 'good'), ('slower', 'degraded'), ('faster', 'good')
                     ],
-                'upload': [(0, 'bad'), (1024, 'degraded'), (1048576, 'good')]
-        ])
+                'upload': [(0, 'bad'), (1024, 'degraded'), (1024 * 1024, 'good')]})*
     timeout: timeout when communicating with speedtest.net servers (default 10)
     unit_bitrate: unit for download/upload rate (default 'MB/s')
     unit_size: unit for bytes_received/bytes_sent (default 'MB')
@@ -80,22 +79,16 @@ Examples:
 # colored based on thresholds
 speedtest_cli {
     thresholds = {
-        'download': [
-            (0, 'bad'), (1024, 'degraded'), (1024 * 1024, 'good')
-        ],
-        'ping': [
-            (200, 'bad'), (150, 'orange'), (100, 'degraded'), (10, 'good')
-        ],
-        'quality': [
+        "download": [(0, "bad"), (1024, "degraded"), (1024 * 1024, "good")],
+        "ping": [(200, "bad"), (150, "orange"), (100, "degraded"), (10, "good")],
+        "quality": [
             ("ok", "good"),
             ("bad", "degraded"),
             ("faster", "good"),
             ("slower", "degraded"),
             ("faster", "good"),
         ],
-        'upload': [
-            (0, 'bad'), (1024, 'degraded'), (1024 * 1024, 'good')
-        ],
+        "upload": [(0, "bad"), (1024, "degraded"), (1024 * 1024, "good")],
     }
     format = '[\?color=ping {ping} ms] [\?color=upload ↑ {upload} {upload_unit}]'
     format += ' [\?color=download ↓ {download} {download_unit}]'

--- a/py3status/modules/speedtest_cli.py
+++ b/py3status/modules/speedtest_cli.py
@@ -4,16 +4,26 @@ Do a bandwidth test with speedtest-cli.
 
 Configuration parameters:
     cache_timeout: refresh interval for this module (default -1)
-    format: display format for this module (default '■ [{ping} ms] [↑ {upload}] [↓ {download}]')
-            {download} and/or {upload} required
+    format: display format for this module, {download} and/or {upload} required
+        (default '■ [{ping} ms] [↑ {upload}] [↓ {download}]')
     server_id: speedtest server to use, `speedtest-cli --list` to get id (default None)
     si_units: use SI units (default False)
     sleep_timeout: when speedtest-cli is allready running, this interval will be used
         to allow faster retry refreshes
-        (default 20)
-    timeout: timeout when communicating with speedtest.net servers (default 10)
+        (default 5)
     thresholds: specify color thresholds to use
-        (default [(0, 'bad'), (11, 'good')])
+        (default [
+                "ping": 
+                    [(200, "bad"), (150, "orange"), (100, "degraded"), (10, "good")],
+                "download": 
+                    [(0, "bad"), (1024, "degraded"), (1024 * 1024, "good")],
+                "upload": 
+                    [(0, "bad"), (1024, "degraded"), (1024 * 1024, "good")],
+                "quality": 
+                    [("ok", "good"), ("bad", "degraded"), ("faster", "good"),
+                            ("slower", "degraded"), ("faster", "good")]
+                ]
+    timeout: timeout when communicating with speedtest.net servers (default 10)
     unit_bitrate: unit for download/upload rate (default 'MB/s')
     unit_size: unit for bytes_received/bytes_sent (default 'MB')
 
@@ -129,7 +139,7 @@ class Py3status:
         "quality": [("ok", "good"), ("bad", "degraded"), ("faster", "good"),
                     ("slower", "degraded"), ("faster", "good")],
     }
-    timeout = 30
+    timeout = 10
     unit_bitrate = "MB/s"
     unit_size = "MB"
 
@@ -252,7 +262,6 @@ class Py3status:
         self.can_refresh = True
         if self._is_running:
             self.py3.prevent_refresh()
-        pass
 
 
 if __name__ == "__main__":

--- a/py3status/modules/speedtest_cli.py
+++ b/py3status/modules/speedtest_cli.py
@@ -101,10 +101,10 @@ speedtest_cli {
 
 # compare only download
 speedtest_cli {
-    format = '[[\?if=quality=slower&color=download ↓ {download} {download_unit}]'
-    format += '[\?if=quality=faster&color=download ↑ {download} {download_unit}]'
-    format += '[\?if=quality=ok&color=download -> {download} {download_unit}]'
-    format += '[\?if=quality=bad&color=download x {download} {download_unit}]]'
+    format = '[[\?if=quality=slower&color=download_raw ↓ {download} {download_unit}]'
+    format += '[\?if=quality=faster&color=download_raw ↑ {download} {download_unit}]'
+    format += '[\?if=quality=ok&color=download_raw -> {download} {download_unit}]'
+    format += '[\?if=quality=bad&color=download_raw x {download} {download_unit}]]'
     format += '|'
 }
 ```
@@ -265,6 +265,14 @@ class Py3status:
                 speedtest_data[x] = current_data[x]
             for x in previous_data:
                 speedtest_data["previous_" + x] = previous_data[x]
+
+            # # cast
+            for x in speedtest_data:
+                try:
+                    value = float(speedtest_data[x])
+                except:
+                    value = speedtest_data[x]
+                speedtest_data[x] = value
 
             # thresholds
             for x in self.thresholds:

--- a/py3status/modules/speedtest_cli.py
+++ b/py3status/modules/speedtest_cli.py
@@ -3,26 +3,24 @@
 Do a bandwidth test with speedtest-cli.
 
 Configuration parameters:
-    cache_timeout: refresh interval for this module (default -1)
+    button_refresh: button to run the check (default 1)
+    button_share: button to open the result link (default None)
     format: display format for this module, {download} and/or {upload} required
-        (default '■ [{ping} ms] [↑ {upload}] [↓ {download}]')
+        (default '● [{ping} ms] [↑ {upload} {upload_unit}] [↓ {download} {download_unit}]')
     server_id: speedtest server to use, `speedtest-cli --list` to get id (default None)
     si_units: use SI units (default False)
     sleep_timeout: when speedtest-cli is allready running, this interval will be used
         to allow faster retry refreshes
         (default 5)
     thresholds: specify color thresholds to use
-        (default [
-                "ping": 
-                    [(200, "bad"), (150, "orange"), (100, "degraded"), (10, "good")],
-                "download": 
-                    [(0, "bad"), (1024, "degraded"), (1024 * 1024, "good")],
-                "upload": 
-                    [(0, "bad"), (1024, "degraded"), (1024 * 1024, "good")],
-                "quality": 
-                    [("ok", "good"), ("bad", "degraded"), ("faster", "good"),
-                            ("slower", "degraded"), ("faster", "good")]
-                ]
+        (default {
+                'download': [(0, 'bad'), (1024, 'degraded'), (1048576, 'good')],
+                'ping': [(200, 'bad'), (150, 'orange'), (100, 'degraded'), (10, 'good')],
+                'quality': [('ok', 'good'), ('bad', 'degraded'),
+                            ('faster', 'good'), ('slower', 'degraded'), ('faster', 'good')
+                ],
+                'upload': [(0, 'bad'), (1024, 'degraded'), (1048576, 'good')]
+        })
     timeout: timeout when communicating with speedtest.net servers (default 10)
     unit_bitrate: unit for download/upload rate (default 'MB/s')
     unit_size: unit for bytes_received/bytes_sent (default 'MB')
@@ -52,7 +50,7 @@ Format placeholders:
     {timestamp} timestamp of the run
     {server_cc} server country code, eg 'FR'
     {server_country} server country, eg 'France'
-    {server_d} server d, eg '2.316599376968091'
+    {server_d} server distance, eg '2.316599376968091'
     {server_host} server host, eg 'speedtest.telecom-paristech.fr:8080'
     {server_id} server id, eg '11977'
     {server_lat} server latitude, eg '48.8742'
@@ -79,11 +77,18 @@ Examples:
 # colored based on thresholds
 speedtest_cli {
     thresholds = {
+        'download': [
+            (0, 'bad'), (1024, 'degraded'), (1024 * 1024, 'good')
+        ],
         'ping': [
             (200, 'bad'), (150, 'orange'), (100, 'degraded'), (10, 'good')
         ],
-        'download': [
-            (0, 'bad'), (1024, 'degraded'), (1024 * 1024, 'good')
+        'quality': [
+            ("ok", "good"),
+            ("bad", "degraded"),
+            ("faster", "good"),
+            ("slower", "degraded"),
+            ("faster", "good"),
         ],
         'upload': [
             (0, 'bad'), (1024, 'degraded'), (1024 * 1024, 'good')
@@ -125,7 +130,8 @@ class Py3status:
     """
 
     # available configuration parameters
-    cache_timeout = -1
+    button_refresh = 1
+    button_share = None
     format = (
         u"\u25cf [{ping} ms] [↑ {upload} {upload_unit}] [↓ {download} {download_unit}]"
     )
@@ -133,9 +139,8 @@ class Py3status:
     si_units = False
     sleep_timeout = 5
     thresholds = {
-        "ping": [(200, "bad"), (150, "orange"), (100, "degraded"), (10, "good")],
         "download": [(0, "bad"), (1024, "degraded"), (1024 * 1024, "good")],
-        "upload": [(0, "bad"), (1024, "degraded"), (1024 * 1024, "good")],
+        "ping": [(200, "bad"), (150, "orange"), (100, "degraded"), (10, "good")],
         "quality": [
             ("ok", "good"),
             ("bad", "degraded"),
@@ -143,6 +148,7 @@ class Py3status:
             ("slower", "degraded"),
             ("faster", "good"),
         ],
+        "upload": [(0, "bad"), (1024, "degraded"), (1024 * 1024, "good")],
     }
     timeout = 10
     unit_bitrate = "MB/s"
@@ -152,7 +158,7 @@ class Py3status:
         if not self.py3.check_commands("speedtest-cli"):
             raise Exception(STRING_NOT_INSTALLED)
 
-        self.can_refresh = False
+        self.first_run = True
         self.placeholders = list(set(self.py3.get_placeholders_list(self.format)))
 
         dont_upload = ''
@@ -167,17 +173,19 @@ class Py3status:
         if self.server_id and int(self.server_id):
             server = '--server {}'.format(self.server_id)
 
-        self.command = "speedtest-cli --json --secure --timeout {} {} {} {}".format(
-            self.timeout, dont_upload, dont_download, server
+        share = ''
+        if self.button_share and all(
+            x in self.placeholders for x in ['download', 'upload']
+        ):
+            share = '--share'
+
+        self.command = "speedtest-cli --json --secure --timeout {} {} {} {} {}".format(
+            self.timeout, dont_upload, dont_download, server, share
         )
 
         # fail if download or upload missing
         if not any(x in ['download', 'upload'] for x in self.placeholders):
             raise Exception('%s' % (MISSING_PLACEHOLDER))
-
-        # avoid bad behavior if speedtest timeout greater than cache_timeout
-        if self.cache_timeout < self.timeout and self.cache_timeout != -1:
-            self.cache_timeout = self.timeout + 5
 
     def _is_running(self):
         try:
@@ -195,80 +203,92 @@ class Py3status:
         return data
 
     def speedtest_cli(self):
-        current_data = {}
         speedtest_data = {}
-        previous_data = {}
-        cached_until = self.sleep_timeout
+        if self.first_run:
+            self.first_run = False
+            cached_until = self.py3.time_in(0)
+        else:
+            current_data = {}
+            previous_data = {}
+            cached_until = self.py3.time_in(self.sleep_timeout)
+            if self.first_run:
+                self.first_run = False
 
-        if not self._is_running() and self.can_refresh:
-            previous_data = self.py3.storage_get("speedtest_data")
-            current_data = self._get_speedtest_data()
-            cached_until = self.cache_timeout
+            if not self._is_running():
+                previous_data = self.py3.storage_get("speedtest_data")
+                current_data = self._get_speedtest_data()
+                cached_until = self.py3.CACHE_FOREVER
 
-            if current_data and len(current_data) > 1:
-                # create a "total" for know if cnx is better or not
-                # between two run
-                current_data["total"] = int(current_data.get("download", 0)) + int(
-                    current_data.get("upload", 0)
+                if current_data and len(current_data) > 1:
+                    # create a "total" for know if cnx is better or not
+                    # between two run
+                    current_data["total"] = int(current_data.get("download", 0)) + int(
+                        current_data.get("upload", 0)
+                    )
+
+                    # create "quality" #maybe bad name
+                    if "total" in previous_data:
+                        if current_data["total"] >= previous_data["total"]:
+                            quality = "faster"
+                        else:
+                            quality = "slower"
+                    else:
+                        if current_data["total"] <= 0:
+                            quality = "bad"
+                        else:
+                            quality = "ok"
+                    current_data["quality"] = quality
+
+            # zero-ing if not fetched, raw version and units convertion
+            for x in ["download", "upload"]:
+                current_data[x] = current_data.get(x, 0)
+                current_data[x + "_raw"] = current_data[x]
+                current_data[x], current_data[x + "_unit"] = self.py3.format_units(
+                    current_data[x], unit=self.unit_bitrate, si=self.si_units
                 )
 
-                # create "quality" #maybe bad name
-                if "total" in previous_data:
-                    if current_data["total"] >= previous_data["total"]:
-                        quality = "faster"
-                    else:
-                        quality = "slower"
-                else:
-                    if current_data["total"] <= 0:
-                        quality = "bad"
-                    else:
-                        quality = "ok"
-                current_data["quality"] = quality
+            for x in ["bytes_received", "bytes_sent"]:
+                current_data[x] = current_data.get(x, 0)
+                current_data[x + "_raw"] = current_data[x]
+                current_data[x], current_data[x + "_unit"] = self.py3.format_units(
+                    current_data[x], unit=self.unit_size, si=self.si_units
+                )
 
-        # zero-ing if not fetched, raw version and units convertion
-        for x in ["download", "upload"]:
-            current_data[x] = current_data.get(x, 0)
-            current_data[x + "_raw"] = current_data[x]
-            current_data[x], current_data[x + "_unit"] = self.py3.format_units(
-                current_data[x], unit=self.unit_bitrate, si=self.si_units
-            )
+            # extra data, not sure we want to expose
+            for x in ["server", "client"]:
+                if x in current_data:
+                    for y in current_data[x]:
+                        current_data[x + '_' + y] = current_data[x][y]
+                    del current_data[x]
 
-        for x in ["bytes_received", "bytes_sent"]:
-            current_data[x] = current_data.get(x, 0)
-            current_data[x + "_raw"] = current_data[x]
-            current_data[x], current_data[x + "_unit"] = self.py3.format_units(
-                current_data[x], unit=self.unit_size, si=self.si_units
-            )
+            # store last data fetched
+            self.py3.storage_set("speedtest_data", current_data)
 
-        # extra data, not sure we want to expose
-        for x in ["server", "client"]:
-            if x in current_data:
-                for y in current_data[x]:
-                    current_data[x + '_' + y] = current_data[x][y]
-                del current_data[x]
+            # get speedtest result url
+            if 'share' in current_data:
+                self.url = current_data['share']
 
-        # store last data fetched
-        self.py3.storage_set("speedtest_data", current_data)
+            # create placeholders
+            for x in current_data:
+                speedtest_data[x] = current_data[x]
+            for x in previous_data:
+                speedtest_data["previous_" + x] = previous_data[x]
 
-        # create placeholders
-        for x in current_data:
-            speedtest_data[x] = current_data[x]
-        for x in previous_data:
-            speedtest_data["previous_" + x] = previous_data[x]
-
-        # thresholds
-        for x in self.thresholds:
-            if x in speedtest_data:
-                self.py3.threshold_get_color(speedtest_data[x], x)
+            # thresholds
+            for x in self.thresholds:
+                if x in speedtest_data:
+                    self.py3.threshold_get_color(speedtest_data[x], x)
 
         return {
-            "cached_until": self.py3.time_in(cached_until),
+            "cached_until": cached_until,
             "full_text": self.py3.safe_format(self.format, speedtest_data),
         }
 
     def on_click(self, event):
-        self.can_refresh = True
-        if self._is_running:
+        button = event['button']
+        if button == self.button_share and self.url:
+            self.py3.command_run('xdg-open %s' % self.url)
+        elif button != self.button_refresh:
             self.py3.prevent_refresh()
 
 

--- a/py3status/modules/speedtest_cli.py
+++ b/py3status/modules/speedtest_cli.py
@@ -123,6 +123,7 @@ MISSING_PLACEHOLDER = "{download} or {upload} placeholder required"
 class Py3status:
     """
     """
+
     # available configuration parameters
     cache_timeout = -1
     format = (
@@ -132,12 +133,16 @@ class Py3status:
     si_units = False
     sleep_timeout = 5
     thresholds = {
-        "ping": [(200, "bad"), (150, "orange"), (100, "degraded"), (10,
-                                                                    "good")],
+        "ping": [(200, "bad"), (150, "orange"), (100, "degraded"), (10, "good")],
         "download": [(0, "bad"), (1024, "degraded"), (1024 * 1024, "good")],
         "upload": [(0, "bad"), (1024, "degraded"), (1024 * 1024, "good")],
-        "quality": [("ok", "good"), ("bad", "degraded"), ("faster", "good"),
-                    ("slower", "degraded"), ("faster", "good")],
+        "quality": [
+            ("ok", "good"),
+            ("bad", "degraded"),
+            ("faster", "good"),
+            ("slower", "degraded"),
+            ("faster", "good"),
+        ],
     }
     timeout = 10
     unit_bitrate = "MB/s"
@@ -148,8 +153,7 @@ class Py3status:
             raise Exception(STRING_NOT_INSTALLED)
 
         self.can_refresh = False
-        self.placeholders = list(
-            set(self.py3.get_placeholders_list(self.format)))
+        self.placeholders = list(set(self.py3.get_placeholders_list(self.format)))
 
         dont_upload = ''
         if 'upload' not in self.placeholders:
@@ -164,7 +168,8 @@ class Py3status:
             server = '--server {}'.format(self.server_id)
 
         self.command = "speedtest-cli --json --secure --timeout {} {} {} {}".format(
-            self.timeout, dont_upload, dont_download, server)
+            self.timeout, dont_upload, dont_download, server
+        )
 
         # fail if download or upload missing
         if not any(x in ['download', 'upload'] for x in self.placeholders):
@@ -203,8 +208,9 @@ class Py3status:
             if current_data and len(current_data) > 1:
                 # create a "total" for know if cnx is better or not
                 # between two run
-                current_data["total"] = int(current_data.get(
-                    "download", 0)) + int(current_data.get("upload", 0))
+                current_data["total"] = int(current_data.get("download", 0)) + int(
+                    current_data.get("upload", 0)
+                )
 
                 # create "quality" #maybe bad name
                 if "total" in previous_data:
@@ -224,13 +230,15 @@ class Py3status:
             current_data[x] = current_data.get(x, 0)
             current_data[x + "_raw"] = current_data[x]
             current_data[x], current_data[x + "_unit"] = self.py3.format_units(
-                current_data[x], unit=self.unit_bitrate, si=self.si_units)
+                current_data[x], unit=self.unit_bitrate, si=self.si_units
+            )
 
         for x in ["bytes_received", "bytes_sent"]:
             current_data[x] = current_data.get(x, 0)
             current_data[x + "_raw"] = current_data[x]
             current_data[x], current_data[x + "_unit"] = self.py3.format_units(
-                current_data[x], unit=self.unit_size, si=self.si_units)
+                current_data[x], unit=self.unit_size, si=self.si_units
+            )
 
         # extra data, not sure we want to expose
         for x in ["server", "client"]:

--- a/py3status/modules/speedtest_cli.py
+++ b/py3status/modules/speedtest_cli.py
@@ -1,0 +1,151 @@
+# -*- coding: utf-8 -*-
+"""
+Do a bandwidth test with speedtest-cli.
+
+Configuration parameters:
+    cache_timeout: refresh interval for this module (default -1)
+    format: display format for this module (default '■ [{ping} ms] [↑ {upload}] [↓ {download}]')
+    si_units: use SI units (default False)
+    sleep_timeout: when speedtest-cli is allready running, this interval will be used
+        to allow faster retry refreshes
+        (default 20)
+    thresholds: specify color thresholds to use
+        (default [(0, 'bad'), (11, 'good')])
+
+Format placeholders:
+    {download} download rate from speedtest server (in MB/s)
+    {ping} ping time in ms to speedtest server
+    {upload} upload rate to speedtest server (in MB/s)
+    {bytes_sent} bytes sent during test (in MB)
+    {bytes_received} bytes received during test (in MB)
+
+Requires:
+    speedtest-cli: Command line interface for testing internet bandwidth using speedtest.net
+
+Examples:
+```
+# colored based on thresholds
+speedtest_cli {
+    thresholds = {
+        'ping': [
+            (200, 'bad'), (150, 'orange'), (100, 'degraded'), (10, 'good')
+        ],
+        'download': [
+            (0, 'bad'), (1024, 'degraded'), (1024 * 1024, 'good')
+        ],
+        'upload': [
+            (0, 'bad'), (1024, 'degraded'), (1024 * 1024, 'good')
+        ],
+    }
+    format = '[\?color=ping {ping} ms] [\?color=upload ↑ {upload}] [\?color=download ↓ {download}]'
+}
+
+@author Cyril Levis (@cyrinux)
+
+SAMPLE OUTPUT
+{'full_text': u'\u25cf 208.18 ms \u2191 0.247 MB/s \u2193 0.453 MB/s'}
+"""
+
+from __future__ import division  # python2 compatibility
+from json import loads
+
+STRING_NOT_INSTALLED = 'not installed'
+
+
+class Py3status:
+    """
+    """
+    # available configuration parameters
+    cache_timeout = -1
+    format = u'\u25cf [{ping} ms] [↑ {upload}] [↓ {download}]'
+    si_units = False
+    sleep_timeout = 20
+    thresholds = {
+        'ping': [
+            (200, 'bad'), (150, 'orange'), (100, 'degraded'), (10, 'good')
+        ],
+        'download': [
+            (0, 'bad'), (1024, 'degraded'), (1024 * 1024, 'good')
+        ],
+        'upload': [
+            (0, 'bad'), (1024, 'degraded'), (1024 * 1024, 'good')
+        ],
+    }
+
+    def post_config_hook(self):
+        if not self.py3.check_commands('speedtest-cli'):
+            raise Exception(STRING_NOT_INSTALLED)
+
+        self.placeholders = list(
+            set(self.py3.get_placeholders_list(self.format))
+        )
+        self.speedtest_command = 'speedtest-cli --json --secure'
+
+    def _is_running(self):
+        try:
+            self.py3.command_output(['pgrep', 'speedtest-cli'])
+            return True
+        except:
+            return False
+
+    def _get_speedtest_data(self):
+        try:
+            line = self.py3.command_output(self.speedtest_command)
+        except self.py3.CommandError as ce:
+            return ce.output
+
+        if line:
+            return loads(line)
+        else:
+            return None
+
+    def _get_last_speedtest_data(self):
+        new_data = {}
+        last_data = self.py3.storage_get('speedtest_data')
+        if last_data:
+            for x in last_data:
+                new_data['last_' + x] = last_data[x]
+        return new_data
+
+    def speedtest_cli(self):
+        speedtest_data = {}
+        cached_until = self.sleep_timeout
+
+        if not self._is_running():
+            last_speedtest_data = self._get_last_speedtest_data()
+            speedtest_data = self._get_speedtest_data()
+            cached_until = self.cache_timeout
+            if speedtest_data:
+                self.py3.storage_set('speedtest_data', speedtest_data)
+                if last_speedtest_data:
+                    speedtest_data.update(last_speedtest_data)
+
+                # thresholds
+                for x in self.thresholds:
+                    if x in speedtest_data:
+                        self.py3.threshold_get_color(speedtest_data[x], x)
+
+                # units
+                for x in ['download', 'upload']:
+                    rate, unit = self.py3.format_units(speedtest_data[x], unit='MB/s', si=self.si_units)
+                    speedtest_data[x] = str(rate) + ' ' + unit
+
+                for x in ['bytes_received', 'bytes_sent']:
+                    size, unit = self.py3.format_units(speedtest_data[x], unit='MB', si=self.si_units)
+                    speedtest_data[x] = str(size) + ' ' + unit
+
+        return {
+            'cached_until': self.py3.time_in(cached_until),
+            'full_text': self.py3.safe_format(self.format, speedtest_data)
+        }
+
+
+    def on_click(self, event):
+        pass
+
+if __name__ == "__main__":
+    """
+    Run module in test mode.
+    """
+    from py3status.module_test import module_test
+    module_test(Py3status)

--- a/py3status/modules/speedtest_cli.py
+++ b/py3status/modules/speedtest_cli.py
@@ -54,7 +54,7 @@ Format placeholders:
     {upload} upload rate to speedtest server, human readable
     {upload_raw} upload rate to speedtest server, for format comparation
     {upload_unit} unit used for upload, eg 'MB/s'
-    
+
 
 The module will be triggered on clic only. Not at start.
 
@@ -114,7 +114,6 @@ MISSING_PLACEHOLDER = "{download} or {upload} placeholder required"
 class Py3status:
     """
     """
-
     # available configuration parameters
     cache_timeout = -1
     format = (
@@ -128,21 +127,21 @@ class Py3status:
                                                                     "good")],
         "download": [(0, "bad"), (1024, "degraded"), (1024 * 1024, "good")],
         "upload": [(0, "bad"), (1024, "degraded"), (1024 * 1024, "good")],
-        "quality": [("ok", "good"), ("bad", "degraded"), ("faster", "good"), ("slower", "degraded"), ("faster","good")],
+        "quality": [("ok", "good"), ("bad", "degraded"), ("faster", "good"),
+                    ("slower", "degraded"), ("faster", "good")],
     }
     timeout = 30
     unit_bitrate = "MB/s"
     unit_size = "MB"
-    
 
     def post_config_hook(self):
         if not self.py3.check_commands("speedtest-cli"):
             raise Exception(STRING_NOT_INSTALLED)
-        
+
         self.can_refresh = False
         self.placeholders = list(
             set(self.py3.get_placeholders_list(self.format)))
-        
+
         dont_upload = ''
         if 'upload' not in self.placeholders:
             dont_upload = '--no-upload'
@@ -151,9 +150,9 @@ class Py3status:
         if 'download' not in self.placeholders:
             dont_download = '--no-download'
 
-        server = '' # if not specified, nearest server is use
+        server = ''  # if not specified, nearest server is use
         if self.server_id and int(self.server_id):
-            server = '--server {}'.format(self.server_id) 
+            server = '--server {}'.format(self.server_id)
 
         self.command = "speedtest-cli --json --secure --timeout {} {} {} {}".format(
             self.timeout, dont_upload, dont_download, server)
@@ -224,11 +223,11 @@ class Py3status:
             current_data[x], current_data[x + "_unit"] = self.py3.format_units(
                 current_data[x], unit=self.unit_size, si=self.si_units)
 
-        # extra data, not sure we want to expose 
+        # extra data, not sure we want to expose
         for x in ["server", "client"]:
             if x in current_data:
                 for y in current_data[x]:
-                    current_data[x+'_'+y] = current_data[x][y]
+                    current_data[x + '_' + y] = current_data[x][y]
                 del current_data[x]
 
         # store last data fetched
@@ -255,6 +254,7 @@ class Py3status:
         if self._is_running:
             self.py3.prevent_refresh()
         pass
+
 
 if __name__ == "__main__":
     """

--- a/py3status/modules/speedtest_cli.py
+++ b/py3status/modules/speedtest_cli.py
@@ -104,7 +104,6 @@ SAMPLE OUTPUT
 {'full_text': u'\u25cf 208.18 ms \u2191 0.247 MB/s \u2193 0.453 MB/s'}
 """
 
-from __future__ import division  # python2 compatibility
 from json import loads
 
 STRING_NOT_INSTALLED = "not installed"

--- a/py3status/modules/speedtest_cli.py
+++ b/py3status/modules/speedtest_cli.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 """
-Do a bandwidth test with speedtest-cli.
+Do a bandwidth test with speedtest-cli. 
 
 Configuration parameters:
     cache_timeout: refresh interval for this module (default -1)
@@ -11,13 +11,29 @@ Configuration parameters:
         (default 20)
     thresholds: specify color thresholds to use
         (default [(0, 'bad'), (11, 'good')])
+    unit_bitrate: unit for download/upload rate (default 'MB/s')
+    unit_size: unit for bytes_received/bytes_sent (default 'MB')
 
 Format placeholders:
-    {download} download rate from speedtest server (in MB/s)
+    {download} download rate from speedtest server, human readable
+    {download_raw} download rate from speedtest server, for format comparation
+    {download_unit} unit used as , eg 'MB/s'
     {ping} ping time in ms to speedtest server
-    {upload} upload rate to speedtest server (in MB/s)
-    {bytes_sent} bytes sent during test (in MB)
-    {bytes_received} bytes received during test (in MB)
+    {upload} upload rate to speedtest server, human readable
+    {upload_raw} upload rate to speedtest server, for format comparation
+    {upload_unit} unit used for upload, eg 'MB/s'
+    {bytes_sent} bytes sent during test, human readable
+    {bytes_sent_unit} unit used for bytes_sent, eg 'MB'
+    {bytes_sent_raw} bytes sent during test, for format comparation
+    {bytes_received} bytes received during test, human readable
+    {bytes_received_raw} bytes received during test, for format comparation
+    {bytes_received_unit} unit used for bytes_received, eg 'MB'
+    {timestamp} timestamp of the run
+
+The module will be triggered on clic only. Not at start.
+
+Note that all placeholders have a version prefixed by `last_`, eg `last_download`.
+This can be usefull to compare two runs.
 
 Requires:
     speedtest-cli: Command line interface for testing internet bandwidth using speedtest.net
@@ -37,7 +53,14 @@ speedtest_cli {
             (0, 'bad'), (1024, 'degraded'), (1024 * 1024, 'good')
         ],
     }
-    format = '[\?color=ping {ping} ms] [\?color=upload ↑ {upload}] [\?color=download ↓ {download}]'
+    format = '[\?color=ping {ping} ms] [\?color=upload ↑ {upload} {upload_unit}]'
+    format += ' [\?color=download ↓ {download} {download_unit}]'
+}
+
+
+# colored based on comparation between two last runs
+speedtest_cli {
+    format = ' [[\?if=download_raw<last_download_raw&color=degraded ↓]|[\?color=ok ↑]]'
 }
 
 @author Cyril Levis (@cyrinux)
@@ -51,13 +74,12 @@ from json import loads
 
 STRING_NOT_INSTALLED = 'not installed'
 
-
 class Py3status:
     """
     """
     # available configuration parameters
     cache_timeout = -1
-    format = u'\u25cf [{ping} ms] [↑ {upload}] [↓ {download}]'
+    format = u'\u25cf [{ping} ms] [↑ {upload} {upload_unit}] [↓ {download} {download_unit}]'
     si_units = False
     sleep_timeout = 20
     thresholds = {
@@ -71,6 +93,8 @@ class Py3status:
             (0, 'bad'), (1024, 'degraded'), (1024 * 1024, 'good')
         ],
     }
+    unit_bitrate = 'MB/s'
+    unit_size = 'MB'
 
     def post_config_hook(self):
         if not self.py3.check_commands('speedtest-cli'):
@@ -79,6 +103,7 @@ class Py3status:
         self.placeholders = list(
             set(self.py3.get_placeholders_list(self.format))
         )
+        self.run = False
         self.speedtest_command = 'speedtest-cli --json --secure'
 
     def _is_running(self):
@@ -111,28 +136,37 @@ class Py3status:
         speedtest_data = {}
         cached_until = self.sleep_timeout
 
-        if not self._is_running():
+        if not self._is_running() and self.run:
             last_speedtest_data = self._get_last_speedtest_data()
             speedtest_data = self._get_speedtest_data()
             cached_until = self.cache_timeout
+
             if speedtest_data:
                 self.py3.storage_set('speedtest_data', speedtest_data)
                 if last_speedtest_data:
                     speedtest_data.update(last_speedtest_data)
 
+                # raw version and units convertion
+                for x in ['download', 'upload']:
+                    speedtest_data[x + '_raw'] = speedtest_data[x]
+                    speedtest_data[x], speedtest_data[x + '_unit'] = self.py3.format_units(
+                        speedtest_data[x], unit=self.unit_bitrate, si=self.si_units
+                    )
+
+                for x in ['bytes_received', 'bytes_sent']:
+                    speedtest_data[x + '_raw'] = speedtest_data[x]
+                    speedtest_data[x], speedtest_data[x + '_unit'] = self.py3.format_units(
+                        speedtest_data[x], unit=self.unit_size, si=self.si_units
+                    )
+                    
                 # thresholds
                 for x in self.thresholds:
                     if x in speedtest_data:
                         self.py3.threshold_get_color(speedtest_data[x], x)
-
-                # units
-                for x in ['download', 'upload']:
-                    rate, unit = self.py3.format_units(speedtest_data[x], unit='MB/s', si=self.si_units)
-                    speedtest_data[x] = str(rate) + ' ' + unit
-
-                for x in ['bytes_received', 'bytes_sent']:
-                    size, unit = self.py3.format_units(speedtest_data[x], unit='MB', si=self.si_units)
-                    speedtest_data[x] = str(size) + ' ' + unit
+        else:
+            # little hack for prevent running speedtest
+            # at start, allow only trigger on_click / refresh
+            self.run = True
 
         return {
             'cached_until': self.py3.time_in(cached_until),
@@ -141,6 +175,7 @@ class Py3status:
 
 
     def on_click(self, event):
+        # trigger refresh on any click
         pass
 
 if __name__ == "__main__":


### PR DESCRIPTION
Hi family,

Here a new module for do speedtest.
It needs speedtest-cli to be working.

![image](https://user-images.githubusercontent.com/519083/44311967-10da7c00-a3f1-11e8-8ebc-14496cb482d8.png)

Some point:
* This module if not refreshed at py3status, but only next on click / py3-cmd refresh.
I think I will personally refresh it with a networkmanager dispatcher hook.

* I have first done a "hack" which is the `{quality}` placeholder. Done this because there is yet a bug for int/float comparaison with the formatter. Even when this will be fix i think we can keep it, but, what is a "good" or "bad" connection? Must I add params for report quality based or user preference?

* To be quick, i do upload or download only if placeholders are present. Need at least `{download}` or `{upload}`

Waiting for review :)

(I will have lot of travis fix to do first I think)