### PR TITLE
core: add short_text support [wip]

### DIFF
--- a/py3status/core.py
+++ b/py3status/core.py
@@ -908,7 +908,6 @@ class Py3statusWrapper:
                 output_modules[name]['module'] = self.modules[name]
                 output_modules[name]['type'] = 'py3status'
                 output_modules[name]['color'] = self.mappings_color.get(name)
-                output_modules[name]['short_format'] = self.mappings_short_format.get(name)
         # i3status modules
         for name in i3modules:
             if name not in output_modules:
@@ -917,7 +916,6 @@ class Py3statusWrapper:
                 output_modules[name]['module'] = i3modules[name]
                 output_modules[name]['type'] = 'i3status'
                 output_modules[name]['color'] = self.mappings_color.get(name)
-                output_modules[name]['short_format'] = self.mappings_short_format.get(name)
 
         self.output_modules = output_modules
 
@@ -935,30 +933,23 @@ class Py3statusWrapper:
                 color = None
             mappings[name] = color
 
-            short_format = self.get_config_attribute(name, 'short_format')
-            if hasattr(short_format, 'none_setting'):
-                short_format = None
-            mappings[name] = short_format
-
         # Store mappings for later use.
         self.mappings_color = mappings
-        self.mappings_short_format = mappings
 
     def process_module_output(self, module):
         """
         Process the output for a module and return a json string representing it.
         Color processing occurs here.
-        Shortened text 'short_text' processing occurs here.
         """
         outputs = module['module'].get_latest()
         color = module['color']
-        short_format = module['short_format']
 
         for output in outputs:
             if color:
                 # Color: substitute the config defined color
                 if "color" not in output:
                     output["color"] = color
+
         # Create the json string output.
         return ",".join([dumps(x) for x in outputs])
 

--- a/py3status/core.py
+++ b/py3status/core.py
@@ -932,13 +932,21 @@ class Py3statusWrapper:
             if hasattr(color, "none_setting"):
                 color = None
             mappings[name] = color
+
+            max_size = self.get_config_attribute(name, 'max_size')
+            if hasattr(max_size, 'none_setting'):
+                max_size = None
+            mappings[name] = max_size
+
         # Store mappings for later use.
+        self.mappings_max_size = mappings
         self.mappings_color = mappings
 
     def process_module_output(self, module):
         """
         Process the output for a module and return a json string representing it.
         Color processing occurs here.
+        Shortened text 'short_text' processing occurs here.
         """
         outputs = module["module"].get_latest()
         color = module["color"]

--- a/py3status/core.py
+++ b/py3status/core.py
@@ -904,18 +904,20 @@ class Py3statusWrapper:
         for name in self.modules:
             if name not in output_modules:
                 output_modules[name] = {}
-                output_modules[name]["position"] = positions.get(name, [])
-                output_modules[name]["module"] = self.modules[name]
-                output_modules[name]["type"] = "py3status"
-                output_modules[name]["color"] = self.mappings_color.get(name)
+                output_modules[name]['position'] = positions.get(name, [])
+                output_modules[name]['module'] = self.modules[name]
+                output_modules[name]['type'] = 'py3status'
+                output_modules[name]['color'] = self.mappings_color.get(name)
+                output_modules[name]['short_format'] = self.mappings_short_format.get(name)
         # i3status modules
         for name in i3modules:
             if name not in output_modules:
                 output_modules[name] = {}
-                output_modules[name]["position"] = positions.get(name, [])
-                output_modules[name]["module"] = i3modules[name]
-                output_modules[name]["type"] = "i3status"
-                output_modules[name]["color"] = self.mappings_color.get(name)
+                output_modules[name]['position'] = positions.get(name, [])
+                output_modules[name]['module'] = i3modules[name]
+                output_modules[name]['type'] = 'i3status'
+                output_modules[name]['color'] = self.mappings_color.get(name)
+                output_modules[name]['short_format'] = self.mappings_short_format.get(name)
 
         self.output_modules = output_modules
 
@@ -933,14 +935,14 @@ class Py3statusWrapper:
                 color = None
             mappings[name] = color
 
-            max_size = self.get_config_attribute(name, 'max_size')
-            if hasattr(max_size, 'none_setting'):
-                max_size = None
-            mappings[name] = max_size
+            short_format = self.get_config_attribute(name, 'short_format')
+            if hasattr(short_format, 'none_setting'):
+                short_format = None
+            mappings[name] = short_format
 
         # Store mappings for later use.
-        self.mappings_max_size = mappings
         self.mappings_color = mappings
+        self.mappings_short_format = mappings
 
     def process_module_output(self, module):
         """
@@ -948,10 +950,12 @@ class Py3statusWrapper:
         Color processing occurs here.
         Shortened text 'short_text' processing occurs here.
         """
-        outputs = module["module"].get_latest()
-        color = module["color"]
-        if color:
-            for output in outputs:
+        outputs = module['module'].get_latest()
+        color = module['color']
+        short_format = module['short_format']
+
+        for output in outputs:
+            if color:
                 # Color: substitute the config defined color
                 if "color" not in output:
                     output["color"] = color

