### PR TITLE
config parser: improve unicode support

### DIFF
--- a/py3status/parse_config.py
+++ b/py3status/parse_config.py
@@ -290,7 +290,7 @@ class ConfigParser:
         It is possible to define unicode characters in the config either as the
         actual utf-8 character or using escape sequences the following all will
         show the Greek delta character.
-        Δ \N{GREEK CAPITAL LETTER DELTA} \U00000394  \u0349
+        Δ \N{GREEK CAPITAL LETTER DELTA} \U00000394  \u0394
         '''
         def fix_fn(match):
             # we don't escape an escaped backslash
@@ -298,7 +298,7 @@ class ConfigParser:
                 return r'\\'
             return match.group(0).encode('utf-8').decode('unicode-escape')
         return re.sub(
-            '\\\\\\\\|\\\\u\w{4}|\\\\U\w{8}|\\\\N\{.+\}', fix_fn, value
+            r'\\\\|\\u\w{4}|\\U\w{8}|\\N\{([^}\\]|\\.)+\}', fix_fn, value
         )
 
     def make_value(self, value):


### PR DESCRIPTION
So this fixes two issues but they are very related and the PR is only two lines

1) The comment is somehow corrupt.  With the old version if you paste it into your config you get some weird unicode char `'͉'` [Combining Left Angle Below](https://unicode-table.com/en/0349/) in python3 (not python2).  anyhow it is clearly not `Δ` [capital delta](https://unicode-table.com/en/0394/).  Anyway we fix this

2) update the regex
   * use `r` style string to remove the duplication of backslashes.  

   * change `\\N\{.+\}` to `\\N\{([^}\\]|\\.)+\}` although the pattern is more complicated it is more predictable. essentially we change from. `\N{ .. anything .. }` to `\N{ .. anything that is not a } unless it is escaped .. }`.  Even though I am unaware of any unicode name chars that use an escaped `}` it feels the correct thing to do and I feel is less error prone.


@lasers as an aside this is the level of detail it is nice to have in a PR, explaining what we are doing and why - ok so this is a relatively complex change.  You may also note that I've tried to make my changes into a series of small independent PRs rather than one huge monster.  And as noted at the start this could be two PRs

