### PR TITLE
py3status lexer updates for docs

### DIFF
--- a/py3status/autodoc.py
+++ b/py3status/autodoc.py
@@ -7,7 +7,7 @@ import re
 
 from docutils import nodes
 from docutils.parsers.rst import Directive
-from pygments.lexer import RegexLexer
+from pygments.lexer import RegexLexer, bygroups
 import pygments.token as pygments_token
 
 from py3status.docstrings import core_module_docstrings
@@ -33,15 +33,73 @@ class Py3statusLexer(RegexLexer):
 
     tokens = {
         'root': [
-            (r'#.*?$', pygments_token.Comment),
-            (r'"(?:[^"\\]|\\.)*"', pygments_token.String.Double),
-            (r"'(?:[^'\\]|\\.)*'", pygments_token.String.Single),
-            (r'([0-9]+)|([0-9]*)\.([0-9]*)', pygments_token.Number),
-            (r'True|False|None', pygments_token.Literal),
-            (r'(\+=)|=', pygments_token.Operator),
-            (r'\s+', pygments_token.Text),
-            (r'[{}\[\](),:]', pygments_token.Text,),
-            (r'\S+', pygments_token.Keyword),
+            (  # comments
+                r'#.*?$', pygments_token.Comment
+            ),
+            (  # double quoted strings
+                r'"(?:[^"\\]|\\.)*"', pygments_token.String.Double
+            ),
+            (  # single quoted strings
+                r"'(?:[^'\\]|\\.)*'", pygments_token.String.Single
+            ),
+            (  # numbers
+                r'([0-9]+)|([0-9]*)\.([0-9]*)', pygments_token.Number
+            ),
+            (  # True, False & None
+                r'True|False|None', pygments_token.Literal
+            ),
+            (  # = and +=
+                r'(\+=)|=', pygments_token.Operator
+            ),
+            (  # other things like (){}[],:
+                r'[{}\[\](),:]', pygments_token.Punctuation
+            ),
+            (  # config functions eg env(value, type)
+                r'(\S+)([(])(.*?)((\s*,\s*)(\w+))?([)])',
+                bygroups(
+                    pygments_token.Name.Function,
+                    pygments_token.Punctuation,
+                    pygments_token.Literal,
+                    None,
+                    pygments_token.Punctuation,
+                    pygments_token.Keyword.Type,
+                    pygments_token.Punctuation,
+                )
+            ),
+            (  # module names
+                r'(\S+)(\s*)([^=]*)(\s*)(\{)',
+                bygroups(
+                    pygments_token.Keyword.Reserved,
+                    pygments_token.Whitespace,
+                    pygments_token.Keyword.Reserved,
+                    pygments_token.Whitespace,
+                    pygments_token.Punctuation,
+                )
+            ),
+            (  # order += ....
+                r'^(order)(\s+)(\+=)',
+                bygroups(
+                    pygments_token.Keyword.Reserved,
+                    pygments_token.Whitespace,
+                    pygments_token.Punctuation,
+                )
+            ),
+            (  # on_click x
+                r'on_click\s*\d',
+                pygments_token.Name.Variable,
+            ),
+            (  # module parameters
+                r'(\w+)((:)(\S+))?',
+                bygroups(
+                    pygments_token.Name.Variable,
+                    None,
+                    pygments_token.Punctuation,
+                    pygments_token.Keyword.Type,
+                )
+            ),
+            (  # whitespace
+                r'\s+', pygments_token.Whitespace
+            ),
         ],
     }
 


### PR DESCRIPTION
So I was looking at the docs and things are getting a mess with the config syntax highlighting.
Things have got more complicated and the highlighting was always fairly basic.

I think the `shell(..)` and `env(..)` where the final straw.
https://py3status.readthedocs.io/en/latest/configuration.html#environment-variables

Anyhow this gives us a ~~spring~~autumn clean and makes everything super shiny once again.  Anyhow it's all fairly ugly regex stuff and seeing as I'm the only one who works on this bit I'm not going to go into much detail.  But there are some new comments (mainly for me when I revisit this in a couple of years or so)

if you are testing make sure to `make clean html` or else you won't get a clean build

No screenshots to preserve the mystery
