### PR TITLE
sql, timewarrior: fix getattr(self, name) or ''

### DIFF
--- a/py3status/modules/sql.py
+++ b/py3status/modules/sql.py
@@ -131,7 +131,7 @@ class Py3status:
         self.thresholds_init = {}
         for name in ('format', 'format_row'):
             self.thresholds_init[name] = self.py3.get_color_names_list(
-                getattr(self, name) or ''
+                getattr(self, name, '')
             )
 
     def _get_sql_data(self):

--- a/py3status/modules/timewarrior.py
+++ b/py3status/modules/timewarrior.py
@@ -223,7 +223,7 @@ class Py3status:
         self.thresholds_init = {}
         for name in ('format', 'format_tag', 'format_time'):
             self.thresholds_init[name] = self.py3.get_color_names_list(
-                getattr(self, name) or ''
+                getattr(self, name, '')
             )
 
     def _get_timewarrior_data(self):


### PR DESCRIPTION
`getattr(self, name) or ''` --> `getattr(self, name, '')` 