### PR TITLE
module_test: print modules in terminal

### DIFF
--- a/doc/writing_modules.rst
+++ b/doc/writing_modules.rst
@@ -805,4 +805,21 @@ can be done as follows.
         module_test(Py3status, config=config)
 
 Such modules can then be tested independently by running
-``python path/to/module``
+``python /path/to/module.py``.
+
+.. code-block:: bash
+    $ python loadavg.py
+    [{'full_text': 'Loadavg ', 'separator': False,
+    'separator_block_width': 0, 'cached_until': 1538755796.0},
+    {'full_text': '1.87 1.73 1.87', 'color': '#9DD7FB'}]
+    ^C
+
+We also can produce an output similar to i3bar output in terminal with
+``python /path/to/module.py --term``.
+
+.. code-block:: bash
+    $ python loadavg.py --term
+    Loadavg 1.41 1.61 1.82
+    Loadavg 1.41 1.61 1.82
+    Loadavg 1.41 1.61 1.82
+    ^C

--- a/py3status/module_test.py
+++ b/py3status/module_test.py
@@ -1,3 +1,4 @@
+from sys import argv
 from threading import Event
 from time import sleep, time
 
@@ -79,9 +80,22 @@ def module_test(module_class, config=None):
                     del item["instance"]
                 if "name" in item:
                     del item["name"]
-            if len(output) == 1:
-                output = output[0]
-            print(output)
+
+            if '--term' in argv:
+                line = ''
+                for item in output:
+                    color = item.get('color')
+                    if color:
+                        line += '\033[38;2;{};{};{}m'.format(
+                            *[int(color[1:][i:i + 2], 16) for i in (0, 2, 4)]
+                        )
+                    line += item['full_text'] + '\033[0m'
+                print(line)
+            else:
+                if len(output) == 1:
+                    output = output[0]
+                print(output)
+
             sleep(1)
         except KeyboardInterrupt:
             m.kill()


### PR DESCRIPTION
This allows us to produce an output similar to the i3bar output in terminal with `--term`.

![2018-10-05-161851_754x540_scrot](https://user-images.githubusercontent.com/852504/46560772-8ecbe700-c8ba-11e8-9702-57ad0e3862cf.png)
