### PR TITLE
test_formatter: add {None:.2f} to print None, not {None}

### DIFF
--- a/tests/test_formatter.py
+++ b/tests/test_formatter.py
@@ -1017,6 +1017,13 @@ def test_numeric_strings_6():
     })
 
 
+def test_numeric_none():
+    run_formatter({
+        'format': '{None:.2f}',
+        'expected': "None",
+    })
+
+
 def test_not_zero_1():
     run_formatter({
         'format': '[\?not_zero {zero}]',


### PR DESCRIPTION
Add a formatter test for https://github.com/ultrabug/py3status/pull/1426. 

With `{'key': None}` and `format = '{key:.2f}'`... it prints `{key}`. (Before)
With `{'key': None}` and `format = '{key:.2f}'`... it prints `None`. (After)

It was faking `{nonexistent_key}` behavior instead of printing `None`.