### PR TITLE
adds ~/.config/i3 as a default config directory, closes #1548

### DIFF
--- a/py3status/cli.py
+++ b/py3status/cli.py
@@ -19,6 +19,7 @@ def parse_cli():
         "{}/i3status/config".format(
             os.environ.get("XDG_CONFIG_HOME", "{}/.config".format(home_path))
         ),
+        "{}/.config/i3/".format(home_path),
         "/etc/i3status.conf",
         "{}/i3status/config".format(os.environ.get("XDG_CONFIG_DIRS", "/etc/xdg")),
     ]


### PR DESCRIPTION
I consider it a bug on our part