### PR TITLE
module: align modules with py3status instead of i3bar

### DIFF
--- a/py3status/module.py
+++ b/py3status/module.py
@@ -4,6 +4,7 @@ import inspect
 
 from collections import OrderedDict
 from time import time
+from random import randint
 
 from py3status.composite import Composite
 from py3status.py3 import Py3, PY3_CACHE_FOREVER, ModuleErrorException
@@ -309,7 +310,8 @@ class Module:
         Set universal module options to be interpreted by i3bar
         https://i3wm.org/i3status/manpage.html#_universal_module_options
         """
-        self.module_options = {}
+        self.i3s_module_options = {}
+        self.py3_module_options = {}
         mod_config = self.config['py3_config'].get(module, {})
 
         if 'min_width' in mod_config:
@@ -318,7 +320,8 @@ class Module:
                 err = 'invalid "min_width" attribute should be an int'
                 raise TypeError(err)
 
-            self.module_options['min_width'] = min_width
+            self.py3_module_options['min_width'] = min_width
+            self.random_int = randint(0, 1)
 
             if 'align' in mod_config:
                 align = mod_config['align']
@@ -328,7 +331,7 @@ class Module:
                     err += ' left, center, right'
                     raise ValueError(err)
 
-                self.module_options['align'] = align
+                self.py3_module_options['align'] = align
 
         if 'separator' in mod_config:
             separator = mod_config['separator']
@@ -336,7 +339,7 @@ class Module:
                 err = 'invalid "separator" attribute, should be a bool'
                 raise TypeError(err)
 
-            self.module_options['separator'] = separator
+            self.i3s_module_options['separator'] = separator
 
         if 'separator_block_width' in mod_config:
             sep_block_width = mod_config['separator_block_width']
@@ -345,7 +348,7 @@ class Module:
                 err += "should be an int"
                 raise TypeError(err)
 
-            self.module_options['separator_block_width'] = sep_block_width
+            self.i3s_module_options['separator_block_width'] = sep_block_width
 
     def process_composite(self, response):
         """
@@ -373,16 +376,7 @@ class Module:
             err = 'conflicting "full_text" and "composite" in response'
             raise Exception(err)
         # set universal options on last component
-        composite[-1].update(self.module_options)
-        # calculate any min width (we split this across components)
-        min_width = None
-        if 'min_width' in self.module_options:
-            min_width = int(self.module_options['min_width'] / len(composite))
-        # store alignment
-        align = None
-        if 'align' in self.module_options:
-            align = self.module_options['align']
-
+        composite[-1].update(self.i3s_module_options)
         # update all components
         color = response.get('color')
         urgent = response.get('urgent')
@@ -402,12 +396,6 @@ class Module:
                 if 'separator' not in item:
                     item['separator'] = False
                     item['separator_block_width'] = 0
-            # set min width
-            if min_width:
-                item['min_width'] = min_width
-            # set align
-            if align:
-                item['align'] = align
             # If a color was supplied for the composite and a composite
             # part does not supply a color, use the composite color.
             if color and 'color' not in item:
@@ -423,6 +411,41 @@ class Module:
             # if urgent we want to set this to all parts
             elif urgent and 'urgent' not in item:
                 item['urgent'] = urgent
+
+        # set min_width
+        if 'min_width' in self.py3_module_options:
+            min_width = self.py3_module_options['min_width']
+
+            # get width, skip if width exceeds min_width
+            width = sum([len(x['full_text']) for x in response['composite']])
+            if width >= min_width:
+                return
+
+            # sometimes when we go under min_width to pad both side evenly,
+            # we will add extra space on either side to honor min_width
+            padding = int((min_width / 2.0) - (width / 2.0))
+            offset = min_width - ((padding * 2) + width)
+
+            # set align
+            align = self.py3_module_options.get('align', 'center')
+            if align == 'center':
+                left = right = ' ' * padding
+                if self.random_int:
+                    left += ' ' * offset
+                else:
+                    right += ' ' * offset
+            elif align == 'left':
+                left, right = '', ' ' * (padding * 2 + offset)
+            elif align == 'right':
+                right, left = '', ' ' * (padding * 2 + offset)
+
+            # padding
+            if left:
+                response['composite'][0]['full_text'] = (
+                    left + response['composite'][0]['full_text']
+                )
+            if right:
+                response['composite'][-1]['full_text'] += right
 
     def _params_type(self, method_name, instance):
         """
@@ -775,7 +798,7 @@ class Module:
                         if not self.allow_urgent and 'urgent' in result:
                             del result['urgent']
                         # set universal module options in result
-                        result.update(self.module_options)
+                        result.update(self.i3s_module_options)
 
                     result['instance'] = self.module_inst
                     result['name'] = self.module_name


### PR DESCRIPTION
Addresses https://github.com/ultrabug/py3status/issues/815. 

![align_081337_scrot](https://user-images.githubusercontent.com/852504/44314304-feeede00-a3dc-11e8-9ba3-b94c53710ed5.png)