### PR TITLE
add new module: wanda_the_fish 

### DIFF
--- a/py3status/modules/wanda_the_fish.py
+++ b/py3status/modules/wanda_the_fish.py
@@ -1,0 +1,191 @@
+# -*- coding: utf-8 -*-
+"""
+Display a fortune-telling, swimming fish.
+
+Wanda has no use what-so-ever. It only takes up disk space and compilation time,
+and if loaded, it also takes up precious bar space, memory, and cpu cycles.
+Anybody found using it should be promptly sent for a psychiatric evaluation.
+
+Configuration parameters:
+    button_refresh: mouse button to refresh this module (default 2)
+    button_toggle: mouse button to toggle fortunes (default 1)
+    cache_timeout: refresh interval for this module (default 0)
+    format: display format for this module
+        (default '{nomotion}[{fortune} ]{wanda}{motion}')
+    fortune_timeout: refresh interval for fortune (default 60)
+
+Format placeholders:
+    {fortune} one of many aphorisms or vague prophecies
+    {wanda} name of one of the most commonly kept freshwater aquarium fish
+    {motion} biologically propelled motion through a liquid medium
+    {nomotion} opposite behavior of motion to prevent modules from shifting
+
+Optional:
+    fortune-mod: the fortune cookie program from bsd games
+
+Examples:
+```
+# disable motions when not in use
+wanda_the_fish {
+    format = '[\?if=fortune {nomotion}][{fortune} ]'
+    format += '{wanda}[\?if=fortune {motion}]'
+}
+
+# no motions, no fortunes, you click
+wanda_the_fish {
+    format = '[{fortune} ]{wanda}'
+    cache_timeout = -1
+}
+
+# wanda moves, fortunes stays
+wanda_the_fish {
+    format = '[{fortune} ]{nomotion}{wanda}{motion}'
+}
+
+# wanda is swimming too fast, slow down wanda
+wanda_the_fish {
+    cache_timeout = 2
+}
+
+@author lasers
+
+SAMPLE OUTPUT
+[
+    {'full_text': u'innovate, v.: To annoy people.'},
+    {'full_text': u'<', 'color': '#ffa500'}
+    {'full_text': u'\xba', 'color': '#add8e6'},
+    {'full_text': u',', 'color': '#ff8c00'},
+    {'full_text': u'))', 'color': '#ffa500'},
+    {'full_text': u'))>< , 'color': #ff8c00'},
+]
+
+off
+[
+
+    {'full_text': u'<', 'color': '#ffa500'}
+    {'full_text': u'\xba', 'color': '#add8e6'},
+    {'full_text': u',', 'color': '#ff8c00'},
+    {'full_text': u'))', 'color': '#ffa500'},
+    {'full_text': u'))>3, 'color': #ff8c00'},
+]
+
+py3status
+[
+
+    {'full_text': u'py3status is so cool! -- Confucius'},
+    {'full_text': u'<', 'color': '#ffa500'}
+    {'full_text': u'\xba', 'color': '#add8e6'},
+    {'full_text': u',', 'color': '#ff8c00'},
+    {'full_text': u'))', 'color': '#ffa500'},
+    {'full_text': u'))><', 'color': #ff8c00'},
+]
+
+"""
+from time import time
+
+
+class Py3status:
+    """
+    """
+    # available configuration parameters
+    button_refresh = 2
+    button_toggle = 1
+    cache_timeout = 0
+    format = '{nomotion}[{fortune} ]{wanda}{motion}'
+    fortune_timeout = 60
+
+    def post_config_hook(self):
+        body = ('[\?color=orange&show <'
+                '[\?color=lightblue&show º]'
+                '[\?color=darkorange&show ,]))'
+                '[\?color=darkorange&show ))>%s]]')
+        wanda = [body % fin for fin in ('<', '>', '<', '3')]
+        self.wanda = [self.py3.safe_format(x) for x in wanda]
+        self.wanda_length = len(self.wanda)
+        self.index = 0
+
+        self.fortune_command = ['fortune', '-as']
+        self.fortune = self.py3.storage_get('fortune') or None
+        self.toggled = self.py3.storage_get('toggled') or False
+        self.motions = {'motion': ' ', 'nomotion': ''}
+
+        # deal with {new,old} timeout between storage
+        fortune_timeout = self.py3.storage_get('fortune_timeout')
+        timeout = None
+        if self.fortune_timeout != fortune_timeout:
+            timeout = time() + self.fortune_timeout
+        self.time = (
+            timeout or self.py3.storage_get('time') or (
+                time() + self.fortune_timeout)
+        )
+
+    def _set_fortune(self, state=None, new=False):
+        if not self.fortune_command:
+            return
+        if new:
+            try:
+                fortune_data = self.py3.command_output(self.fortune_command)
+            except:
+                self.fortune = ''
+                self.fortune_command = None
+            else:
+                self.fortune = ' '.join(fortune_data.split())
+                self.time = time() + self.fortune_timeout
+        elif state is None:
+            if self.toggled and time() >= self.time:
+                self._set_fortune(new=True)
+        else:
+            self.toggled = state
+            if state:
+                self._set_fortune(new=True)
+            else:
+                self.fortune = None
+
+    def _set_motion(self):
+        for k in self.motions:
+            self.motions[k] = '' if self.motions[k] else ' '
+
+    def _set_wanda(self):
+        self.index += 1
+        if self.index >= self.wanda_length:
+            self.index = 0
+
+    def wanda_the_fish(self):
+        self._set_fortune()
+        self._set_motion()
+        self._set_wanda()
+
+        return {
+            'cached_until': self.py3.time_in(self.cache_timeout),
+            'full_text': self.py3.safe_format(
+                self.format, {
+                    'fortune': self.fortune,
+                    'motion': self.motions['motion'],
+                    'nomotion': self.motions['nomotion'],
+                    'wanda': self.wanda[self.index],
+                }
+            )
+        }
+
+    def kill(self):
+        self.py3.storage_set('toggled', self.toggled)
+        self.py3.storage_set('fortune', self.fortune)
+        self.py3.storage_set('fortune_timeout', self.fortune_timeout)
+        self.py3.storage_set('time', self.time)
+
+    def on_click(self, event):
+        button = event['button']
+        if not self.fortune_command:
+            return
+        elif button == self.button_toggle:
+            self._set_fortune(False if self.toggled else True)
+        elif button != self.button_refresh:
+            self.py3.prevent_refresh()
+
+
+if __name__ == "__main__":
+    """
+    Run module in test mode.
+    """
+    from py3status.module_test import module_test
+    module_test(Py3status)

