### PR TITLE
nvidia_smi: remove a trailing whitespace

### DIFF
--- a/py3status/modules/nvidia_smi.py
+++ b/py3status/modules/nvidia_smi.py
@@ -56,7 +56,7 @@ nvidia_smi {
 SAMPLE OUTPUT
 [
     {'full_text': 'GeForce GTX 1060 '},
-    {'color': '#00ff00', 'full_text': '51°C '},
+    {'color': '#00ff00', 'full_text': '51°C'},
 ]
 
 memory


### PR DESCRIPTION
I need to try `screenshots.py` in the future to see screenshots here first instead of looking at readthedocs. This should finalize the work on `nvidai_smi` module for some time now.