### PR TITLE
WIP: dbus helper for modules

### DIFF
--- a/py3status/dbus_helper.py
+++ b/py3status/dbus_helper.py
@@ -1,0 +1,53 @@
+from threading import Thread
+
+
+class DBus:
+
+    def __init__(self, py3_wrapper):
+        try:
+            from gi.repository import GObject
+            from pydbus import SystemBus, SessionBus
+            self.GObject = GObject
+            self.SessionBus = SessionBus
+            self.SystemBus = SystemBus
+            self.initialized = True
+        except ImportError:
+            # FIXME logging
+            self.initialized = False
+            pass
+        self.py3_wrapper = py3_wrapper
+        self.started = False
+        self.bus_system = None
+        self.bus_session = None
+
+    def get_bus(self, bus):
+        if bus == "system":
+            if self.bus_system is None:
+                self.bus_system = self.SystemBus()
+            return self.bus_system
+        if self.bus_session is None:
+            self.bus_session = self.SessionBus()
+        return self.bus_session
+
+    def start_main_loop(self):
+        self.GObject.threads_init()
+        loop = self.GObject.MainLoop()
+        t = Thread(target=loop.run)
+        t.daemon = True
+        t.start()
+        self.started = True
+
+    def subscribe(self, path, callback, event, bus):
+        if not self.started:
+            self.start_main_loop()
+        bus = self.get_bus(bus)
+        manager = bus.get(path)
+        setattr(manager, event, callback)
+
+    def module_update(self, module):
+        """
+        Create a small helper function that will force a module to update
+        """
+        def update(*args):
+            module.force_update()
+        return update

--- a/py3status/modules/battery_level.py
+++ b/py3status/modules/battery_level.py
@@ -170,6 +170,8 @@ class Py3status:
         self.py3.log("Measurement mode: " + self.measurement_mode)
         if self.measurement_mode != "acpi" and self.measurement_mode != "sys":
             raise NameError("Invalid measurement mode")
+        # subscribe to dbus power notifications
+        self.py3.dbus_subscribe(".UPower", 'update')
 
     def battery_level(self):
         if not os.listdir(self.sys_battery_path):

--- a/py3status/py3.py
+++ b/py3status/py3.py
@@ -14,6 +14,7 @@ from time import time
 from uuid import uuid4
 
 from py3status import exceptions
+from py3status.dbus_helper import DBus
 from py3status.constants import COLOR_NAMES
 from py3status.formatter import Formatter, Composite
 from py3status.request import HttpResponse
@@ -92,6 +93,7 @@ class Py3:
     """Show as Warning"""
 
     # Shared by all Py3 Instances
+    _dbus = None
     _formatter = None
     _gradients = Gradiants()
     _none_color = NoneColor()
@@ -130,6 +132,9 @@ class Py3:
             # that we can do logging etc.
             if not self._formatter:
                 self.__class__._formatter = Formatter(module._py3_wrapper)
+
+            if not self._dbus:
+                self.__class__._dbus = DBus(module._py3_wrapper)
 
     def __getattr__(self, name):
         """
@@ -249,6 +254,17 @@ class Py3:
         self._py3_wrapper.report_exception(
             msg, notify_user=False, error_frame=error_frame
         )
+
+    def dbus_subscribe(
+        self, path, callback, event="onPropertiesChanged", bus="system"
+    ):
+        """
+        subscribe to dbus
+        """
+        if callback == "update":
+            callback = self._dbus.module_update(self._module)
+            self.log(callback)
+        self._dbus.subscribe(path, callback, event=event, bus=bus)
 
     def error(self, msg, timeout=None):
         """


### PR DESCRIPTION
#1546 adds cool udev support

this adds dbus support for modules - the code is still in crude proof of concept form.

The example module is battery_level and it just updates on a dbus power change.  Due to how the module currently works it triggers better when we unplug the power than when we plug it in.  This is more about the module.

It is very crude and needs more work but I wanted to show the code as relates to #1546 so I think it is good to consider the needs of both

The idea of this is

* we can subscribe to dbus events
* get dbus properies (missing)
* trigger dbus methods (missing)
* stop modules doing this and having multiple gobject loops etc as currently

but the real issue for now is how modules interact with this and how it fits in with udev