### PR TITLE
DO NOT MERGE: config allow base64()

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -131,17 +131,31 @@ Store per config cache in different directories.
 
 Configuration obfuscation
 -------------------------
-
-.. note::
-    New in version 3.1
-
 Py3status allows you to hide individual configuration parameters so that they
 do not leak into log files, user notifications or to the i3bar. Additionally
 they allow you to obfuscate configuration parameters using base64 encoding.
 
+.. note::
+    New in version 3.13
+
+To base64 encode a value you can use the ``base64()`` configuration function.
+
+.. code-block:: py3status
+    :caption: Example
+
+    # Example of obfuscated configuration
+    imap {
+        imap_server = 'imap.myprovider.com'
+        password = base64('Y29jb251dA==')
+        user = 'mylogin'
+    }
+
+.. note::
+    New in version 3.1
+
 To do this you need to add an obfuscation option to the configuration
-parameter. Obfuscation options are added by adding `:hide` or `:base64` to the
-name of the parameters.
+parameter. Obfuscation options are added by adding ``:hide`` or ``:base64`` to
+the name of the parameters.
 
 
 .. note::

--- a/py3status/parse_config.py
+++ b/py3status/parse_config.py
@@ -130,6 +130,7 @@ class ConfigParser:
         # environment variables
         '|(?P<env_var>env\(\s*([0-9a-zA-Z_]+)(\s*,\s*[a-zA-Z_]+)?\s*\))'
         '|(?P<shell>shell\(.+?(\s*,\s*(int|float|str|bool|auto))?\))'  # shell code
+        '|(?P<base64>base64\(\s*([^)]+)\s*\))'  # base64 encode
         '|(?P<operator>[()[\]{},:]|\+?=)'  # operators
         '|(?P<literal>'
         r'("(?:[^"\\]|\\.)*")'  # double quoted string
@@ -249,6 +250,8 @@ class ConfigParser:
                 t_type = 'env_var'
             elif token.group('shell'):
                 t_type = 'shell'
+            elif token.group('base64'):
+                t_type = 'base64'
             elif token.group('unknown'):
                 t_type = 'unknown'
             else:
@@ -390,6 +393,31 @@ class ConfigParser:
         except ValueError:
             self.error('Bad conversion')
 
+    def make_value_from_base64(self, value):
+        """
+        We can base 64 encode stuff using base64() in the config
+        """
+        # remove the 'base64(' and ')' that we get
+        value = value[7:-1]
+        # trim whitespace and remove quotes
+        value = value.strip()
+        if value[0] == value[-1] and value[0] in ['"', "'"]:
+            value = value[1:-1]
+
+        # check we are in a module definition etc
+        if not self.current_module:
+            self.error('base64(..) used outside of module or section')
+
+        # check it is valid base64
+        try:
+            import base64
+            base64.b64decode(value)
+        except TypeError as e:
+            self.error('base64(..) error %s' % str(e))
+
+        module_name = self.current_module[-1]
+        return PrivateBase64(value, module_name)
+
     def separator(self, separator=',', end_token=None):
         '''
         Read through tokens till the required separator is found.  We ignore
@@ -472,6 +500,8 @@ class ConfigParser:
                 return self.make_value_from_env(t_value)
             if token['type'] == 'shell':
                 return self.make_value_from_shell(t_value)
+            if token['type'] == 'base64':
+                return self.make_value_from_base64(t_value)
             elif t_value == '[':
                 return self.make_list()
             elif t_value == '{':
@@ -560,6 +590,8 @@ class ConfigParser:
                 if not name and not re.match('[a-zA-Z_]', value):
                     self.error('Invalid name')
                 name.append(value)
+            elif t_type == 'base64':
+                self.error('Name expected')
             elif t_type == 'env_var':
                 self.error('Name expected')
             elif t_type == 'shell':


### PR DESCRIPTION
So I was looking for issues to close and found  #1211

So it is actually a nice idea so I thought I'd implement it. basically it allow us to use `base64(...)` in the config.  It works like the old base64 stuff in that it tries to keep it secret (not that it really does but it keeps things out of the logs etc).

It does allow functionality lacking before like using inside a dict in the config.

So if this is acceptable ~~I'll knock up some documentation - but I'll wait till there is a request.~~  But closing that would get us to the magic single page of issues

Also looking at the `env()` and `shell()` they could do with a clean up too, as well as unifying the code but again I'd like to get this in first.   Also depreciate the old method as tis fits in with the others