### PR TITLE
implement udev event monitoring

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -717,3 +717,32 @@ closing parenthesis ``)`` using a backslash ``\)``.
     Prior to version 3.13 you may not include any closing
     parenthesis ``)`` in the expression. Wrap your commands in a
     script file and call it instead.
+
+
+Refreshing modules on udev events with on_udev dynamic options
+--------------------------------------------------------------
+
+.. note::
+    New in version 3.14
+
+Refreshing of modules can be triggered when an udev event is detected on a
+specific subsystem using the ``on_udev_<subsystem>`` configuration parameter
+and an associated action.
+
+Possible actions:
+- ``refresh``: immediately refresh the module and keep on updating it as usual
+- ``refresh_and_freeze``: module is ONLY refreshed when said udev subsystem emits
+an event
+
+.. code-block:: py3status
+    :caption: Example
+
+    # refresh xrandr only when udev 'drm' events are triggered
+    xrandr {
+        on_udev_drm = "refresh_and_freeze"
+    }
+
+.. note::
+    This feature will only activate when ``pyudev`` is installed on the system.
+    This is an optional dependency of py3status and is therefore not enforced
+    by all package managers.

--- a/py3status/constants.py
+++ b/py3status/constants.py
@@ -211,3 +211,5 @@ COLOR_NAMES = {
     "yellow": "#ffff00",
     "yellowgreen": "#9acd32",
 }
+
+ON_TRIGGER_ACTIONS = ["refresh", "refresh_and_freeze"]

--- a/py3status/core.py
+++ b/py3status/core.py
@@ -24,6 +24,7 @@ from py3status.i3status import I3status
 from py3status.parse_config import process_config
 from py3status.module import Module
 from py3status.profiling import profile
+from py3status.udev_monitor import UdevMonitor
 from py3status.version import version
 
 LOG_LEVELS = {"error": LOG_ERR, "warning": LOG_WARNING, "info": LOG_INFO}
@@ -643,6 +644,9 @@ class Py3statusWrapper:
         self.commands_thread.start()
         if self.config["debug"]:
             self.log("commands thread started")
+
+        # initialize the udev monitor (lazy)
+        self.udev_monitor = UdevMonitor(self)
 
         # suppress modules' ouput wrt issue #20
         if not self.config["debug"]:

--- a/py3status/module.py
+++ b/py3status/module.py
@@ -665,7 +665,7 @@ class Module:
             for on_udev_var in on_udev_vars:
                 on, udev, subsystem = on_udev_var.split("_")
                 trigger_action = getattr(self.module_class, on_udev_var)
-                self.module_class.py3.on_udev_handler(trigger_action, subsystem)
+                self.add_udev_trigger(trigger_action, subsystem)
 
             # allow_urgent
             # get the value form the config or use the module default if
@@ -918,3 +918,12 @@ class Module:
             except Exception:
                 # this would be stupid to die on exit
                 pass
+
+    def add_udev_trigger(self, trigger_action, subsystem):
+        """
+        Subscribe to the requested udev subsystem and apply the given action.
+        """
+        if self._py3_wrapper.udev_monitor.subscribe(self, trigger_action, subsystem):
+            if trigger_action == "refresh_and_freeze":
+                # FIXME: we may want to disable refresh instead of using cache_timeout
+                self.module_class.cache_timeout = PY3_CACHE_FOREVER

--- a/py3status/module.py
+++ b/py3status/module.py
@@ -659,13 +659,10 @@ class Module:
 
             # Subscribe to udev events if on_udev_* dynamic variables are
             # configured on the module
-            on_udev_vars = [
-                i for i in dir(self.module_class) if i.startswith("on_udev_")
-            ]
-            for on_udev_var in on_udev_vars:
-                on, udev, subsystem = on_udev_var.split("_")
-                trigger_action = getattr(self.module_class, on_udev_var)
-                self.add_udev_trigger(trigger_action, subsystem)
+            for param in dir(self.module_class):
+                if param.startswith("on_udev_"):
+                    trigger_action = getattr(self.module_class, param)
+                    self.add_udev_trigger(trigger_action, param[8:])
 
             # allow_urgent
             # get the value form the config or use the module default if

