### PR TITLE
module: rename min_width,align to min_length,position

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -132,8 +132,16 @@ Store per config cache in different directories.
 
 You can specify the following options in module configuration.
 
- ``min_length``: Specify a minimum length for modules.
- ``position``: Specify how modules should be positioned.
+ ``min_length``: Specify a minimum length (of characters) for modules.
+ ``position``: Specify how modules should be positioned when the ``min_length``
+ is not reached. Either ``left`` (default), ``center``, or ``right``.
+
+.. code-block:: py3status
+     # example
+    static_string {
+        min_length = 15
+        position = 'center'
+    }
 
 Configuration obfuscation
 -------------------------

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -127,6 +127,13 @@ Store per config cache in different directories.
         storage = '~/.config/py3status/cache_bottom.data'
     }
 
+.. note::
+    New in version 3.14
+
+You can specify the following options in module configuration.
+
+ ``min_length``: Specify a minimum length for modules.
+ ``position``: Specify how modules should be positioned.
 
 Configuration obfuscation
 -------------------------

--- a/py3status/constants.py
+++ b/py3status/constants.py
@@ -213,3 +213,5 @@ COLOR_NAMES = {
 }
 
 ON_TRIGGER_ACTIONS = ["refresh", "refresh_and_freeze"]
+
+POSITIONS = ["left", "center", "right"]

--- a/py3status/module.py
+++ b/py3status/module.py
@@ -311,14 +311,34 @@ class Module:
         self.py3_module_options = {}
         mod_config = self.config["py3_config"].get(module, {})
 
+        if "min_length" in mod_config:
+            min_length = mod_config["min_length"]
+            if not isinstance(min_length, int):
+                err = 'invalid "min_length" attribute should be an int'
+                raise TypeError(err)
+
+            self.py3_module_options["min_length"] = min_length
+            self.random_int = randint(0, 1)
+
+            if "position" in mod_config:
+                position = mod_config["position"]
+                if not (
+                    isinstance(position, basestring)
+                    and position.lower() in ("left", "center", "right")
+                ):
+                    err = 'invalid "position" attribute, valid values are:'
+                    err += " left, center, right"
+                    raise ValueError(err)
+
+                self.py3_module_options["position"] = position
+
         if "min_width" in mod_config:
             min_width = mod_config["min_width"]
             if not isinstance(min_width, int):
                 err = 'invalid "min_width" attribute should be an int'
                 raise TypeError(err)
 
-            self.py3_module_options["min_width"] = min_width
-            self.random_int = randint(0, 1)
+            self.i3s_module_options["min_width"] = min_width
 
             if "align" in mod_config:
                 align = mod_config["align"]
@@ -330,7 +350,7 @@ class Module:
                     err += " left, center, right"
                     raise ValueError(err)
 
-                self.py3_module_options["align"] = align
+                self.i3s_module_options["align"] = align
 
         if "separator" in mod_config:
             separator = mod_config["separator"]
@@ -416,31 +436,31 @@ class Module:
             elif urgent and "urgent" not in item:
                 item["urgent"] = urgent
 
-        # set min_width
-        if "min_width" in self.py3_module_options:
-            min_width = self.py3_module_options["min_width"]
+        # set min_length
+        if "min_length" in self.py3_module_options:
+            min_length = self.py3_module_options["min_length"]
 
-            # get width, skip if width exceeds min_width
-            width = sum([len(x["full_text"]) for x in response["composite"]])
-            if width >= min_width:
+            # get length, skip if length exceeds min_length
+            length = sum([len(x["full_text"]) for x in response["composite"]])
+            if length >= min_length:
                 return
 
-            # sometimes when we go under min_width to pad both side evenly,
-            # we will add extra space on either side to honor min_width
-            padding = int((min_width / 2.0) - (width / 2.0))
-            offset = min_width - ((padding * 2) + width)
+            # sometimes we go under min_length to pad both side evenly,
+            # we will add extra space on either side to honor min_length
+            padding = int((min_length / 2.0) - (length / 2.0))
+            offset = min_length - ((padding * 2) + length)
 
-            # set align
-            align = self.py3_module_options.get("align", "left")
-            if align == "center":
+            # set position
+            position = self.py3_module_options.get("position", "left")
+            if position == "center":
                 left = right = " " * padding
                 if self.random_int:
                     left += " " * offset
                 else:
                     right += " " * offset
-            elif align == "left":
+            elif position == "left":
                 left, right = "", " " * (padding * 2 + offset)
-            elif align == "right":
+            elif position == "right":
                 right, left = "", " " * (padding * 2 + offset)
 
             # padding

--- a/py3status/module.py
+++ b/py3status/module.py
@@ -7,6 +7,7 @@ from time import time
 from random import randint
 
 from py3status.composite import Composite
+from py3status.constants import POSITIONS
 from py3status.py3 import Py3, PY3_CACHE_FOREVER, ModuleErrorException
 from py3status.profiling import profile
 from py3status.formatter import Formatter
@@ -324,10 +325,10 @@ class Module:
                 position = mod_config["position"]
                 if not (
                     isinstance(position, basestring)
-                    and position.lower() in ("left", "center", "right")
+                    and position.lower() in POSITIONS
                 ):
-                    err = 'invalid "position" attribute, valid values are:'
-                    err += " left, center, right"
+                    err = 'invalid "position" attribute, valid values are: '
+                    err += ", ".join(POSITIONS)
                     raise ValueError(err)
 
                 self.py3_module_options["position"] = position
@@ -344,10 +345,10 @@ class Module:
                 align = mod_config["align"]
                 if not (
                     isinstance(align, basestring)
-                    and align.lower() in ("left", "center", "right")
+                    and align.lower() in POSITIONS
                 ):
-                    err = 'invalid "align" attribute, valid values are:'
-                    err += " left, center, right"
+                    err = 'invalid "align" attribute, valid values are: '
+                    err += ", ".join(POSITIONS)
                     raise ValueError(err)
 
                 self.i3s_module_options["align"] = align


### PR DESCRIPTION
This addresses https://github.com/ultrabug/py3status/issues/1540. From what I understand...

 * Renaming `min_width` to our custom `min_length`.
    * Permit users to still use `min_width` (pixel)
    * We can't use our custom `align` with i3bar's `min_width` so we made our own with chars.
    * We'll rename our custom `align` to `position` too to keep everything away.

* Renaming `align` to our custom `position`.
    * i3bar can't align multi-color modules.
        * All i3status modules are always fully colorized.
    * Permit users to still use `align`... This would only work with single color.
        * We could make universal `allow_colors = False` in the future.
        * We could allow users to override all `color` with a static color (then simplify) in the future.
    * Multi-color mean breaking out into more composites.

* Concerns.
    * Name collisions. I assume we have custom/i3blocks/i3pystatus modules that uses `position` (as well as `min_length`, but mostly `position`). If not, well, future modules might run into this issue because `position` is nice generic config name that modules could sometimes use.
    * Our custom code to work with their configs would not always work so we bust out our own configs instead of trying to deal with align + width ourselves.
   * Making our own config names is better than explaining conflicts in the documentation. 
    * Lack of documentation.

This PR is finished, but not necessarily solidified. I think this is reasonable because we now undo our code to leave i3 universal options fully alone... and having our own own configs instead... permitting more customization even if some configs would not work with some modules.

Ideas? Suggestions? Better names? Etc... or we are good here.