### PR TITLE
timewarrior: fix cosemitc issues with format_duration

### DIFF
--- a/py3status/modules/timewarrior.py
+++ b/py3status/modules/timewarrior.py
@@ -52,14 +52,10 @@ format_datetime placeholders:
     value: strftime characters, eg '%b %d' ----> 'Oct 06'
 
 format_duration placeholders:
-    {years} years
-    {months} months
-    {weeks} weeks
     {days} days
     {hours} hours
     {minutes} minutes
     {seconds} seconds
-    {microseconds} microseconds
 
 Color thresholds:
     format_time:
@@ -276,14 +272,10 @@ class Py3status:
 
             time['format_duration'] = self.py3.safe_format(
                 self.format_duration, {
-                    'years': duration.years,
-                    'months': duration.months,
-                    'weeks': duration.weeks,
                     'days': duration.days,
                     'hours': duration.hours,
                     'minutes': duration.minutes,
                     'seconds': duration.seconds,
-                    'microseconds': duration.microseconds
                 }
             )
 

--- a/py3status/modules/timewarrior.py
+++ b/py3status/modules/timewarrior.py
@@ -23,7 +23,7 @@ Configuration parameters:
         (default '[Timew {format_time}]|No Timew')
     format_datetime: specify strftime characters to format (default {})
     format_duration: display format for time duration
-        (default '\?not_zero [{days}d ][{hours}:]{minutes:02d}:{seconds:02d}')
+        (default '\?not_zero [{days}d ][{hours}:]{minutes}:{seconds}')
     format_tag: display format for tags (default '\?color=state_tag {name}')
     format_tag_separator: show separator if more than one (default ' ')
     format_time: display format for tracked times
@@ -181,7 +181,7 @@ class Py3status:
     filter = None
     format = '[Timew {format_time}]|No Timew'
     format_datetime = {}
-    format_duration = '\?not_zero [{days}d ][{hours}:]{minutes:02d}:{seconds:02d}'
+    format_duration = '\?not_zero [{days}d ][{hours}:]{minutes}:{seconds}'
     format_tag = '\?color=state_tag {name}'
     format_tag_separator = ' '
     format_time = '[\?color=state_time [{format_tag} ]{format_duration}]'
@@ -190,6 +190,19 @@ class Py3status:
         'state_tag': [(0, 'darkgray'), (1, 'darkgray')],
         'state_time': [(0, 'darkgray'), (1, 'degraded')],
     }
+
+    class Meta:
+        update_config = {
+            'update_placeholder_format': [
+                {
+                    'placeholder_formats': {
+                        'minutes': ':02d',
+                        'seconds': ':02d',
+                    },
+                    'format_strings': ['format_duration'],
+                }
+            ],
+        }
 
     def post_config_hook(self):
         if not self.py3.check_commands('timew'):

--- a/py3status/modules/timewarrior.py
+++ b/py3status/modules/timewarrior.py
@@ -23,8 +23,7 @@ Configuration parameters:
         (default '[Timew {format_time}]|No Timew')
     format_datetime: specify strftime characters to format (default {})
     format_duration: display format for time duration
-        *(default '\?not_zero [{years}y ][{months}m ][{weeks}w ]'
-        '[{days}d ][{hours}:]{minutes:02d}:{seconds:02d}')*
+        (default '\?not_zero [{days}d ][{hours}:]{minutes:02d}:{seconds:02d}')
     format_tag: display format for tags (default '\?color=state_tag {name}')
     format_tag_separator: show separator if more than one (default ' ')
     format_time: display format for tracked times
@@ -182,8 +181,7 @@ class Py3status:
     filter = None
     format = '[Timew {format_time}]|No Timew'
     format_datetime = {}
-    format_duration = ('\?not_zero [{years}y ][{months}m ][{weeks}w ]'
-                       '[{days}d ][{hours}:]{minutes:02d}:{seconds:02d}')
+    format_duration = '\?not_zero [{days}d ][{hours}:]{minutes:02d}:{seconds:02d}'
     format_tag = '\?color=state_tag {name}'
     format_tag_separator = ' '
     format_time = '[\?color=state_time [{format_tag} ]{format_duration}]'

--- a/py3status/modules/timewarrior.py
+++ b/py3status/modules/timewarrior.py
@@ -23,8 +23,8 @@ Configuration parameters:
         (default '[Timew {format_time}]|No Timew')
     format_datetime: specify strftime characters to format (default {})
     format_duration: display format for time duration
-        *(default '\?not_zero [{years}y][{months}m][{weeks}w][{days}d]'
-        '[\?soft  ][{hours}:]{minutes:02d}:{seconds:02d}')*
+        *(default '\?not_zero [{years}y ][{months}m ][{weeks}w ]'
+        '[{days}d ][{hours}:]{minutes:02d}:{seconds:02d}')*
     format_tag: display format for tags (default '\?color=state_tag {name}')
     format_tag_separator: show separator if more than one (default ' ')
     format_time: display format for tracked times
@@ -182,8 +182,8 @@ class Py3status:
     filter = None
     format = '[Timew {format_time}]|No Timew'
     format_datetime = {}
-    format_duration = ('\?not_zero [{years}y][{months}m][{weeks}w][{days}d]'
-                       '[\?soft  ][{hours}:]{minutes:02d}:{seconds:02d}')
+    format_duration = ('\?not_zero [{years}y ][{months}m ][{weeks}w ]'
+                       '[{days}d ][{hours}:]{minutes:02d}:{seconds:02d}')
     format_tag = '\?color=state_tag {name}'
     format_tag_separator = ' '
     format_time = '[\?color=state_time [{format_tag} ]{format_duration}]'


### PR DESCRIPTION
Cosemitc bug. `1w12d 5:13:29` (before) vs `1w 12d 5:13:29` (after). Idk I had active time interval.

EDIT: It's 1 week 5 day something.... or 12 days, 5 hours something.

I don't believe we're meant to use `{days}`, `{weeks}`, `{months}`, `{years}` at same time in `format_duration`, but real users of `timew` probably wouldn't leave this running for more than few hours if they wanted to track their time so I'm suggesting to leave this format as-is.

Second thoughts... It's probably better if I take out `{weeks}`, `{months}`, `{years}`.  EDIT: Done.

EDIT: I defaults minutes and seconds with `:02d` too. Don't cause users pain. Thx.

EDIT: Maybe I should remove impractical placeholders `years`, `months`, `weeks`, `microseconds`?