--- a/py3status/module.py
+++ b/py3status/module.py
@@ -190,10 +190,11 @@ class Module:
             color = None
 
         error = {
-            "full_text": message,
-            "color": color,
-            "instance": self.module_inst,
-            "name": self.module_name,
+            'full_text': message,
+            'short_text': message,
+            'color': color,
+            'instance': self.module_inst,
+            'name': self.module_name,
         }
         for method in self.methods.values():
             if method_affected and method["method"] != method_affected:
@@ -279,7 +280,7 @@ class Module:
                 output.extend(data)
             else:
                 # if the output is not 'valid' then don't add it.
-                if data.get("full_text") or "separator" in data:
+                if data.get('full_text') or data.get('short_text') or 'separator' in data:
                     if self.testing:
                         data["cached_until"] = method.get("cached_until")
                     output.append(data)
@@ -682,12 +683,16 @@ class Module:
                             # the method_obj stores infos about each method
                             # of this module.
                             method_obj = {
-                                "cached_until": time(),
-                                "call_type": params_type,
-                                "instance": None,
-                                "last_output": {"name": method, "full_text": ""},
-                                "method": method,
-                                "name": None,
+                                'cached_until': time(),
+                                'call_type': params_type,
+                                'instance': None,
+                                'last_output': {
+                                    'name': method,
+                                    'full_text': '',
+                                    'short_text': ''
+                                },
+                                'method': method,
+                                'name': None
                             }
                             self.methods[method] = method_obj
 

--- a/py3status/module.py
+++ b/py3status/module.py
@@ -659,6 +659,15 @@ class Module:
                 param = True
             self.allow_urgent = param
 
+            # max_size
+            # get the value form the config or use the module default if
+            # supplied.
+            fn = self._py3_wrapper.get_config_attribute
+            param = fn(self.module_full_name, 'max_size')
+            if hasattr(param, 'none_setting'):
+                param = True
+            self.max_size = param
+
             # get the available methods for execution
             for method in sorted(dir(class_inst)):
                 if method.startswith("_"):

--- a/py3status/module.py
+++ b/py3status/module.py
@@ -650,8 +650,7 @@ class Module:
             if not hasattr(self.module_class, "py3"):
                 setattr(self.module_class, "py3", Py3(self))
 
-            # allow_urgent
-            # get the value form the config or use the module default if
+            # get the value from the config or use the module default if
             # supplied.
             fn = self._py3_wrapper.get_config_attribute
             param = fn(self.module_full_name, "allow_urgent")
@@ -660,9 +659,6 @@ class Module:
             self.allow_urgent = param
 
             # max_size
-            # get the value form the config or use the module default if
-            # supplied.
-            fn = self._py3_wrapper.get_config_attribute
             param = fn(self.module_full_name, 'max_size')
             if hasattr(param, 'none_setting'):
                 param = True

--- a/py3status/modules/wwan.py
+++ b/py3status/modules/wwan.py
@@ -563,7 +563,8 @@ class Py3status:
 
         response = {
             'cached_until': self.py3.time_in(self.cache_timeout),
-            'full_text': self.py3.safe_format(self.format, wwan_data)
+            'full_text': self.py3.safe_format(self.format, wwan_data),
+            'short_text': self.py3.safe_format(self.short_format, wwan_data)
         }
         if urgent:
             response['urgent'] = True

--- a/tox.ini
+++ b/tox.ini
@@ -4,14 +4,10 @@ skip_missing_interpreters = True
 [testenv]
 skip_install = True
 deps =
-    coverage
     pytest
     pytest-flake8
 commands =
     pytest --flake8
-    coverage erase
-    coverage run --omit=**/__init__.py --source=modules -m py.test
-    coverage report
 
 [testenv:py36]
 skip_install = True

--- a/tox.ini
+++ b/tox.ini
@@ -4,10 +4,14 @@ skip_missing_interpreters = True
 [testenv]
 skip_install = True
 deps =
+    coverage
     pytest
     pytest-flake8
 commands =
     pytest --flake8
+    coverage erase
+    coverage run --omit=**/__init__.py --source=modules -m py.test
+    coverage report
 
 [testenv:py36]
 skip_install = True


### PR DESCRIPTION
Hi guys,

I started this branch few months ago, this is an @ultrabug request 😉 
I prefer open the PR before forget the tasks.
I just rebased on master, fix travis complain.

The goal is to support the short text feature which shrink text when no more space is available.

When I done the branch, this was working, but it is very simple implementation.

What we have for the moment (if i remember correctly my work):
* max_size = true , if true will auto shrink if needed to display max info.
* max_size = value will shrink all format to the value size.
* short_format per module, which define a cleaner choosen format if no space avaible.

for eg, wwan module:
```
        response = {
            'cached_until': self.py3.time_in(self.cache_timeout),
            'full_text': self.py3.safe_format(self.format, wwan_data),
            'short_text': self.py3.safe_format(self.short_format, wwan_data)
        }
```
its config:
```
wwan {
...
short_format = '[\?color=state state ]'
...
}
```

Now few questions, need help to progress.
As you see, short_text if defined in the module. 
How to implement this for all module without pass on all? I can batch the edit of all module but is it the best way to do?

To be continued...
If you have advise before i continue (or not?).
edit: sorry I have noise if files changed (search "short" ^^)