### PR TITLE
parse_config: decode bytes

### DIFF
--- a/py3status/parse_config.py
+++ b/py3status/parse_config.py
@@ -435,7 +435,7 @@ class ConfigParser:
         if function == 'base64':
             try:
                 import base64
-                value = base64.b64decode(value)
+                value = base64.b64decode(value).decode('utf-8')
             except TypeError as e:
                 self.notify_user('base64(..) error %s' % str(e))
 


### PR DESCRIPTION
This decodes bytes. Allow `base64()` and friends to work on Python3 too.

Bug acknowledged in https://github.com/ultrabug/py3status/issues/1211. ~~EDIT: Testing other values too...~~