### PR TITLE
mail: add IMAP-subfolder checking

### DIFF
--- a/py3status/modules/mail.py
+++ b/py3status/modules/mail.py
@@ -72,7 +72,7 @@ mail {                                       #
                 'server': 'imap.yahoo.com',  #
                                              # <---- no port, use port 993
                 'urgent': False,             # <---- disable urgent
-            }                                #
+            },                               #
             {                                #      │    └── {imap_3}
                 'name': 'subfolder',         # <----│---------└── {subfolder}
                 'user': 'tobes',             #      │
@@ -80,16 +80,16 @@ mail {                                       #
                 'server': 'imap.yahoo.com',  #
                                              # <---- no port, use port 993
                 'urgent': False,             # <---- disable urgent
-                'folder_whitelist': ['py3']  # <---- check only py3 folder for new mail
-            }                                #
+                'folder_whitelist': ['py3']  # <---- check only py3 folder for new mail  # noqa: E501
+            },                               #
             {                                #      │    └── {imap_4}
-                'name': 'subfolder2',              # <----│---------└── {subfolder2}
+                'name': 'subfolder2'         # <----│---------└── {subfolder2}
                 'user': 'tobes',             #      │
                 'password': 'i_love_python', #
                 'server': 'imap.yahoo.com',  #
                                              # <---- no port, use port 993
                 'urgent': False,             # <---- disable urgent
-                'check_subfolders': True     # <---- check subfolders for this account
+                'check_subfolders': True     # <---- check subfolders for this account  # noqa: E501
                 'folder_blacklist': ['py3']  #    └── but not py3 folder
             }                                #
         ]

--- a/py3status/modules/mail.py
+++ b/py3status/modules/mail.py
@@ -7,8 +7,6 @@ Configuration parameters:
     accounts: specify a dict consisting of mailbox types and a list of dicts
         consisting of mailbox settings and/or paths to use (default {})
     cache_timeout: refresh interval for this module (default 60)
-    check_imap_subfolders: should imap subfolders be checked
-        (default False)
     format: display format for this module
         (default '\?not_zero Mail {mail}|No Mail')
     thresholds: specify color thresholds to use (default [])
@@ -74,6 +72,25 @@ mail {                                       #
                 'server': 'imap.yahoo.com',  #
                                              # <---- no port, use port 993
                 'urgent': False,             # <---- disable urgent
+            }                                #
+            {                                #      │    └── {imap_3}
+                'name': 'subfolder',         # <----│---------└── {subfolder}
+                'user': 'tobes',             #      │
+                'password': 'i_love_python', #
+                'server': 'imap.yahoo.com',  #
+                                             # <---- no port, use port 993
+                'urgent': False,             # <---- disable urgent
+                'folder_whitelist': ['py3']  # <---- check only py3 folder for new mail
+            }                                #
+            {                                #      │    └── {imap_4}
+                'name': 'subfolder2',              # <----│---------└── {subfolder2}
+                'user': 'tobes',             #      │
+                'password': 'i_love_python', #
+                'server': 'imap.yahoo.com',  #
+                                             # <---- no port, use port 993
+                'urgent': False,             # <---- disable urgent
+                'check_subfolders': True     # <---- check subfolders for this account
+                'folder_blacklist': ['py3']  #    └── but not py3 folder
             }                                #
         ]
     }

--- a/py3status/modules/mail.py
+++ b/py3status/modules/mail.py
@@ -27,6 +27,24 @@ Format placeholders:
 Color thresholds:
     xxx: print a color based on the value of `xxx` placeholder
 
+IMAP Subscriptions:
+    You can specify a list of filters to decide what to subscribe.
+    By default, we subscribe only to INBOX folder (ie: `'filter': ['INBOX']`).
+    It is also possible to use regular expressions to subscribe to folders.
+    If you use multiple regular expressions they are combined by a logical `or`.
+    So if you use `.*` to subscribe to all folders you won't be able to remove one.
+
+    `'pattern'` will match a folder `pattern`.
+    `[Pp]attern` will match folders `pattern` and `Pattern`.
+    `.*` will match all folders.
+    `^pattern` will match folders beginning with `pattern`.
+    `pattern$` will match folders ending with `pattern`.
+    `^((?![Ss][Pp][Aa][Mm]).)*$` will exclude every possible case of folders
+        with spam in name and subscribe to all other folders.
+
+    For more documentation, see https://docs.python.org/3/library/re.html
+    and/or any regex builder on the web.
+
 Examples:
 ```
 # add multiple accounts

--- a/py3status/modules/mail.py
+++ b/py3status/modules/mail.py
@@ -156,7 +156,7 @@ no_mail
 import mailbox
 from imaplib import IMAP4_SSL
 from os.path import exists, expanduser, expandvars
-
+from csv import reader
 STRING_MISSING = 'missing {} {}'
 STRING_INVALID_NAME = 'invalid name `{}`'
 STRING_INVALID_BOX = 'invalid mailbox `{}`'
@@ -231,11 +231,13 @@ class Py3status:
                     if account['check_subfolders'] or \
                             account['folder_whitelist']:
                         count_mail = 0
-                        for mbox in inbox.list()[1]:
-                            # Don't remove the quotes from the return string as
+                        mlist = [x.decode('utf-8') for x in inbox.list()[1]]
+                        mlist = [x[-1][:] for x in reader(mlist, delimiter=' ')]  # noqa: E501
+                        for mbox in mlist:
+                            mbox = '"' + mbox + '"'
+                            # Don't remove the quotes from the string as
                             # that would make the script unable to access all
                             # mailfolders with special characters.
-                            mbox = mbox.decode('utf-8').split(' "." ')[1]
                             if mbox[1:-1] in account['folder_blacklist'] or \
                                     (not account['check_subfolders'] and
                                      not mbox[1:-1] in account['folder_whitelist']):  # noqa: E501

--- a/py3status/modules/mail.py
+++ b/py3status/modules/mail.py
@@ -212,7 +212,7 @@ class Py3status:
                     if self.check_imap_subfolders:
                         count_mail = 0
                         for mbox in inbox.list()[1]:
-                            # Don't remove the quots from the return string as
+                            # Don't remove the quotes from the return string as
                             # that would make the script unable to access all
                             # mailfolders with special characters.
                             mbox = mbox.decode('utf-8').split(' "." ')[1]


### PR DESCRIPTION
This allows the mail module to check for new mail in IMAP-subfolders and not only in INBOX. Useful when automatically sorting mail.