### PR TITLE
sql: don't make placeholders case-sensitive

### DIFF
--- a/py3status/modules/sql.py
+++ b/py3status/modules/sql.py
@@ -18,15 +18,13 @@ Format placeholders:
     Parameters can be placeholders too, eg {host}, {passd}
 
 Format_row placeholders:
-    {xxx} case-sensitive placeholder name often found in the database
-    {xxx} case-sensitive placeholder name often found in the database
-    {xxx} case-sensitive placeholder name often found in the database
+    {field} placeholders will have the value returned by the query for the field
 
 Color thresholds:
     format:
         row: print a color based on the number of SQL rows
     format_row:
-        xxx: print a color based on the value of `xxx` placeholder
+        field: print a color based on the value of `field` placeholder
 
 Requires:
     mariadb: fast sql database server, drop-in replacement for mysql
@@ -65,8 +63,8 @@ sql {
 # display number of seconds behind master with MySQLdb
 sql {
     database = 'MySQLdb'
-    format_row = '\?color=Seconds_Behind_Master {host} is '
-    format_row += '[{Seconds_Behind_Master}s behind|\?show master]'
+    format_row = '\?color=seconds_behind_master {host} is '
+    format_row += '[{seconds_behind_master}s behind|\?show master]'
     parameters = {
         'host': 'localhost',
         'passwd': '********'


### PR DESCRIPTION
I found another future bug of mine after discussing about color names in https://github.com/ultrabug/py3status/pull/1472. Sorry, not sorry.

Initial PR does not have lowercase. I suggested lowercase to enforce our QA.

>@lasers To make this more readable, we should use Python's naming style (for functions) which is lowercase with words separated by underscores.

Later I made commits to address `format_row` and to ensure everything works well. He tested it too to be working well too. Then things went stale in that PR as well as `py3status`. No more communications.

I got role. I looked at this again and saw that we shouldn't lowercase the keys because we don't know what the keys will look like... and the fact that this can use more than one SQL database now too. I supported case-sensitive placeholders, but I neglected to remove `lower()`. This PR fixes my future bug. 

