### PR TITLE
external_script: show notification with full output on click, refresh only on button_refresh

### DIFF
--- a/py3status/modules/external_script.py
+++ b/py3status/modules/external_script.py
@@ -72,7 +72,8 @@ class Py3status:
         response = {}
         response['cached_until'] = self.py3.time_in(self.cache_timeout)
         try:
-            self.output = self.py3.command_output(self.script_path, shell=True, localized=self.localize)
+            self.output = self.py3.command_output(
+                self.script_path, shell=True, localized=self.localize)
             output_lines = self.output.splitlines()
             if len(output_lines) > 1:
                 output_color = output_lines[1]
@@ -116,6 +117,7 @@ class Py3status:
                     self.format_notification, {'output': self.output})
                 )
             self.py3.prevent_refresh()
+
 
 if __name__ == "__main__":
     """

--- a/py3status/modules/external_script.py
+++ b/py3status/modules/external_script.py
@@ -27,7 +27,7 @@ Format placeholders:
 
 Format notification placeholders:
     {line} number of lines in the output
-    {output} full output of script given by "script_path"
+    {output} first line of the output of script given by "script_path"
 
 i3status.conf example:
 

--- a/py3status/modules/external_script.py
+++ b/py3status/modules/external_script.py
@@ -14,6 +14,7 @@ Configuration parameters:
     cache_timeout: how often we refresh this module in seconds
         (default 15)
     format: see placeholders below (default '{output}')
+    format_notification: see placeholders below (default '{output}')
     localize: should script output be localized (if available)
         (default True)
     script_path: script you want to show output of (compulsory)
@@ -23,7 +24,10 @@ Configuration parameters:
 
 Format placeholders:
     {line} number of lines in the output
-    {output} output of script given by "script_path"
+    {output} first line of the output of script given by "script_path"
+
+Format notification placeholders:
+    {output} full output of script given by "script_path"
 
 i3status.conf example:
 
@@ -54,6 +58,7 @@ class Py3status:
     button_refresh = 2
     cache_timeout = 15
     format = '{output}'
+    format_notification = '{output}'
     localize = True
     script_path = None
     strip_output = False
@@ -106,7 +111,10 @@ class Py3status:
     def on_click(self, event):
         button = event["button"]
         if button != self.button_refresh:
-            self.py3.notify_user(self.output)
+            if self.format_notification:
+                self.py3.notify_user(self.py3.safe_format(
+                    self.format_notification, {'output': self.output})
+                )
             self.py3.prevent_refresh()
 
 if __name__ == "__main__":

--- a/py3status/modules/external_script.py
+++ b/py3status/modules/external_script.py
@@ -22,8 +22,8 @@ Configuration parameters:
         (default False)
 
 Format placeholders:
+    {line} number of lines in the output
     {output} output of script given by "script_path"
-    {count_lines} number of lines in the output
 
 i3status.conf example:
 
@@ -100,7 +100,7 @@ class Py3status:
             output = ''
 
         response['full_text'] = self.py3.safe_format(
-            self.format, {'output': output, 'count_lines': len(output_lines)})
+            self.format, {'output': output, 'line': len(output_lines)})
         return response
 
     def on_click(self, event):

--- a/py3status/modules/external_script.py
+++ b/py3status/modules/external_script.py
@@ -10,6 +10,7 @@ code such as #FF0000 for red).
 The script should not have any parameters, but it could work.
 
 Configuration parameters:
+    button_refresh: button to refresh the module (default 2)
     cache_timeout: how often we refresh this module in seconds
         (default 15)
     format: see placeholders below (default '{output}')
@@ -22,6 +23,7 @@ Configuration parameters:
 
 Format placeholders:
     {output} output of script given by "script_path"
+    {count_lines} number of lines in the output
 
 i3status.conf example:
 
@@ -49,6 +51,7 @@ class Py3status:
     """
     """
     # available configuration parameters
+    button_refresh = 2
     cache_timeout = 15
     format = '{output}'
     localize = True
@@ -64,8 +67,8 @@ class Py3status:
         response = {}
         response['cached_until'] = self.py3.time_in(self.cache_timeout)
         try:
-            output = self.py3.command_output(self.script_path, shell=True, localized=self.localize)
-            output_lines = output.splitlines()
+            self.output = self.py3.command_output(self.script_path, shell=True, localized=self.localize)
+            output_lines = self.output.splitlines()
             if len(output_lines) > 1:
                 output_color = output_lines[1]
                 if re.search(r'^#[0-9a-fA-F]{6}$', output_color):
@@ -97,9 +100,14 @@ class Py3status:
             output = ''
 
         response['full_text'] = self.py3.safe_format(
-            self.format, {'output': output})
+            self.format, {'output': output, 'count_lines': len(output_lines)})
         return response
 
+    def on_click(self, event):
+        button = event["button"]
+        if button != self.button_refresh:
+            self.py3.notify_user(self.output)
+            self.py3.prevent_refresh()
 
 if __name__ == "__main__":
     """

--- a/py3status/modules/external_script.py
+++ b/py3status/modules/external_script.py
@@ -108,7 +108,7 @@ class Py3status:
             raise Exception(STRING_ERROR)
 
         self.button_refresh = 2
-        self.notification = {'normal': []}
+        self.notification = {'normal': [], 'click': False}
         if self.notifications:
             for x in ['changed', 'click', 'current']:
                 self.notification[x] = self.notifications.get(x, False)


### PR DESCRIPTION
Replaces #1431.

Show notification with full `output` on click.
Refresh only on `button_refresh` click.
Still needs #1432 for most scripts that I use.