### PR TITLE
config parser: add explicit exceptions

### DIFF
--- a/py3status/parse_config.py
+++ b/py3status/parse_config.py
@@ -180,7 +180,7 @@ class ConfigParser:
         (file, pathname, description) = info
         try:
             py_mod = imp.load_module(name, file, pathname, description)
-        except:  # noqa e722
+        except Exception:
             # We cannot load the module!  We could error out here but then the
             # user gets informed that the problem is with their config.  This
             # is not correct.  Better to say that all is well and then the
@@ -314,11 +314,11 @@ class ConfigParser:
             return value[1:-1].replace("\\'", "'")
         try:
             return int(value)
-        except:  # noqa e722
+        except ValueError:
             pass
         try:
             return float(value)
-        except:  # noqa e722
+        except ValueError:
             pass
         if value.lower() == 'true':
             return True


### PR DESCRIPTION
This add exceptions to the config parser and removes `# noqa`

 `# noqa` flake8 error suppression should be used extremely sparingly and never to just hide errors.  The whole point of flake8 is to help improve code quality so ignoring it's suggestions undermines the point of using it.

I am confident that `ValueError` is the only exception thrown in the casting as I do not believe we can ever have a situation where `TypeError` is raised.

For module import a variety of exceptions can occur and so catching any feels appropriate in this case.