### PR TITLE
formatter: fix lost left brace

### DIFF
--- a/py3status/formatter.py
+++ b/py3status/formatter.py
@@ -28,8 +28,9 @@ class Formatter:
         r'|(\\\?(?P<command>\S*)\s)'
         r'|(?P<escaped>(\\.|\{\{|\}\}))'
         r'|(?P<placeholder>(\{(?P<key>([^}\\\:\!]|\\.)*)(?P<format>([^}\\]|\\.)*)?\}))'
+        r'|(?P<lost_brace_left>(\{))'
         r'|(?P<literal>([^\[\]\\\{\}\|])+)'
-        r'|(?P<lost_brace>(\}))'
+        r'|(?P<lost_brace_right>(\}))'
     ]
 
     reg_ex = re.compile(TOKENS[0], re.M | re.I)
@@ -141,9 +142,12 @@ class Formatter:
                 key = token.group('key')
                 format = token.group('format')
                 block.add(Placeholder(key, format))
+            elif token.group('lost_brace_left'):
+                # fix lost left brace, eg 'name' instead of '{name'
+                block.add(Literal('{'))
             elif token.group('literal'):
                 block.add(Literal(value))
-            elif token.group('lost_brace'):
+            elif token.group('lost_brace_right'):
                 # due to how parsing happens we can get a lonesome }
                 # eg in format_string '{{something}' this fixes that issue
                 block.add(Literal('}'))


### PR DESCRIPTION
Print `hello_world` (before) vs `{hello_world` (after).
```diff
diff --git a/py3status/modules/static_string.py b/py3status/modules/static_string.py
index dbcec8c6..1df42b9b 100644
--- a/py3status/modules/static_string.py
+++ b/py3status/modules/static_string.py
@@ -16,7 +16,7 @@ class Py3status:
     """
     """
     # available configuration parameters
-    format = 'Hello, world!'
+    format = '{hello_world'
 
     def static_string(self):
         return {
```