### PR TITLE
Mail namecollision

### DIFF
--- a/py3status/modules/mail.py
+++ b/py3status/modules/mail.py
@@ -22,7 +22,8 @@ Format placeholders:
 
     We can divide mailbox, eg `{maildir}`, into numbered placeholders based
     on number of mailbox accounts, eg `{maildir_1}`, and if we add `name` to
-    a mailbox account, we can use `{acc_'name'}` placeholder instead, eg `{acc_home}`.
+    a mailbox account, we can use `{acc_'name'}` placeholder instead,
+    eg `{acc_home}`.
 
 Color thresholds:
     xxx: print a color based on the value of `xxx` placeholder

--- a/py3status/modules/mail.py
+++ b/py3status/modules/mail.py
@@ -22,7 +22,7 @@ Format placeholders:
 
     We can divide mailbox, eg `{maildir}`, into numbered placeholders based
     on number of mailbox accounts, eg `{maildir_1}`, and if we add `name` to
-    a mailbox account, we can use `{name}` placeholder instead, eg `{home}`.
+    a mailbox account, we can use `{acc_'name'}` placeholder instead, eg `{acc_home}`.
 
 Color thresholds:
     xxx: print a color based on the value of `xxx` placeholder
@@ -206,7 +206,7 @@ class Py3status:
                     count_mail = len(inbox)
                     inbox.close()
                 if 'name' in account:
-                    mail_data[account['name']] = count_mail
+                    mail_data['acc' + account['name']] = count_mail
                 if account['urgent'] and count_mail:
                     mail_data['urgent'] = True
                 mail_data['%s_%s' % (k, i)] = count_mail


### PR DESCRIPTION
Prefix mailbox placeholders with acc_ to avoid namecollissons. Now the
number of unread mails in a mailbox can be accessed with {acc_'name'}.

Fixes #1543 