--- a/py3status/modules/wanda_the_fish.py
+++ b/py3status/modules/wanda_the_fish.py
@@ -7,8 +7,6 @@ and if loaded, it also takes up precious bar space, memory, and cpu cycles.
 Anybody found using it should be promptly sent for a psychiatric evaluation.
 
 Configuration parameters:
-    button_refresh: mouse button to refresh this module (default 2)
-    button_toggle: mouse button to toggle fortunes (default 1)
     cache_timeout: refresh interval for this module (default 0)
     format: display format for this module
         (default '{nomotion}[{fortune} ]{wanda}{motion}')
@@ -88,8 +86,6 @@ class Py3status:
     """
     """
     # available configuration parameters
-    button_refresh = 2
-    button_toggle = 1
     cache_timeout = 0
     format = '{nomotion}[{fortune} ]{wanda}{motion}'
     fortune_timeout = 60
@@ -174,13 +170,9 @@ class Py3status:
         self.py3.storage_set('time', self.time)
 
     def on_click(self, event):
-        button = event['button']
         if not self.fortune_command:
             return
-        elif button == self.button_toggle:
-            self._set_fortune(False if self.toggled else True)
-        elif button != self.button_refresh:
-            self.py3.prevent_refresh()
+        self._set_fortune(False if self.toggled else True)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Hi. I made a new module `wanda_the_fish`. This module display a fortune-telling, swimming fish.

There was a nice little GNOME2 panel applet where it displays an animated character (a fish) which pops up quotes generated by `fortune`. Simply put, there are people out there who adores `wanda_the_fish` too much. People also made this possible for other DEs too, but we still don't have one for `i3wm`. :frowning_face: 

Now with this module, we can start appreciating `wanda_the_fish` and her fortunes again. :tropical_fish:  :blush: :heart_eyes: :heart_eyes:

![wanda_0](https://user-images.githubusercontent.com/852504/44417744-02e54200-a53c-11e8-9164-05c5eddf1c49.png)
![wanda_1](https://user-images.githubusercontent.com/852504/44417745-02e54200-a53c-11e8-81ef-7a8fede3e977.png)
![wanda_2](https://user-images.githubusercontent.com/852504/44417746-037dd880-a53c-11e8-9463-b92e08924667.png)
![wanda_3](https://user-images.githubusercontent.com/852504/44417748-037dd880-a53c-11e8-8cf1-bf92d0110910.png)
![wanda_4](https://user-images.githubusercontent.com/852504/44417749-037dd880-a53c-11e8-9b44-67e45cb1a9fa.png)
![wanda_5](https://user-images.githubusercontent.com/852504/44417751-04166f00-a53c-11e8-9521-ecb88822b559.png)

