### PR TITLE
Revert formatter changes

### DIFF
--- a/py3status/formatter.py
+++ b/py3status/formatter.py
@@ -314,9 +314,7 @@ class Placeholder:
                 output = u'{%s%s}' % (self.key, self.format)
                 value = value_ = output.format(**{self.key: value})
 
-            if block.parent is None:
-                valid = True
-            elif block.commands.not_zero:
+            if block.commands.not_zero:
                 valid = value_ not in ['', 'None', None, False, '0', '0.0', 0, 0.0]
             else:
                 # '', None, and False are ignored

--- a/py3status/formatter.py
+++ b/py3status/formatter.py
@@ -315,11 +315,11 @@ class Placeholder:
                 value = value_ = output.format(**{self.key: value})
 
             if block.commands.not_zero:
-                valid = value_ not in ['', 'None', None, False, '0', '0.0', 0, 0.0]
+                valid = value_ not in ['', None, False, '0', '0.0', 0, 0.0]
             else:
                 # '', None, and False are ignored
                 # numbers like 0 and 0.0 are not.
-                valid = not (value_ in ['', 'None', None] or value_ is False)
+                valid = not (value_ in ['', None] or value_ is False)
             enough = False
         except:  # noqa e722
             # Exception raised when we don't have the param

--- a/tests/test_formatter.py
+++ b/tests/test_formatter.py
@@ -328,18 +328,10 @@ def test_26():
 
 
 def test_27():
-    run_formatter({'format': '{None}', 'expected': 'None', })
+    run_formatter({'format': '{None}', 'expected': '', })
 
 
 def test_27a():
-    run_formatter({'format': '{None} {no}', 'expected': 'None False', })
-
-
-def test_27b():
-    run_formatter({'format': '[Hello {None}] {no}', 'expected': ' False', })
-
-
-def test_27c():
     run_formatter({'format': '[Hi, my name is {None_str}]', 'expected': '', })
 
 
@@ -352,7 +344,7 @@ def test_29():
 
 
 def test_30():
-    run_formatter({'format': '{no}', 'expected': 'False', })
+    run_formatter({'format': '{no}', 'expected': '', })
 
 
 def test_31():
@@ -1182,7 +1174,7 @@ def test_module_true_value():
 
 
 def test_module_false_value():
-    run_formatter({'format': '{module_false}', 'expected': 'False'})
+    run_formatter({'format': '{module_false}', 'expected': ''})
 
 
 def test_zero_format_1():

--- a/tests/test_formatter.py
+++ b/tests/test_formatter.py
@@ -27,7 +27,6 @@ param_dict = {
     'no': False,
     'empty': '',
     'None': None,
-    'None_str': 'None',
     '?bad name': 'evil',
     u'☂ Very bad name ': u'☂ extremely evil',
     'long_str': 'I am a long string though not too long',
@@ -329,10 +328,6 @@ def test_26():
 
 def test_27():
     run_formatter({'format': '{None}', 'expected': '', })
-
-
-def test_27a():
-    run_formatter({'format': '[Hi, my name is {None_str}]', 'expected': '', })
 
 
 def test_28():


### PR DESCRIPTION
@ultrabug 

This reverts 2 commits. related to the formatter.

These change the behaviour of the formatter.  I feel we need to better understand what we want from the formatter rather than @lasers changing it because he has an issue with some module he is writing.

* maybe we should change some of the behaviours but it should be a concious choice.

* @lasers could easily make his modules work correctly I think if he thought about things a little more and used some tricks like the attr_getter functionality of the formatter.

The first commit I objected to and don't feel that accepting the PR was the correct decision because I don't think it was thought through, I agree that I have been somewhat absent in the recent past.

The last commit was just merged by the author which I think is not good.  The only urgency is @lasers module writing and he might better spend his time getting any one of his PRs up to scratch rather than writing as much code as possible.  We need to be upping the code quality especially in core not creating more of a mess as we go.

Anyhow that's my take here.  If we make a release with these changes I will not be a happy bunny

I think we should revert the changes and then discuss the issue maybe on irc over few days to try to get some agreement.

