### PR TITLE
Some commands in some environments does require LANGUAGE=C to print output in english.

### DIFF
--- a/py3status/py3.py
+++ b/py3status/py3.py
@@ -109,6 +109,7 @@ class Py3:
         self._config_setting = {}
         self._english_env = dict(os.environ)
         self._english_env['LC_ALL'] = 'C'
+        self._english_env['LANGUAGE'] = 'C'
         self._format_placeholders = {}
         self._format_placeholders_cache = {}
         self._is_python_2 = sys.version_info < (3, 0)


### PR DESCRIPTION
Add `LANGUAGE="C"` to "English" environment so that commands like `hamster` will print output in English (esp. on systems where `LANGUAGE` is set to something different).

Useful link about locale-related environment variables:
[https://www.gnu.org/software/gettext/manual/html_node/Locale-Environment-Variables.html#Locale-Environment-Variables](https://www.gnu.org/software/gettext/manual/html_node/Locale-Environment-Variables.html#Locale-Environment-Variables)