### PR TITLE
Update Arch Linux installation instructions for official package

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -99,14 +99,10 @@ Using emerge:
 
 Arch Linux
 ----------
-Thanks to @Horgix, py3status is present in the Arch User Repository:
+Using pacman:
+::
 
-- `py3status <https://aur.archlinux.org/packages/py3status>`_, which is a
-  stable version updated at each release
-- `py3status-git <https://aur.archlinux.org/packages/py3status-git/>`_, which
-  builds directly against the upstream master branch
-
-Thanks to @waaaaargh and @carstene1ns for initially creating the packages.
+   $ pacman -S py3status
 
 Fedora
 ------


### PR DESCRIPTION
Hi there,

As of today, the AUR package have been adopted in `[community]` by [the Arch Linux Trusted User _Morten Linderud_](https://www.archlinux.org/people/trusted-users/#Foxboron) and is now an **officially maintained package** :tada: 

Consequently, [the AUR package has been removed](https://lists.archlinux.org/pipermail/aur-requests/2018-September/026688.html) and I'll only keep maintaining the [`py3status-git`](https://aur.archlinux.org/packages/py3status-git/) package which almost never needs anything done.

It was a pleasure maintaining the `py3status` package for so long!

This PR updates the installation instructions according to [this new package home](https://www.archlinux.org/packages/community/any/py3status/) :slightly_smiling_face: 