### PR TITLE
module: default left align instead of center

### DIFF
--- a/py3status/module.py
+++ b/py3status/module.py
@@ -427,7 +427,7 @@ class Module:
             offset = min_width - ((padding * 2) + width)
 
             # set align
-            align = self.py3_module_options.get('align', 'center')
+            align = self.py3_module_options.get('align', 'left')
             if align == 'center':
                 left = right = ' ' * padding
                 if self.random_int:


### PR DESCRIPTION
Splitting up one huge monster into little cute monsters.... :japanese_ogre: :ghost: :wolf:

I'm defaulting `left` instead of `center` to be more consistent with the i3bar protocol... in case some users switched over from `i3status` and it generally looks more nice in the long run too.

>**align** 
>_Align text on the center, right or left (default) of the block, when the minimum width of the latter, specified by the min_width key, is not reached._

