### PR TITLE
mpd_status: Add deprecation waring for state_{play,pause,stop}

### DIFF
--- a/py3status/modules/mpd_status.py
+++ b/py3status/modules/mpd_status.py
@@ -98,6 +98,26 @@ def song_attr(song, attr):
 class Py3status:
     """
     """
+
+    class Meta:
+
+        deprecated = {
+            'remove': [
+                {
+                    'param': 'state_pause',
+                    'msg': 'Removing for easier if-statements in the formater.'
+                },
+                {
+                    'param': 'state_play',
+                    'msg': 'Removing for easier if-statements in the formater.'
+                },
+                {
+                    'param': 'state_stop',
+                    'msg': 'Removing for easier if-statements in the formater.'
+                }
+            ] 
+        }
+
     # available configuration parameters
     cache_timeout = 2
     format = '{state} [[[{artist}] - {title}]|[{file}]]'


### PR DESCRIPTION
I'd like to remove the state_{play,pause,stop} config-options to make it easier to write if-statements for this module in the format. This is a pull request to give people the time to change their format-strings.

As I don't see an easy possibility to remove the options while retaining the old functionality there are no actual changes to the code. I will make another pull request in a month to remove the config-options.