--- a/py3status/module.py
+++ b/py3status/module.py
@@ -657,6 +657,16 @@ class Module:
             if not hasattr(self.module_class, "py3"):
                 setattr(self.module_class, "py3", Py3(self))
 
+            # Subscribe to udev events if on_udev_* dynamic variables are
+            # configured on the module
+            on_udev_vars = [
+                i for i in dir(self.module_class) if i.startswith("on_udev_")
+            ]
+            for on_udev_var in on_udev_vars:
+                on, udev, subsystem = on_udev_var.split("_")
+                trigger_action = getattr(self.module_class, on_udev_var)
+                self.module_class.py3.on_udev_handler(trigger_action, subsystem)
+
             # allow_urgent
             # get the value form the config or use the module default if
             # supplied.

--- a/py3status/modules/xrandr.py
+++ b/py3status/modules/xrandr.py
@@ -54,6 +54,9 @@ Configuration parameters:
             ```
             output_combinations = "eDP1|eDP1+DP1"
             ```
+    update_on_udev: the udev subsystem we want to monitor for events
+        that will trigger a refresh of this module.
+        (default 'drm')
 
 Dynamic configuration parameters:
     <OUTPUT>_pos: apply the given position to the OUTPUT
@@ -131,6 +134,7 @@ class Py3status:
     icon_clone = '='
     icon_extend = '+'
     output_combinations = None
+    update_on_udev = 'drm'
 
     class Meta:
         deprecated = {
@@ -157,6 +161,7 @@ class Py3status:
         self.active_mode = 'extend'
         self.displayed = None
         self.max_width = 0
+        self.py3.update_on_udev(self.update_on_udev)
 
     def _get_layout(self):
         """

--- a/py3status/modules/xrandr.py
+++ b/py3status/modules/xrandr.py
@@ -37,6 +37,9 @@ Configuration parameters:
         (default '=')
     icon_extend: icon used to display a 'extend' combination
         (default '+')
+    on_udev_drm: dynamic variable to watch for `drm` udev subsystem events to
+        trigger specified action.
+        (default 'refresh_and_freeze')
     output_combinations: string used to define your own subset of output
         combinations to use, instead of generating every possible combination
         automatically. Provide the values in the format that this module uses,
@@ -53,9 +56,6 @@ Configuration parameters:
             output_combinations = "eDP1|eDP1+DP1"
             ```
         (default None)
-    update_on_udev: the udev subsystem we want to monitor for events
-        that will trigger a refresh of this module.
-        (default 'drm')
 
 Dynamic configuration parameters:
     <OUTPUT>_pos: apply the given position to the OUTPUT
@@ -132,8 +132,8 @@ class Py3status:
     hide_if_single_combination = False
     icon_clone = '='
     icon_extend = '+'
+    on_udev_drm = 'refresh_and_freeze'
     output_combinations = None
-    update_on_udev = 'drm'
 
     class Meta:
         deprecated = {
@@ -160,7 +160,6 @@ class Py3status:
         self.active_mode = 'extend'
         self.displayed = None
         self.max_width = 0
-        self.py3.update_on_udev(self.update_on_udev)
 
     def _get_layout(self):
         """

--- a/py3status/py3.py
+++ b/py3status/py3.py
@@ -1261,14 +1261,3 @@ class Py3:
             auth=auth,
             cookiejar=cookiejar,
         )
-
-    def on_udev_handler(self, trigger_action, subsystem):
-        """
-        When pyudev (optional) is available and the consumer subscription
-        worked, we disable the automatic refresh of the module.
-        """
-        if self._py3_wrapper.udev_monitor.subscribe(self, trigger_action, subsystem):
-            if trigger_action == "refresh_and_freeze":
-                self._py3status_module.cache_timeout = PY3_CACHE_FOREVER
-            return True
-        return False

--- a/py3status/py3.py
+++ b/py3status/py3.py
@@ -1238,3 +1238,11 @@ class Py3:
             auth=auth,
             cookiejar=cookiejar,
         )
+
+    def update_on_udev(self, subsystem):
+        """
+        When pyudev (optional) is available and the consumer subscription
+        worked, we disable the automatic refresh of the module.
+        """
+        if self._py3_wrapper.udev_monitor.subscribe(self, subsystem):
+            self._py3status_module.cache_timeout = PY3_CACHE_FOREVER

--- a/py3status/py3.py
+++ b/py3status/py3.py
@@ -1262,10 +1262,13 @@ class Py3:
             cookiejar=cookiejar,
         )
 
-    def update_on_udev(self, subsystem):
+    def on_udev_handler(self, trigger_action, subsystem):
         """
         When pyudev (optional) is available and the consumer subscription
         worked, we disable the automatic refresh of the module.
         """
-        if self._py3_wrapper.udev_monitor.subscribe(self, subsystem):
-            self._py3status_module.cache_timeout = PY3_CACHE_FOREVER
+        if self._py3_wrapper.udev_monitor.subscribe(self, trigger_action, subsystem):
+            if trigger_action == "refresh_and_freeze":
+                self._py3status_module.cache_timeout = PY3_CACHE_FOREVER
+            return True
+        return False

--- a/py3status/udev_monitor.py
+++ b/py3status/udev_monitor.py
@@ -1,0 +1,72 @@
+from collections import defaultdict
+
+try:
+    import pyudev
+except ImportError:
+    pyudev = None
+
+
+class UdevMonitor:
+    """
+    This class allows us to react to udev events.
+    """
+
+    def __init__(self, py3_wrapper):
+        """
+        The udev monitoring will be lazy loaded if a module uses it.
+        """
+        self.enabled = pyudev is not None
+        self.py3_wrapper = py3_wrapper
+        self.udev_consumers = defaultdict(list)
+        self.udev_observer = None
+
+    def _setup_pyudev_monitoring(self):
+        """
+        Setup the udev monitor.
+        """
+        context = pyudev.Context()
+        monitor = pyudev.Monitor.from_netlink(context)
+        self.udev_observer = pyudev.MonitorObserver(monitor, self._udev_event)
+        self.udev_observer.start()
+        self.py3_wrapper.log("udev monitoring enabled")
+
+    def _udev_event(self, action, device):
+        """
+        This is a callback method that will trigger a refresh on subscribers.
+        """
+        self.refresh_subscribers(device.subsystem)
+
+    def subscribe(self, py3_module, subsystem):
+        """
+        Subscribe the given module to the given udev subsystem.
+
+        Here we will lazy load the monitor if necessary and return success or
+        failure based on the availability of pyudev.
+        """
+        if self.enabled:
+            # lazy load the udev monitor
+            if self.udev_observer is None:
+                self._setup_pyudev_monitoring()
+            self.udev_consumers[subsystem].append(py3_module)
+            self.py3_wrapper.log(
+                "module %s subscribed to udev events on %s"
+                % (py3_module._module_full_name, subsystem)
+            )
+            return True
+        else:
+            self.py3_wrapper.log(
+                "could not subscribe module %s to udev events on %s"
+                % (py3_module._module_full_name, subsystem)
+            )
+            return False
+
+    def refresh_subscribers(self, subsystem):
+        """
+        Refresh all modules which subscribed to the given subsystem.
+        """
+        for py3_module in self.udev_consumers[subsystem]:
+            self.py3_wrapper.log(
+                "%s udev event, refresh consumer %s"
+                % (subsystem, py3_module._module_full_name)
+            )
+            py3_module.update()


### PR DESCRIPTION
Allows modules to use a generic interface to subscribe to udev events and be refreshed **ONLY** when they happen.

This allows some modules, such as featured xrandr, to not poll for change all the time :+1: 

Comments / review welcome. I've been using it for a while now.