### PR TITLE
new module: updates

### DIFF
--- a/py3status/modules/updates.py
+++ b/py3status/modules/updates.py
@@ -14,7 +14,6 @@ Format placeholders:
     {apt}     number of updates, eg 0 .. Debian, Ubuntu
     {auracle} number of updates, eg 0 .. Arch Linux (AUR)
     {cower}   number of updates, eg 0 .. Arch Linux (AUR)
-    {dnf}     number of updates, eg 0 .. Fedora           .. NOT TESTED
     {eopkg}   number of updates, eg 0 .. Solus
     {pacman}  number of updates, eg 0 .. Arch Linux
     {xbps}    number of updates, eg 0 .. Void Linux       .. NOT TESTED
@@ -103,12 +102,6 @@ class Cower(Update):
             return ce.output
 
 
-class Dnf(Update):
-    def count_updates(self, output):
-        lines = output.splitlines()[2:]
-        return len([x for x in lines if 'Security:' not in x])
-
-
 class Eopkg(Update):
     def get_output(self):
         output = self.parent.py3.command_output(self.command)
@@ -151,7 +144,6 @@ class Py3status:
             ("yay", ["yay", "--query", "--upgrades", "--aur"]),
             ("apk", ["apk", "version", "-l", '"<"']),
             ("apt", ["apt", "list", "--upgradeable"]),
-            ("dnf", ["dnf", "check-upgrades"]),
             ("eopkg", ["eopkg", "list-upgrades"]),
             ("pkg", ["pkg", "upgrade", "--dry-run", "--quiet"]),
             ("xbps", ["xbps-install", "--update", "--dry-run"]),

--- a/py3status/modules/updates.py
+++ b/py3status/modules/updates.py
@@ -243,8 +243,11 @@ class Py3status:
                             break
             managers = new_managers
 
-        placeholders = self.py3.get_placeholders_list(self.format or "")
-        placeholders = [x for x in placeholders if x != "update"]
+        if self.format:
+            placeholders = self.py3.get_placeholders_list(self.format)
+            placeholders = [x for x in placeholders if x != "update"]
+        else:
+            placeholders = []
 
         formats = []
         self.backends = []

--- a/py3status/modules/updates.py
+++ b/py3status/modules/updates.py
@@ -17,6 +17,7 @@ Format placeholders:
     {dnf}     number of updates, eg 0 .. Fedora
     {eopkg}   number of updates, eg 0 .. Solus
     {flatpak} number of updates, eg 0 .. Flatpak
+    {gem}     number of updates, eg 0 .. Ruby Programs and Libaries
     {pacman}  number of updates, eg 0 .. Arch Linux
     {pakku}   number of updates, eg 0 .. Arch Linux (AUR)
     {pikaur}  number of updates, eg 0 .. Arch Linux (AUR)
@@ -32,7 +33,7 @@ Color thresholds:
 
 @author Iain Tatch <iain.tatch@gmail.com> (arch)
 @author Joshua Pratt <jp10010101010000@gmail.com> (apt)
-@author lasers (apk, auracle, eopkg, flatpak, pakku, pikaur, pkg, snappy, trizen, xbps, yay, zypper)
+@author lasers (apk, auracle, eopkg, flatpak, gem, pakku, pikaur, pkg, snappy, trizen, xbps, yay, zypper)
 @author tobes (dnf)
 @license BSD (apt, arch, dnf)
 
@@ -219,6 +220,7 @@ class Py3status:
                 ]
             others = [
                 ("Flatpak", "flatpak remote-ls --updates --all"),
+                ("Gem", "gem outdated --quiet"),
                 ("Snappy", "snap refresh --list --color=never"),
             ]
 

--- a/py3status/modules/updates.py
+++ b/py3status/modules/updates.py
@@ -106,7 +106,7 @@ class Update:
 
 class Apt(Update):
     def count_updates(self, output):
-        return len(output.splitlines()[1:])
+        return len([x for x in output.splitlines() if x[:4] == "Inst"])
 
 
 class Apk(Update):
@@ -192,7 +192,11 @@ class Py3status:
             else:
                 managers = [
                     ("Apk", "apk version -l '<'"),
-                    ("Apt", "apt list --upgradeable"),
+                    (
+                        "Apt",
+                        "apt-get dist-upgrade --dry-run -qq "
+                        "-o APT::Get::Show-User-Simulation-Note=no",
+                    ),
                     ("Eopkg", "eopkg list-upgrades"),
                     ("Pkg", "pkg upgrade --dry-run --quiet"),
                     ("Xbps", "xbps-install --update --dry-run"),

--- a/py3status/modules/updates.py
+++ b/py3status/modules/updates.py
@@ -16,6 +16,7 @@ Format placeholders:
     {auracle} number of updates, eg 0 .. Arch Linux (AUR)
     {eopkg}   number of updates, eg 0 .. Solus
     {pacman}  number of updates, eg 0 .. Arch Linux
+    {pikaur}  number of updates, eg 0 .. Arch Linux (AUR)
     {xbps}    number of updates, eg 0 .. Void Linux       [NOT TESTED]
     {yay}     number of updates, eg 0 .. Arch Linux (AUR)
     {zypper}  number of updates, eg 0 .. openSUSE         [NOT TESTED]
@@ -25,7 +26,7 @@ Color thresholds:
 
 @author Iain Tatch <iain.tatch@gmail.com> (arch)
 @author Joshua Pratt <jp10010101010000@gmail.com> (apt)
-@author lasers (apk, auracle, eopkg, xbps, yay, zypper)
+@author lasers (apk, auracle, eopkg, pikaur, xbps, yay, zypper)
 @license BSD (apt, arch)
 
 Examples:
@@ -158,6 +159,7 @@ class Py3status:
             ("Pacman", "checkupdates"),
             ("Auracle", "auracle sync --color=never"),
             ("Yay", "yay --query --upgrades --aur"),
+            ("Pikaur", "pikaur -Quaq"),
             ("Apk", "apk version -l '<'"),
             ("Apt", "apt list --upgradeable"),
             ("Eopkg", "eopkg list-upgrades"),

--- a/py3status/modules/updates.py
+++ b/py3status/modules/updates.py
@@ -17,6 +17,7 @@ Format placeholders:
     {eopkg}   number of updates, eg 0 .. Solus
     {pacman}  number of updates, eg 0 .. Arch Linux
     {pikaur}  number of updates, eg 0 .. Arch Linux (AUR)
+    {pkg}     number of updates, eg 0 .. FreeBSD          [NOT TESTED]
     {trizen}  number of updates, eg 0 .. Arch Linux (AUR)
     {xbps}    number of updates, eg 0 .. Void Linux       [NOT TESTED]
     {yay}     number of updates, eg 0 .. Arch Linux (AUR)
@@ -27,7 +28,7 @@ Color thresholds:
 
 @author Iain Tatch <iain.tatch@gmail.com> (arch)
 @author Joshua Pratt <jp10010101010000@gmail.com> (apt)
-@author lasers (apk, auracle, eopkg, pikaur, trizen, xbps, yay, zypper)
+@author lasers (apk, auracle, eopkg, pikaur, pkg, trizen, xbps, yay, zypper)
 @license BSD (apt, arch)
 
 Examples:

--- a/py3status/modules/updates.py
+++ b/py3status/modules/updates.py
@@ -164,19 +164,25 @@ class Py3status:
         }
 
     def post_config_hook(self):
-        managers = [
-            ("Pacman", "checkupdates"),
-            ("Auracle", "auracle sync --color=never"),
-            ("Yay", "yay --query --upgrades --aur"),
-            ("Pikaur", "pikaur -Quaq"),
-            ("Trizen", "trizen -Quaq"),
-            ("Apk", "apk version -l '<'"),
-            ("Apt", "apt list --upgradeable"),
-            ("Eopkg", "eopkg list-upgrades"),
-            ("Pkg", "pkg upgrade --dry-run --quiet"),
-            ("Xbps", "xbps-install --update --dry-run"),
-            ("Zypper", "zypper list-updates"),
-        ]
+        with open("/etc/os-release") as f:
+            multiple = "archlinux" in f.read()
+            if multiple:
+                managers = [
+                    ("Pacman", "checkupdates"),  # must be first
+                    ("Auracle", "auracle sync --color=never"),
+                    ("Pikaur", "pikaur -Quaq --color=never"),
+                    ("Trizen", "trizen -Quaq --color=never"),
+                    ("Yay", "yay -Quaq --color=never")
+                ]
+            else:
+                managers = [
+                    ("Apk", "apk version -l '<'"),
+                    ("Apt", "apt list --upgradeable"),
+                    ("Eopkg", "eopkg list-upgrades"),
+                    ("Pkg", "pkg upgrade --dry-run --quiet"),
+                    ("Xbps", "xbps-install --update --dry-run"),
+                    ("Zypper", "zypper list-updates"),
+                ]
 
         if self.managers:
             new_managers = []
@@ -211,6 +217,8 @@ class Py3status:
                     backend = Update
                 formats.append((name, name_lowercased))
                 self.backends.append(backend(self, name_lowercased, command))
+                if not multiple:
+                    break
 
         if not self.format:
             if getattr(self, 'verbose', False):

--- a/py3status/modules/updates.py
+++ b/py3status/modules/updates.py
@@ -16,6 +16,7 @@ Format placeholders:
     {auracle} number of updates, eg 0 .. Arch Linux (AUR)
     {dnf}     number of updates, eg 0 .. Fedora
     {eopkg}   number of updates, eg 0 .. Solus
+    {flatpak} number of updates, eg 0 .. Flatpak
     {pacman}  number of updates, eg 0 .. Arch Linux
     {pakku}   number of updates, eg 0 .. Arch Linux (AUR)
     {pikaur}  number of updates, eg 0 .. Arch Linux (AUR)
@@ -30,7 +31,7 @@ Color thresholds:
 
 @author Iain Tatch <iain.tatch@gmail.com> (arch)
 @author Joshua Pratt <jp10010101010000@gmail.com> (apt)
-@author lasers (apk, auracle, eopkg, pakku, pikaur, pkg, trizen, xbps, yay, zypper)
+@author lasers (apk, auracle, eopkg, flatpak, pakku, pikaur, pkg, trizen, xbps, yay, zypper)
 @author tobes (dnf)
 @license BSD (apt, arch, dnf)
 
@@ -215,6 +216,9 @@ class Py3status:
                     ("Xbps", "xbps-install --update --dry-run"),
                     ("Zypper", "zypper list-updates"),
                 ]
+            managers += [
+                ("Flatpak", "flatpak remote-ls --updates --all"),
+            ]
 
         if self.managers:
             new_managers = []

--- a/py3status/modules/updates.py
+++ b/py3status/modules/updates.py
@@ -16,6 +16,7 @@ Format placeholders:
     {auracle} number of updates, eg 0 .. Arch Linux (AUR)
     {eopkg}   number of updates, eg 0 .. Solus
     {pacman}  number of updates, eg 0 .. Arch Linux
+    {pakku}   number of updates, eg 0 .. Arch Linux (AUR)
     {pikaur}  number of updates, eg 0 .. Arch Linux (AUR)
     {pkg}     number of updates, eg 0 .. FreeBSD          [NOT TESTED]
     {trizen}  number of updates, eg 0 .. Arch Linux (AUR)
@@ -28,7 +29,7 @@ Color thresholds:
 
 @author Iain Tatch <iain.tatch@gmail.com> (arch)
 @author Joshua Pratt <jp10010101010000@gmail.com> (apt)
-@author lasers (apk, auracle, eopkg, pikaur, pkg, trizen, xbps, yay, zypper)
+@author lasers (apk, auracle, eopkg, pakku, pikaur, pkg, trizen, xbps, yay, zypper)
 @license BSD (apt, arch)
 
 Examples:
@@ -148,6 +149,17 @@ class Eopkg(Update):
         return output
 
 
+class Pakku(Update):
+    def get_output(self):
+        try:
+            return self.parent.py3.command_output(self.command)
+        except self.parent.py3.CommandError as ce:
+            return ce.output
+
+    def count_updates(self, output):
+        return len([x for x in output.splitlines() if x == "aur"])
+
+
 class Trizen(Update):
     def get_output(self):
         try:
@@ -195,6 +207,7 @@ class Py3status:
                 managers = [
                     ("Pacman", "checkupdates"),  # must be first
                     ("Auracle", "auracle sync --color=never"),
+                    ("Pakku", "pakku -Su --print-format '%r' --color=never"),
                     ("Pikaur", "pikaur -Quaq --color=never"),
                     ("Trizen", "trizen -Quaq --color=never"),
                     ("Yay", "yay -Quaq --color=never")

--- a/py3status/modules/updates.py
+++ b/py3status/modules/updates.py
@@ -212,7 +212,7 @@ class Py3status:
                         "-o APT::Get::Show-User-Simulation-Note=no",
                     ),
                     ("Dnf", "dnf list --refresh --upgrades --quiet"),
-                    ("Eopkg", "eopkg list-upgrades"),
+                    ("Eopkg", "eopkg list-upgrades --no-color"),
                     ("Pkg", "pkg upgrade --dry-run --quiet"),
                     ("Xbps", "xbps-install --update --dry-run"),
                     ("Zypper", "zypper list-updates"),

--- a/py3status/modules/updates.py
+++ b/py3status/modules/updates.py
@@ -21,6 +21,7 @@ Format placeholders:
     {pakku}   number of updates, eg 0 .. Arch Linux (AUR)
     {pikaur}  number of updates, eg 0 .. Arch Linux (AUR)
     {pkg}     number of updates, eg 0 .. FreeBSD          [NOT TESTED]
+    {snappy}  number of updates, eg 0 .. Snappy
     {trizen}  number of updates, eg 0 .. Arch Linux (AUR)
     {xbps}    number of updates, eg 0 .. Void Linux       [NOT TESTED]
     {yay}     number of updates, eg 0 .. Arch Linux (AUR)
@@ -31,7 +32,7 @@ Color thresholds:
 
 @author Iain Tatch <iain.tatch@gmail.com> (arch)
 @author Joshua Pratt <jp10010101010000@gmail.com> (apt)
-@author lasers (apk, auracle, eopkg, flatpak, pakku, pikaur, pkg, trizen, xbps, yay, zypper)
+@author lasers (apk, auracle, eopkg, flatpak, pakku, pikaur, pkg, snappy, trizen, xbps, yay, zypper)
 @author tobes (dnf)
 @license BSD (apt, arch, dnf)
 
@@ -218,6 +219,7 @@ class Py3status:
                 ]
             managers += [
                 ("Flatpak", "flatpak remote-ls --updates --all"),
+                ("Snappy", "snap refresh --list --color=never"),
             ]
 
         if self.managers:

--- a/py3status/modules/updates.py
+++ b/py3status/modules/updates.py
@@ -217,7 +217,7 @@ class Py3status:
                     ("Xbps", "xbps-install --update --dry-run"),
                     ("Zypper", "zypper list-updates"),
                 ]
-            managers += [
+            others = [
                 ("Flatpak", "flatpak remote-ls --updates --all"),
                 ("Snappy", "snap refresh --list --color=never"),
             ]
@@ -247,19 +247,22 @@ class Py3status:
 
         formats = []
         self.backends = []
-        for name, command in managers:
-            name_lowercased = name.lower()
-            if placeholders and name_lowercased not in placeholders:
-                continue
-            if self.py3.check_commands(command.split()[0]):
-                try:
-                    backend = globals()[name.capitalize()]
-                except KeyError:
-                    backend = Update
-                formats.append((name, name_lowercased))
-                self.backends.append(backend(self, name_lowercased, command))
-                if not multiple:
-                    break
+        for index, managers in enumerate((managers, others)):
+            for name, command in managers:
+                name_lowercased = name.lower()
+                if placeholders and name_lowercased not in placeholders:
+                    continue
+                if self.py3.check_commands(command.split()[0]):
+                    try:
+                        backend = globals()[name.capitalize()]
+                    except KeyError:
+                        backend = Update
+                    formats.append((name, name_lowercased))
+                    self.backends.append(
+                        backend(self, name_lowercased, command)
+                    )
+                    if not index and not multiple:
+                        break
 
         if not self.format:
             auto = "[\?not_zero {name} [\?color={lower} {{{lower}}}]]"

--- a/py3status/modules/updates.py
+++ b/py3status/modules/updates.py
@@ -13,7 +13,6 @@ Format placeholders:
     {apk}     number of updates, eg 0 .. Alpine Linux     .. NOT TESTED
     {apt}     number of updates, eg 0 .. Debian, Ubuntu
     {auracle} number of updates, eg 0 .. Arch Linux (AUR)
-    {cower}   number of updates, eg 0 .. Arch Linux (AUR)
     {eopkg}   number of updates, eg 0 .. Solus
     {pacman}  number of updates, eg 0 .. Arch Linux
     {xbps}    number of updates, eg 0 .. Void Linux       .. NOT TESTED
@@ -34,8 +33,7 @@ updates {
 
 # Arch Linux
 updates {
-    format = 'Updates [\?color=pacman {pacman}]/[\?color=cower {cower}]'
-    # format = 'Updates [\?color=pacman {pacman}]/[\?color=auracle {auracle}]'
+    format = 'Updates [\?color=pacman {pacman}]/[\?color=auracle {auracle}]'
     # format = 'Updates [\?color=pacman {pacman}]/[\?color=yay {yay}]'
 }
 ```
@@ -48,7 +46,7 @@ SAMPLE OUTPUT
 
 29and5pkgs
 [{'full_text': 'Pacman '}, {'full_text': '29 ', 'color': '#FFFF00'},
-{'full_text': 'Cower '}, {'full_text': '5', 'color': '#a9a9a9'}]
+{'full_text': 'Auracle '}, {'full_text': '5', 'color': '#a9a9a9'}]
 
 35pkgs
 [{'full_text': 'Zypper '}, {'full_text': '34', 'color': '#ffa500'}]
@@ -93,15 +91,6 @@ class Apk(Update):
         return len(output.splitlines()[1:])
 
 
-class Cower(Update):
-    def get_output(self):
-        try:
-            self.parent.py3.command_output(self.command)
-            return None
-        except self.parent.py3.CommandError as ce:
-            return ce.output
-
-
 class Eopkg(Update):
     def get_output(self):
         output = self.parent.py3.command_output(self.command)
@@ -130,7 +119,7 @@ class Py3status:
             "rename_placeholder": [
                 {
                     "placeholder": "aur",
-                    "new": "cower",
+                    "new": "auracle",
                     "format_strings": ["format"],
                 }
             ]
@@ -140,7 +129,6 @@ class Py3status:
         managers = [
             ("pacman", ["checkupdates"]),
             ("auracle", ["auracle", "sync"]),
-            ("cower", ["cower", "-u"]),
             ("yay", ["yay", "--query", "--upgrades", "--aur"]),
             ("apk", ["apk", "version", "-l", '"<"']),
             ("apt", ["apt", "list", "--upgradeable"]),

--- a/py3status/modules/updates.py
+++ b/py3status/modules/updates.py
@@ -14,6 +14,7 @@ Format placeholders:
     {apk}     number of updates, eg 0 .. Alpine Linux     [NOT TESTED]
     {apt}     number of updates, eg 0 .. Debian, Ubuntu
     {auracle} number of updates, eg 0 .. Arch Linux (AUR)
+    {dnf}     number of updates, eg 0 .. Fedora
     {eopkg}   number of updates, eg 0 .. Solus
     {pacman}  number of updates, eg 0 .. Arch Linux
     {pakku}   number of updates, eg 0 .. Arch Linux (AUR)
@@ -30,7 +31,8 @@ Color thresholds:
 @author Iain Tatch <iain.tatch@gmail.com> (arch)
 @author Joshua Pratt <jp10010101010000@gmail.com> (apt)
 @author lasers (apk, auracle, eopkg, pakku, pikaur, pkg, trizen, xbps, yay, zypper)
-@license BSD (apt, arch)
+@author tobes (dnf)
+@license BSD (apt, arch, dnf)
 
 Examples:
 ```
@@ -114,6 +116,11 @@ class Apk(Update):
         return len(output.splitlines()[1:])
 
 
+class Dnf(Update):
+    def count_updates(self, output):
+        return len(output.splitlines()[1:])
+
+
 class Eopkg(Update):
     def get_output(self):
         output = self.parent.py3.command_output(self.command)
@@ -174,6 +181,11 @@ class Py3status:
                     "new": "update",
                     "format_strings": ["format"],
                 },
+                {
+                    "placeholder": "updates",
+                    "new": "update",
+                    "format_strings": ["format"],
+                },
             ]
         }
 
@@ -197,6 +209,7 @@ class Py3status:
                         "apt-get dist-upgrade --dry-run -qq "
                         "-o APT::Get::Show-User-Simulation-Note=no",
                     ),
+                    ("Dnf", "dnf list --refresh --upgrades --quiet"),
                     ("Eopkg", "eopkg list-upgrades"),
                     ("Pkg", "pkg upgrade --dry-run --quiet"),
                     ("Xbps", "xbps-install --update --dry-run"),

--- a/py3status/modules/updates.py
+++ b/py3status/modules/updates.py
@@ -17,6 +17,7 @@ Format placeholders:
     {eopkg}   number of updates, eg 0 .. Solus
     {pacman}  number of updates, eg 0 .. Arch Linux
     {pikaur}  number of updates, eg 0 .. Arch Linux (AUR)
+    {trizen}  number of updates, eg 0 .. Arch Linux (AUR)
     {xbps}    number of updates, eg 0 .. Void Linux       [NOT TESTED]
     {yay}     number of updates, eg 0 .. Arch Linux (AUR)
     {zypper}  number of updates, eg 0 .. openSUSE         [NOT TESTED]
@@ -26,7 +27,7 @@ Color thresholds:
 
 @author Iain Tatch <iain.tatch@gmail.com> (arch)
 @author Joshua Pratt <jp10010101010000@gmail.com> (apt)
-@author lasers (apk, auracle, eopkg, pikaur, xbps, yay, zypper)
+@author lasers (apk, auracle, eopkg, pikaur, trizen, xbps, yay, zypper)
 @license BSD (apt, arch)
 
 Examples:
@@ -122,6 +123,14 @@ class Eopkg(Update):
         return output
 
 
+class Trizen(Update):
+    def get_output(self):
+        try:
+            return self.parent.py3.command_output(self.command)
+        except self.parent.py3.CommandError as ce:
+            return ce.output
+
+
 class Zypper(Update):
     def count_updates(self, output):
         return len([x for x in output.splitlines() if x][4:])
@@ -160,6 +169,7 @@ class Py3status:
             ("Auracle", "auracle sync --color=never"),
             ("Yay", "yay --query --upgrades --aur"),
             ("Pikaur", "pikaur -Quaq"),
+            ("Trizen", "trizen -Quaq"),
             ("Apk", "apk version -l '<'"),
             ("Apt", "apt list --upgradeable"),
             ("Eopkg", "eopkg list-upgrades"),

--- a/py3status/modules/updates.py
+++ b/py3status/modules/updates.py
@@ -38,11 +38,35 @@ updates {
     format = '[\?not_zero UPD [\?color=update {update}]]'
 }
 
-# Arch Linux
+# total updates with single or multiple managers
 updates {
-    format = 'UPD [\?color=pacman {pacman}]/[\?color=auracle {auracle}]'
-    # format = 'UPD [\?color=pacman {pacman}]/[\?color=pikaur {pikaur}]'
-    # format = 'UPD [\?color=pacman {pacman}]/[\?color=yay {yay}]'
+    # total
+    format = "UPD [\?color=update {update}]"
+
+    # single managers like apt, xbps, etc will always be same as total.
+    format = "UPD [\?color=apt {apt}]"
+
+    # archlinux have several aur helpers. querying more than one would give
+    # a wrong total so users should keep only one or to specify managers.
+    format = "UPD [\?color=update {update}]"
+    managers = ['pacman', 'yay']
+}
+
+# verbose and/or hide zeroes
+updates {
+    # default is non-verbose, show if updates
+
+    # non-verbose, show if updates, hide zeroes
+    format "[\?if=update UPD [\?color=pacman {pacman}]"
+    format += "[\?soft /][\?color=pikaur {pikaur}]]'
+
+    # verbose, show if updates, show zeroes
+    format "[Pacman [\?color=pacman {pacman}]][\?soft  ]"
+    format += "[Trizen [\?color=trizen {trizen}]]"
+
+    # verbose, hide zeroes
+    format "[\?not_zero Pacman [\?color=pacman {pacman}]][\?soft  ]"
+    format += "[\?not_zero Yay [\?color=yay {yay}]]"
 }
 
 # specify a list of managers (aka supported placeholders)

--- a/py3status/modules/updates.py
+++ b/py3status/modules/updates.py
@@ -1,0 +1,214 @@
+# -*- coding: utf-8 -*-
+"""
+Display numbers of updates for various linux distributions.
+
+Configuration parameters:
+    cache_timeout: refresh interval for this module (default 600)
+    format: display format for this module, otherwise auto (default None)
+    thresholds: specify color thresholds to use *(default [(0, 'darkgray'),
+        (10, 'degraded'), (20, 'orange'), (30, 'bad')])*
+
+Format placeholders:
+    {update}  number of updates, eg 0
+    {apk}     number of updates, eg 0 .. Alpine Linux     .. NOT TESTED
+    {apt}     number of updates, eg 0 .. Debian, Ubuntu
+    {auracle} number of updates, eg 0 .. Arch Linux (AUR)
+    {cower}   number of updates, eg 0 .. Arch Linux (AUR)
+    {dnf}     number of updates, eg 0 .. Fedora           .. NOT TESTED
+    {eopkg}   number of updates, eg 0 .. Solus
+    {pacman}  number of updates, eg 0 .. Arch Linux
+    {xbps}    number of updates, eg 0 .. Void Linux       .. NOT TESTED
+    {yay}     number of updates, eg 0 .. Arch Linux (AUR)
+    {zypper}  number of updates, eg 0 .. openSUSE         .. NOT TESTED
+
+Color thresholds:
+    xxx: print a color based on the value of `xxx` placeholder
+
+@author lasers
+
+Examples:
+```
+# multiple distributions, same format
+updates {
+    format = '[\?not_zero Updates [\?color=update {update}]]'
+}
+
+# Arch Linux
+updates {
+    format = 'Updates [\?color=pacman {pacman}]/[\?color=cower {cower}]'
+    # format = 'Updates [\?color=pacman {pacman}]/[\?color=auracle {auracle}]'
+    # format = 'Updates [\?color=pacman {pacman}]/[\?color=yay {yay}]'
+}
+```
+
+SAMPLE OUTPUT
+[{'full_text': 'Apk '}, {'full_text': '3', 'color': '#a9a9a9'}]
+
+14pkgs
+[{'full_text': 'Apt '}, {'full_text': '14', 'color': '#00FF00'}]
+
+29and5pkgs
+[{'full_text': 'Pacman '}, {'full_text': '29 ', 'color': '#FFFF00'},
+{'full_text': 'Cower '}, {'full_text': '5', 'color': '#a9a9a9'}]
+
+35pkgs
+[{'full_text': 'Zypper '}, {'full_text': '34', 'color': '#ffa500'}]
+
+45pkgs
+[{'full_text': 'Xbps '}, {'full_text': '45', 'color': '#FF0000'}]
+
+no_updates
+{'full_text': 'No Updates'}
+"""
+
+
+class Update:
+    def __init__(self, parent, name, command):
+        self.parent = parent
+        self.name = name
+        self.command = command
+
+    def get_output(self):
+        try:
+            return self.parent.py3.command_output(self.command)
+        except self.parent.py3.CommandError:
+            return None
+
+    def count_updates(self, output):
+        return len(output.splitlines())
+
+    def get_updates(self):
+        output = self.get_output()
+        if output is None:
+            return {self.name: output}
+        return {self.name: self.count_updates(output)}
+
+
+class Apt(Update):
+    def count_updates(self, output):
+        return len(output.splitlines()[1:])
+
+
+class Apk(Update):
+    def count_updates(self, output):
+        return len(output.splitlines()[1:])
+
+
+class Cower(Update):
+    def get_output(self):
+        try:
+            self.parent.py3.command_output(self.command)
+            return None
+        except self.parent.py3.CommandError as ce:
+            return ce.output
+
+
+class Dnf(Update):
+    def count_updates(self, output):
+        lines = output.splitlines()[2:]
+        return len([x for x in lines if 'Security:' not in x])
+
+
+class Eopkg(Update):
+    def get_output(self):
+        output = self.parent.py3.command_output(self.command)
+        if "No packages to upgrade." in output:
+            return ''
+        return output
+
+
+class Zypper(Update):
+    def count_updates(self, output):
+        return len([x for x in output.splitlines() if x][4:])
+
+
+class Py3status:
+    """
+    """
+
+    # available configuration parameters
+    cache_timeout = 600
+    format = None
+    thresholds = [(0, 'darkgray'), (10, 'degraded'),
+                  (20, 'orange'), (30, 'bad')]
+
+    class Meta:
+        deprecated = {
+            "rename_placeholder": [
+                {
+                    "placeholder": "aur",
+                    "new": "cower",
+                    "format_strings": ["format"],
+                }
+            ]
+        }
+
+    def post_config_hook(self):
+        managers = [
+            ("pacman", ["checkupdates"]),
+            ("auracle", ["auracle", "sync"]),
+            ("cower", ["cower", "-u"]),
+            ("yay", ["yay", "--query", "--upgrades", "--aur"]),
+            ("apk", ["apk", "version", "-l", '"<"']),
+            ("apt", ["apt", "list", "--upgradeable"]),
+            ("dnf", ["dnf", "check-upgrades"]),
+            ("eopkg", ["eopkg", "list-upgrades"]),
+            ("pkg", ["pkg", "upgrade", "--dry-run", "--quiet"]),
+            ("xbps", ["xbps-install", "--update", "--dry-run"]),
+            ("zypper", ["zypper", "list-updates"]),
+        ]
+
+        managed = getattr(self, 'managers', [])
+        if not managed:
+            placeholders = self.py3.get_placeholders_list(self.format or '')
+            managed = [x for x in placeholders if x != 'update']
+
+        names = []
+        self.backends = []
+        for name, command in managers:
+            if managed:
+                for manager in managed:
+                    if manager == name:
+                        break
+                else:
+                    continue
+            if self.py3.check_commands(command[0]):
+                names.append(name)
+                try:
+                    backend = globals()[name.capitalize()]
+                except KeyError:
+                    backend = Update
+                self.backends.append(backend(self, name, command))
+
+        if not self.format:
+            auto = "[\?not_zero {Name} [\?color={name} {{{name}}}]]"
+            self.format = "[{}|\?show No Updates]".format("[\?soft  ]".join(
+                auto.format(Name=x.capitalize(), name=x) for x in names
+            ))
+
+        self.thresholds_init = self.py3.get_color_names_list(self.format)
+
+    def updates(self):
+        update_data = {'update': 0}
+        for backend in self.backends:
+            update = backend.get_updates()
+            update_data['update'] += update[backend.name] or 0
+            update_data.update(update)
+
+        for x in self.thresholds_init:
+            if x in update_data:
+                self.py3.threshold_get_color(update_data[x], x)
+
+        return {
+            "cached_until": self.py3.time_in(self.cache_timeout),
+            "full_text": self.py3.safe_format(self.format, update_data),
+        }
+
+
+if __name__ == "__main__":
+    """
+    Run module in test mode.
+    """
+    from py3status.module_test import module_test
+
+    module_test(Py3status)

--- a/py3status/modules/updates.py
+++ b/py3status/modules/updates.py
@@ -34,17 +34,12 @@ Color thresholds:
 
 Examples:
 ```
-# multiple distributions, same format
-updates {
-    format = '[\?not_zero UPD [\?color=update {update}]]'
-}
-
-# total updates with single or multiple managers
+# show total updates
 updates {
     # total
     format = "UPD [\?color=update {update}]"
 
-    # single managers like apt, xbps, etc will always be same as total.
+    # single managers (eg apt, xbps, etc) would be same as total.
     format = "UPD [\?color=apt {apt}]"
 
     # archlinux have several aur helpers. querying more than one would give
@@ -53,39 +48,17 @@ updates {
     managers = ['pacman', 'yay']
 }
 
-# specify format - verbose and/or hide zeroes
+# specify a list and/or 2-tuples of managers
 updates {
-    # default is non-verbose, show if updates
-
-    # non-verbose, show if updates, hide zeroes
-    format "[\?if=update UPD [\?color=pacman {pacman}]"
-    format += "[\?soft /][\?color=pikaur {pikaur}]]'
-
-    # verbose, show if updates, show zeroes
-    format "[Pacman [\?color=pacman {pacman}]][\?soft  ]"
-    format += "[Trizen [\?color=trizen {trizen}]]"
-
-    # verbose, hide zeroes
-    format "[\?not_zero Pacman [\?color=pacman {pacman}]][\?soft  ]"
-    format += "[\?not_zero Yay [\?color=yay {yay}]]"
-}
-
-# specify a list of managers (aka supported placeholders)
-updates {
+    # supported placeholders            # UPD {pacman}/{yay}
     managers = ['pacman', 'yay']
-    # Similar to 'Pacman {pacman} Yay {yay}'
-}
 
-# specify a list of 2-tuples managers (aka custom commands)
-updates {
-    managers = [('PAC', 'checkupdates'), ('AUR', 'auracle sync')]
-    # Similar to 'PAC {pac} AUR {aur}'
-}
-
-# specify a list of managers and/or 2-tuples (aka mixed options)
-updates {
-    managers = ['pacman', ('AUR', 'auracle sync')]
-    # Similiar to 'Pacman {pacman} AUR {aur}'
+    # custom/mixed commands             # UPD {pacman}/{aur}/{custom}
+    managers = [
+        'pacman',
+        ('aur', 'auracle sync'),
+        ('custom', 'command querying a list of updates'),
+    ]
 }
 ```
 

--- a/py3status/modules/updates.py
+++ b/py3status/modules/updates.py
@@ -21,6 +21,7 @@ Format placeholders:
     {pacman}  number of updates, eg 0 .. Arch Linux
     {pakku}   number of updates, eg 0 .. Arch Linux (AUR)
     {pikaur}  number of updates, eg 0 .. Arch Linux (AUR)
+    {pip}     number of updates, eg 0 .. Pip Installs Packages (Python)
     {pkg}     number of updates, eg 0 .. FreeBSD          [NOT TESTED]
     {snappy}  number of updates, eg 0 .. Snappy
     {trizen}  number of updates, eg 0 .. Arch Linux (AUR)
@@ -33,7 +34,7 @@ Color thresholds:
 
 @author Iain Tatch <iain.tatch@gmail.com> (arch)
 @author Joshua Pratt <jp10010101010000@gmail.com> (apt)
-@author lasers (apk, auracle, eopkg, flatpak, gem, pakku, pikaur, pkg, snappy, trizen, xbps, yay, zypper)
+@author lasers (apk, auracle, eopkg, flatpak, gem, pakku, pikaur, pip, pkg, snappy, trizen, xbps, yay, zypper)
 @author tobes (dnf)
 @license BSD (apt, arch, dnf)
 
@@ -143,6 +144,11 @@ class Pakku(Update):
         return len([x for x in output.splitlines() if x == "aur"])
 
 
+class Pip(Update):
+    def count_updates(self, output):
+        return len(output.splitlines()[2:])
+
+
 class Trizen(Update):
     def get_output(self):
         try:
@@ -221,6 +227,7 @@ class Py3status:
             others = [
                 ("Flatpak", "flatpak remote-ls --updates --all"),
                 ("Gem", "gem outdated --quiet"),
+                ("Pip", "pip list --outdated --no-color"),
                 ("Snappy", "snap refresh --list --color=never"),
             ]
 

--- a/py3status/modules/updates.py
+++ b/py3status/modules/updates.py
@@ -262,24 +262,9 @@ class Py3status:
                     break
 
         if not self.format:
-            if getattr(self, "verbose", False):
-                if getattr(self, "not_zero", False):
-                    auto = "[\?not_zero {name} [\?color={lower} {{{lower}}}]]"
-                else:
-                    auto = "[{name} [\?color={lower} {{{lower}}}]]"
-                format_string = "{}"
-                separator = "[\?soft  ]"
-            else:
-                if getattr(self, "not_zero", False):
-                    auto = "[\?not_zero [\?color={lower} {{{lower}}}]]"
-                else:
-                    auto = "[\?color={lower} {{{lower}}}]"
-                format_string = "[\?if=update UPD {}]"
-                separator = "[\?soft /]"
-            self.format = format_string.format(
-                separator.join(
-                    auto.format(name=n, lower=l) for n, l in formats
-                )
+            auto = "[\?not_zero {name} [\?color={lower} {{{lower}}}]]"
+            self.format = "[\?soft  ]".join(
+                auto.format(name=n, lower=l) for n, l in formats
             )
 
         self.thresholds_init = self.py3.get_color_names_list(self.format)
@@ -307,4 +292,4 @@ if __name__ == "__main__":
     """
     from py3status.module_test import module_test
 
-    module_test(Py3status, config={"verbose": True})
+    module_test(Py3status)

--- a/py3status/modules/updates.py
+++ b/py3status/modules/updates.py
@@ -53,7 +53,7 @@ updates {
     managers = ['pacman', 'yay']
 }
 
-# verbose and/or hide zeroes
+# specify format - verbose and/or hide zeroes
 updates {
     # default is non-verbose, show if updates
 
@@ -90,23 +90,23 @@ updates {
 ```
 
 SAMPLE OUTPUT
-[{'full_text': 'Apk '}, {'full_text': '3', 'color': '#a9a9a9'}]
+[{'full_text': 'UPD '}, {'full_text': '8', 'color': '#a9a9a9'}]
 
-14pkgs
-[{'full_text': 'Apt '}, {'full_text': '14', 'color': '#00FF00'}]
+degraded
+[{'full_text': 'UPD '}, {'full_text': '15', 'color': '#ffff00'}]
 
-29and5pkgs
-[{'full_text': 'Pacman '}, {'full_text': '29 ', 'color': '#FFFF00'},
-{'full_text': 'Auracle '}, {'full_text': '5', 'color': '#a9a9a9'}]
+orange
+[{'full_text': 'UPD '}, {'full_text': '34', 'color': '#ffa500'}]
 
-35pkgs
-[{'full_text': 'Zypper '}, {'full_text': '34', 'color': '#ffa500'}]
+bad
+[{'full_text': 'UPD '}, {'full_text': '45', 'color': '#ff0000'}]
 
-45pkgs
-[{'full_text': 'Xbps '}, {'full_text': '45', 'color': '#FF0000'}]
+arch
+[{'full_text': 'UPD '}, {'full_text': '14', 'color': '#ffff00'},
+{'full_text': '/'}, {'full_text': '2', 'color': '#a9a9a9'}]
 """
 
-STRING_INVALID_MANAGERS = 'invalid managers'
+STRING_INVALID_MANAGERS = "invalid managers"
 
 
 class Update:
@@ -182,7 +182,11 @@ class Py3status:
     format = None
     managers = []
     thresholds = [
-        (0, 'darkgray'), (10, 'degraded'), (20, 'orange'), (30, 'bad')]
+        (0, "darkgray"),
+        (10, "degraded"),
+        (20, "orange"),
+        (30, "bad"),
+    ]
 
     class Meta:
         deprecated = {
@@ -196,7 +200,7 @@ class Py3status:
                     "placeholder": "total",
                     "new": "update",
                     "format_strings": ["format"],
-                }
+                },
             ]
         }
 
@@ -206,11 +210,11 @@ class Py3status:
             if multiple:
                 managers = [
                     ("Pacman", "checkupdates"),  # must be first
-                    ("Auracle", "auracle sync --color=never"),
-                    ("Pakku", "pakku -Su --print-format '%r' --color=never"),
+                    ("Auracle", "auracle sync -q --color=never"),
+                    ("Pakku", "pakku -Suq --print-format '%r' --color=never"),
                     ("Pikaur", "pikaur -Quaq --color=never"),
                     ("Trizen", "trizen -Quaq --color=never"),
-                    ("Yay", "yay -Quaq --color=never")
+                    ("Yay", "yay -Quaq --color=never"),
                 ]
             else:
                 managers = [
@@ -226,12 +230,12 @@ class Py3status:
             new_managers = []
             for entry in self.managers:
                 if isinstance(entry, tuple):
-                    if len(entry) != 2 or entry[0].lower() == 'update':
+                    if len(entry) != 2 or entry[0].lower() == "update":
                         raise Exception(STRING_INVALID_MANAGERS)
                     new_managers.append(entry)
                 else:
                     name = entry.lower()
-                    if name == 'update':
+                    if name == "update":
                         raise Exception(STRING_INVALID_MANAGERS)
                     for manager in managers:
                         if manager[0].lower() == name:
@@ -239,8 +243,8 @@ class Py3status:
                             break
             managers = new_managers
 
-        placeholders = self.py3.get_placeholders_list(self.format or '')
-        placeholders = [x for x in placeholders if x != 'update']
+        placeholders = self.py3.get_placeholders_list(self.format or "")
+        placeholders = [x for x in placeholders if x != "update"]
 
         formats = []
         self.backends = []
@@ -259,31 +263,33 @@ class Py3status:
                     break
 
         if not self.format:
-            if getattr(self, 'verbose', False):
-                if getattr(self, 'not_zero', False):
+            if getattr(self, "verbose", False):
+                if getattr(self, "not_zero", False):
                     auto = "[\?not_zero {name} [\?color={lower} {{{lower}}}]]"
                 else:
                     auto = "[{name} [\?color={lower} {{{lower}}}]]"
                 format_string = "{}"
                 separator = "[\?soft  ]"
             else:
-                if getattr(self, 'not_zero', False):
+                if getattr(self, "not_zero", False):
                     auto = "[\?not_zero [\?color={lower} {{{lower}}}]]"
                 else:
                     auto = "[\?color={lower} {{{lower}}}]"
                 format_string = "[\?if=update UPD {}]"
                 separator = "[\?soft /]"
-            self.format = format_string.format(separator.join(
-                auto.format(name=n, lower=l) for n, l in formats
-            ))
+            self.format = format_string.format(
+                separator.join(
+                    auto.format(name=n, lower=l) for n, l in formats
+                )
+            )
 
         self.thresholds_init = self.py3.get_color_names_list(self.format)
 
     def updates(self):
-        update_data = {'update': 0}
+        update_data = {"update": 0}
         for backend in self.backends:
             update = backend.get_updates()
-            update_data['update'] += update[backend.name] or 0
+            update_data["update"] += update[backend.name] or 0
             update_data.update(update)
 
         for x in self.thresholds_init:
@@ -302,4 +308,4 @@ if __name__ == "__main__":
     """
     from py3status.module_test import module_test
 
-    module_test(Py3status, config={'verbose': True})
+    module_test(Py3status, config={"verbose": True})

--- a/py3status/modules/updates.py
+++ b/py3status/modules/updates.py
@@ -32,13 +32,14 @@ Examples:
 ```
 # multiple distributions, same format
 updates {
-    format = '[\?not_zero Updates [\?color=update {update}]]'
+    format = '[\?not_zero UPD [\?color=update {update}]]'
 }
 
 # Arch Linux
 updates {
-    format = 'Updates [\?color=pacman {pacman}]/[\?color=auracle {auracle}]'
-    # format = 'Updates [\?color=pacman {pacman}]/[\?color=yay {yay}]'
+    format = 'UPD [\?color=pacman {pacman}]/[\?color=auracle {auracle}]'
+    # format = 'UPD [\?color=pacman {pacman}]/[\?color=pikaur {pikaur}]'
+    # format = 'UPD [\?color=pacman {pacman}]/[\?color=yay {yay}]'
 }
 
 # specify a list of managers (aka supported placeholders)
@@ -75,9 +76,6 @@ SAMPLE OUTPUT
 
 45pkgs
 [{'full_text': 'Xbps '}, {'full_text': '45', 'color': '#FF0000'}]
-
-no_updates
-{'full_text': 'No Updates'}
 """
 
 STRING_INVALID_MANAGERS = 'invalid managers'
@@ -203,8 +201,21 @@ class Py3status:
                 self.backends.append(backend(self, name_lowercased, command))
 
         if not self.format:
-            auto = "[\?not_zero {name} [\?color={lower} {{{lower}}}]]"
-            self.format = "[{}|\?show No Updates]".format("[\?soft  ]".join(
+            if getattr(self, 'verbose', False):
+                if getattr(self, 'not_zero', False):
+                    auto = "[\?not_zero {name} [\?color={lower} {{{lower}}}]]"
+                else:
+                    auto = "[{name} [\?color={lower} {{{lower}}}]]"
+                format_string = "{}"
+                separator = "[\?soft  ]"
+            else:
+                if getattr(self, 'not_zero', False):
+                    auto = "[\?not_zero [\?color={lower} {{{lower}}}]]"
+                else:
+                    auto = "[\?color={lower} {{{lower}}}]"
+                format_string = "[\?if=update UPD {}]"
+                separator = "[\?soft /]"
+            self.format = format_string.format(separator.join(
                 auto.format(name=n, lower=l) for n, l in formats
             ))
 
@@ -233,4 +244,4 @@ if __name__ == "__main__":
     """
     from py3status.module_test import module_test
 
-    module_test(Py3status)
+    module_test(Py3status, config={'verbose': True})

--- a/py3status/modules/updates.py
+++ b/py3status/modules/updates.py
@@ -10,32 +10,33 @@ Configuration parameters:
         (10, 'degraded'), (20, 'orange'), (30, 'bad')])*
 
 Format placeholders:
-    {update}  number of updates, eg 0
-    {apk}     number of updates, eg 0 .. Alpine Linux     [NOT TESTED]
-    {apt}     number of updates, eg 0 .. Debian, Ubuntu
-    {auracle} number of updates, eg 0 .. Arch Linux (AUR)
-    {dnf}     number of updates, eg 0 .. Fedora
-    {eopkg}   number of updates, eg 0 .. Solus
-    {flatpak} number of updates, eg 0 .. Flatpak
-    {gem}     number of updates, eg 0 .. Ruby Programs and Libaries
-    {npm}     number of updates, eg 0 .. Node.js Package Manager (JavaScript)
-    {pacman}  number of updates, eg 0 .. Arch Linux
-    {pakku}   number of updates, eg 0 .. Arch Linux (AUR)
-    {pikaur}  number of updates, eg 0 .. Arch Linux (AUR)
-    {pip}     number of updates, eg 0 .. Pip Installs Packages (Python)
-    {pkg}     number of updates, eg 0 .. FreeBSD          [NOT TESTED]
-    {snappy}  number of updates, eg 0 .. Snappy
-    {trizen}  number of updates, eg 0 .. Arch Linux (AUR)
-    {xbps}    number of updates, eg 0 .. Void Linux       [NOT TESTED]
-    {yay}     number of updates, eg 0 .. Arch Linux (AUR)
-    {zypper}  number of updates, eg 0 .. openSUSE         [NOT TESTED]
+    {update}   number of updates, eg 0
+    {apk}      number of updates, eg 0 .. Alpine Linux     [NOT TESTED]
+    {apt}      number of updates, eg 0 .. Debian, Ubuntu
+    {auracle}  number of updates, eg 0 .. Arch Linux (AUR)
+    {dnf}      number of updates, eg 0 .. Fedora
+    {eopkg}    number of updates, eg 0 .. Solus
+    {flatpak}  number of updates, eg 0 .. Flatpak
+    {gem}      number of updates, eg 0 .. Ruby Programs and Libaries
+    {luarocks} number of updates, eg 0 .. Lua Package Manager
+    {npm}      number of updates, eg 0 .. Node.js Package Manager (JavaScript)
+    {pacman}   number of updates, eg 0 .. Arch Linux
+    {pakku}    number of updates, eg 0 .. Arch Linux (AUR)
+    {pikaur}   number of updates, eg 0 .. Arch Linux (AUR)
+    {pip}      number of updates, eg 0 .. Pip Installs Packages (Python)
+    {pkg}      number of updates, eg 0 .. FreeBSD          [NOT TESTED]
+    {snappy}   number of updates, eg 0 .. Snappy
+    {trizen}   number of updates, eg 0 .. Arch Linux (AUR)
+    {xbps}     number of updates, eg 0 .. Void Linux       [NOT TESTED]
+    {yay}      number of updates, eg 0 .. Arch Linux (AUR)
+    {zypper}   number of updates, eg 0 .. openSUSE         [NOT TESTED]
 
 Color thresholds:
     xxx: print a color based on the value of `xxx` placeholder
 
 @author Iain Tatch <iain.tatch@gmail.com> (arch)
 @author Joshua Pratt <jp10010101010000@gmail.com> (apt)
-@author lasers (apk, auracle, eopkg, flatpak, gem, npm, pakku, pikaur, pip, pkg, snappy, trizen, xbps, yay, zypper)
+@author lasers (apk, auracle, eopkg, flatpak, gem, luarocks, npm, pakku, pikaur, pip, pkg, snappy, trizen, xbps, yay, zypper)
 @author tobes (dnf)
 @license BSD (apt, arch, dnf)
 
@@ -233,6 +234,7 @@ class Py3status:
             others = [
                 ("Flatpak", "flatpak remote-ls --updates --all"),
                 ("Gem", "gem outdated --quiet"),
+                ("LuaRocks", "luarocks list --outdated --porcelain"),
                 ("Npm", "npm outdated"),
                 ("Pip", "pip list --outdated --no-color"),
                 ("Snappy", "snap refresh --list --color=never"),

--- a/py3status/modules/updates.py
+++ b/py3status/modules/updates.py
@@ -24,6 +24,7 @@ Format placeholders:
     {pakku}    number of updates, eg 0 .. Arch Linux (AUR)
     {pikaur}   number of updates, eg 0 .. Arch Linux (AUR)
     {pip}      number of updates, eg 0 .. Pip Installs Packages (Python)
+    {pkcon}    number of updates, eg 0 .. PackageKit
     {pkg}      number of updates, eg 0 .. FreeBSD          [NOT TESTED]
     {snappy}   number of updates, eg 0 .. Snappy
     {trizen}   number of updates, eg 0 .. Arch Linux (AUR)
@@ -36,7 +37,7 @@ Color thresholds:
 
 @author Iain Tatch <iain.tatch@gmail.com> (arch)
 @author Joshua Pratt <jp10010101010000@gmail.com> (apt)
-@author lasers (apk, auracle, eopkg, flatpak, gem, luarocks, npm, pakku, pikaur, pip, pkg, snappy, trizen, xbps, yay, zypper)
+@author lasers (apk, auracle, eopkg, flatpak, gem, luarocks, npm, pakku, pikaur, pip, pkcon pkg, snappy, trizen, xbps, yay, zypper)
 @author tobes (dnf)
 @license BSD (apt, arch, dnf)
 
@@ -156,6 +157,15 @@ class Pip(Update):
         return len(output.splitlines()[2:])
 
 
+class Pkcon(Update):
+    def get_output(self):
+        try:
+            output = self.parent.py3.command_output(self.command)
+        except self.parent.py3.CommandError:
+            return ""
+        return output.partition("Results:\n")[-1]
+
+
 class Trizen(Update):
     def get_output(self):
         try:
@@ -237,6 +247,7 @@ class Py3status:
                 ("LuaRocks", "luarocks list --outdated --porcelain"),
                 ("Npm", "npm outdated"),
                 ("Pip", "pip list --outdated --no-color"),
+                ("Pkcon", "pkcon get-updates --plain"),
                 ("Snappy", "snap refresh --list --color=never"),
             ]
 

--- a/py3status/modules/updates.py
+++ b/py3status/modules/updates.py
@@ -196,10 +196,7 @@ class Py3status:
     format = None
     managers = []
     thresholds = [
-        (0, "darkgray"),
-        (10, "degraded"),
-        (20, "orange"),
-        (30, "bad"),
+        (0, "darkgray"), (10, "degraded"), (20, "orange"), (30, "bad"),
     ]
 
     class Meta:
@@ -296,11 +293,13 @@ class Py3status:
         if placeholders:
             log += '== Placeholders: '.format(", ".join(placeholders))
         if custom:
-            log += '== Custom\n-{}\n'.format(custom)
-                "- '{}', '{}'\n".join(*x for x in custom
+            log += '== Custom Managers\n{}'.format(''.join(
+                ["- {:10}{}\n".format(*x) for x in custom])
             )
         else:
-            log += '== Managers\n- {}\n'.format(managers, indent=2)
+            log += '== Supported Managers\n{}'.format(''.join(
+                ["- {:10}{}\n".format(*x) for x in managers])
+            )
 
         self._init_managers([], custom, placeholders, False)
         self._init_managers(custom, managers, placeholders, multiple)
@@ -312,9 +311,11 @@ class Py3status:
             self.format = "[\?soft  ]".join(
                 auto.format(name=x, lower=x.lower()) for x in self.names
             )
-
         self.thresholds_init = self.py3.get_color_names_list(self.format)
-        log += '== Running... ' + ', '.join(self.names)
+
+        log += '== Running Managers\n{}'.format(''.join(
+            ["- {}\n".format(x) for x in self.names])
+        )[:-1]
         self.py3.log(log)
 
     def _init_managers(self, custom, managers, placeholders, multiple):

--- a/py3status/modules/updates.py
+++ b/py3status/modules/updates.py
@@ -18,6 +18,7 @@ Format placeholders:
     {eopkg}   number of updates, eg 0 .. Solus
     {flatpak} number of updates, eg 0 .. Flatpak
     {gem}     number of updates, eg 0 .. Ruby Programs and Libaries
+    {npm}     number of updates, eg 0 .. Node.js Package Manager (JavaScript)
     {pacman}  number of updates, eg 0 .. Arch Linux
     {pakku}   number of updates, eg 0 .. Arch Linux (AUR)
     {pikaur}  number of updates, eg 0 .. Arch Linux (AUR)
@@ -34,7 +35,7 @@ Color thresholds:
 
 @author Iain Tatch <iain.tatch@gmail.com> (arch)
 @author Joshua Pratt <jp10010101010000@gmail.com> (apt)
-@author lasers (apk, auracle, eopkg, flatpak, gem, pakku, pikaur, pip, pkg, snappy, trizen, xbps, yay, zypper)
+@author lasers (apk, auracle, eopkg, flatpak, gem, npm, pakku, pikaur, pip, pkg, snappy, trizen, xbps, yay, zypper)
 @author tobes (dnf)
 @license BSD (apt, arch, dnf)
 
@@ -133,6 +134,11 @@ class Eopkg(Update):
         return output
 
 
+class Npm(Update):
+    def count_updates(self, output):
+        return len(output.splitlines()[1:])
+
+
 class Pakku(Update):
     def get_output(self):
         try:
@@ -227,6 +233,7 @@ class Py3status:
             others = [
                 ("Flatpak", "flatpak remote-ls --updates --all"),
                 ("Gem", "gem outdated --quiet"),
+                ("Npm", "npm outdated"),
                 ("Pip", "pip list --outdated --no-color"),
                 ("Snappy", "snap refresh --list --color=never"),
             ]

--- a/py3status/modules/updates.py
+++ b/py3status/modules/updates.py
@@ -262,10 +262,10 @@ class Py3status:
                     name = entry.lower()
                     if name == "update":
                         raise Exception(STRING_INVALID_MANAGERS)
-                    for manager in managers:
-                        if manager[0].lower() == name:
-                            new_managers.append(manager)
-                            break
+                    for _managers in (managers, others):
+                        for manager in _managers:
+                            if manager[0].lower() == name:
+                                new_managers.append(manager)
             managers = new_managers
 
         if self.format:
@@ -276,10 +276,13 @@ class Py3status:
 
         formats = []
         self.backends = []
-        for index, managers in enumerate((managers, others)):
-            for name, command in managers:
+        for index, _managers in enumerate((managers, others)):
+            for name, command in _managers:
                 name_lowercased = name.lower()
-                if placeholders and name_lowercased not in placeholders:
+                if not index:
+                    if placeholders and name_lowercased not in placeholders:
+                        continue
+                elif name_lowercased not in placeholders:
                     continue
                 if self.py3.check_commands(command.split()[0]):
                     try:
@@ -299,6 +302,7 @@ class Py3status:
                 auto.format(name=n, lower=l) for n, l in formats
             )
 
+        self.py3.log('Updating: ' + ', '.join([x[0] for x in formats]))
         self.thresholds_init = self.py3.get_color_names_list(self.format)
 
     def updates(self):

--- a/py3status/modules/updates.py
+++ b/py3status/modules/updates.py
@@ -14,6 +14,7 @@ Format placeholders:
     {apk}      number of updates, eg 0 .. Alpine Linux     [NOT TESTED]
     {apt}      number of updates, eg 0 .. Debian, Ubuntu
     {auracle}  number of updates, eg 0 .. Arch Linux (AUR)
+    {cargo}    number of updates, eg 0 .. Rust package manager [NOT TESTED]
     {dnf}      number of updates, eg 0 .. Fedora
     {eopkg}    number of updates, eg 0 .. Solus
     {flatpak}  number of updates, eg 0 .. Flatpak
@@ -37,7 +38,7 @@ Color thresholds:
 
 @author Iain Tatch <iain.tatch@gmail.com> (arch)
 @author Joshua Pratt <jp10010101010000@gmail.com> (apt)
-@author lasers (apk, auracle, eopkg, flatpak, gem, luarocks, npm, pakku, pikaur, pip, pkcon pkg, snappy, trizen, xbps, yay, zypper)
+@author lasers (apk, auracle, cargo, eopkg, flatpak, gem, luarocks, npm, pakku, pikaur, pip, pkcon pkg, snappy, trizen, xbps, yay, zypper)
 @author tobes (dnf)
 @license BSD (apt, arch, dnf)
 
@@ -122,6 +123,11 @@ class Apt(Update):
 class Apk(Update):
     def count_updates(self, output):
         return len(output.splitlines()[1:])
+
+
+class Cargo(Update):
+    def count_updates(self, output):
+        return len(output.splitlines()[2:])
 
 
 class Dnf(Update):
@@ -243,6 +249,7 @@ class Py3status:
                     ("Zypper", "zypper list-updates"),
                 ]
             others = [
+                ("Cargo", "cargo outdated --color=never"),
                 ("Flatpak", "flatpak remote-ls --updates --all"),
                 ("Gem", "gem outdated --quiet"),
                 ("LuaRocks", "luarocks list --outdated --porcelain"),
@@ -325,7 +332,10 @@ class Py3status:
                 continue
             if any([name_lowercased in x[1] for x in self.formats]):
                 continue
-            if self.py3.check_commands(command.split()[0]):
+            check_command = command.split()[0]
+            if check_command == 'cargo':
+                check_command = 'cargo-outdated'
+            if self.py3.check_commands(check_command):
                 try:
                     backend = globals()[name.capitalize()]
                 except KeyError:

--- a/py3status/modules/updates.py
+++ b/py3status/modules/updates.py
@@ -196,7 +196,10 @@ class Py3status:
     format = None
     managers = []
     thresholds = [
-        (0, "darkgray"), (10, "degraded"), (20, "orange"), (30, "bad"),
+        (0, "darkgray"),
+        (10, "degraded"),
+        (20, "orange"),
+        (30, "bad"),
     ]
 
     class Meta:
@@ -222,7 +225,8 @@ class Py3status:
 
     def post_config_hook(self):
         distributions = {
-            'archlinux': [
+            "alpine": [("Apk", "apk version -l '<'")],
+            "archlinux": [
                 ("Pacman", "checkupdates"),  # must be first
                 ("Auracle", "auracle sync -q --color=never"),
                 ("Pakku", "pakku -Suq --print-format '%r' --color=never"),
@@ -230,16 +234,18 @@ class Py3status:
                 ("Trizen", "trizen -Quaq --color=never"),
                 ("Yay", "yay -Quaq --color=never"),
             ],
-            'alpine': [("Apk", "apk version -l '<'")],
-            'debian': [(
-                "Apt", "apt-get dist-upgrade --dry-run -qq "
-                "-o APT::Get::Show-User-Simulation-Note=no",
-            )],
-            'fedora': [("Dnf", "dnf list --refresh --upgrades --quiet")],
-            'opensuse': [("Zypper", "zypper list-updates")],
-            'solus': [("Eopkg", "eopkg list-upgrades --no-color")],
-            'freebsd': [("Pkg", "pkg upgrade --dry-run --quiet")],
-            'voidlinux': [("Xbps", "xbps-install --update --dry-run")]
+            "debian": [
+                (
+                    "Apt",
+                    "apt-get dist-upgrade --dry-run -qq "
+                    "-o APT::Get::Show-User-Simulation-Note=no",
+                )
+            ],
+            "fedora": [("Dnf", "dnf list --refresh --upgrades --quiet")],
+            "freebsd": [("Pkg", "pkg upgrade --dry-run --quiet")],
+            "opensuse": [("Zypper", "zypper list-updates")],
+            "solus": [("Eopkg", "eopkg list-upgrades --no-color")],
+            "voidlinux": [("Xbps", "xbps-install --update --dry-run")],
         }
         others = [
             ("Cargo", "cargo outdated --color=never"),
@@ -291,14 +297,14 @@ class Py3status:
             managers = custom
 
         if placeholders:
-            log += '== Placeholders: '.format(", ".join(placeholders))
+            log += "== Placeholders: ".format(", ".join(placeholders))
         if custom:
-            log += '== Custom Managers\n{}'.format(''.join(
-                ["- {:10}{}\n".format(*x) for x in custom])
+            log += "== Custom Managers\n{}".format(
+                "".join(["- {:10}{}\n".format(*x) for x in custom])
             )
         else:
-            log += '== Supported Managers\n{}'.format(''.join(
-                ["- {:10}{}\n".format(*x) for x in managers])
+            log += "== Supported Managers\n{}".format(
+                "".join(["- {:10}{}\n".format(*x) for x in managers])
             )
 
         self._init_managers([], custom, placeholders, False)
@@ -313,8 +319,8 @@ class Py3status:
             )
         self.thresholds_init = self.py3.get_color_names_list(self.format)
 
-        log += '== Running Managers\n{}'.format(''.join(
-            ["- {}\n".format(x) for x in self.names])
+        log += "== Running Managers\n{}".format(
+            "".join(["- {}\n".format(x) for x in self.names])
         )[:-1]
         self.py3.log(log)
 
@@ -326,17 +332,15 @@ class Py3status:
             if any([name_lowercased in x.lower() for x in self.names]):
                 continue
             check_command = command.split()[0]
-            if check_command == 'cargo':
-                check_command = 'cargo-outdated'
+            if check_command == "cargo":
+                check_command = "cargo-outdated"
             if self.py3.check_commands(check_command):
                 try:
                     backend = globals()[name.capitalize()]
                 except KeyError:
                     backend = Update
                 self.names.append(name)
-                self.backends.append(
-                    backend(self, name_lowercased, command)
-                )
+                self.backends.append(backend(self, name_lowercased, command))
                 if not multiple:
                     break
 

--- a/py3status/modules/updates.py
+++ b/py3status/modules/updates.py
@@ -15,6 +15,7 @@ Format placeholders:
     {apt}      number of updates, eg 0 .. Debian, Ubuntu
     {auracle}  number of updates, eg 0 .. Arch Linux (AUR)
     {cargo}    number of updates, eg 0 .. Rust package manager [NOT TESTED]
+    {cpan}     number of updates, eg 0 .. CPAN modules (Perl)
     {dnf}      number of updates, eg 0 .. Fedora
     {eopkg}    number of updates, eg 0 .. Solus
     {flatpak}  number of updates, eg 0 .. Flatpak
@@ -38,7 +39,7 @@ Color thresholds:
 
 @author Iain Tatch <iain.tatch@gmail.com> (arch)
 @author Joshua Pratt <jp10010101010000@gmail.com> (apt)
-@author lasers (apk, auracle, cargo, eopkg, flatpak, gem, luarocks, npm, pakku, pikaur, pip, pkcon pkg, snappy, trizen, xbps, yay, zypper)
+@author lasers (apk, auracle, cargo, cpan, eopkg, flatpak, gem, luarocks, npm, pakku, pikaur, pip, pkcon pkg, snappy, trizen, xbps, yay, zypper)
 @author tobes (dnf)
 @license BSD (apt, arch, dnf)
 
@@ -250,6 +251,7 @@ class Py3status:
                 ]
             others = [
                 ("Cargo", "cargo outdated --color=never"),
+                ("Cpan", "cpan-outdated"),
                 ("Flatpak", "flatpak remote-ls --updates --all"),
                 ("Gem", "gem outdated --quiet"),
                 ("LuaRocks", "luarocks list --outdated --porcelain"),

--- a/py3status/modules/updates.py
+++ b/py3status/modules/updates.py
@@ -90,7 +90,6 @@ arch
 {'full_text': '/'}, {'full_text': '2', 'color': '#a9a9a9'}]
 """
 
-from pprint import pformat
 STRING_INVALID_MANAGERS = "invalid managers"
 STRING_UNKNOWN_LINUX_DISTRIBUTION = "unknown linux distribution"
 
@@ -295,11 +294,13 @@ class Py3status:
             managers = custom
 
         if placeholders:
-            log += '== Placeholders\n-{}\n'.format(placeholders)
+            log += '== Placeholders: '.format(", ".join(placeholders))
         if custom:
-            log += '== Custom\n-{}\n'.format(pformat(custom, indent=4))
+            log += '== Custom\n-{}\n'.format(custom)
+                "- '{}', '{}'\n".join(*x for x in custom
+            )
         else:
-            log += '== Managers\n- {}\n'.format(pformat(managers, indent=4))
+            log += '== Managers\n- {}\n'.format(managers, indent=2)
 
         self._init_managers([], custom, placeholders, False)
         self._init_managers(custom, managers, placeholders, multiple)

--- a/py3status/modules/updates.py
+++ b/py3status/modules/updates.py
@@ -37,11 +37,12 @@ Format placeholders:
 Color thresholds:
     xxx: print a color based on the value of `xxx` placeholder
 
-@author Iain Tatch <iain.tatch@gmail.com> (arch)
+@author Iain Tatch <iain.tatch@gmail.com> (pacman)
 @author Joshua Pratt <jp10010101010000@gmail.com> (apt)
-@author lasers (apk, auracle, cargo, cpan, eopkg, flatpak, gem, luarocks, npm, pakku, pikaur, pip, pkcon pkg, snappy, trizen, xbps, yay, zypper)
+@author lasers (apk, auracle, cargo, cpan, eopkg, flatpak, gem, luarocks,
+    npm, pakku, pikaur, pip, pkcon, pkg, snappy, trizen, xbps, yay, zypper)
 @author tobes (dnf)
-@license BSD (apt, arch, dnf)
+@license BSD (apt, pacman, dnf)
 
 Examples:
 ```
@@ -296,8 +297,6 @@ class Py3status:
                             break
             managers = custom
 
-        if placeholders:
-            log += "== Placeholders: ".format(", ".join(placeholders))
         if custom:
             log += "== Custom Managers\n{}".format(
                 "".join(["- {:10}{}\n".format(*x) for x in custom])
@@ -306,6 +305,8 @@ class Py3status:
             log += "== Supported Managers\n{}".format(
                 "".join(["- {:10}{}\n".format(*x) for x in managers])
             )
+        if placeholders:
+            log += "== Placeholders:\n- {}\n".format(", ".join(placeholders))
 
         self._init_managers([], custom, placeholders, False)
         self._init_managers(custom, managers, placeholders, multiple)
@@ -319,7 +320,7 @@ class Py3status:
             )
         self.thresholds_init = self.py3.get_color_names_list(self.format)
 
-        log += "== Running Managers\n{}".format(
+        log += "== Running Managers:\n{}".format(
             "".join(["- {}\n".format(x) for x in self.names])
         )[:-1]
         self.py3.log(log)
@@ -367,22 +368,4 @@ if __name__ == "__main__":
     """
     from py3status.module_test import module_test
 
-    config = {}
-    # config = {'managers': ['pkcon', 'yay', 'pacman']}
-    # config = {'format': '{yay}'}
-
-    # config = {
-    #     'managers': ['pkcon', 'yay', 'pacman'],
-    #     'format': '{yay}',
-    # }
-
-    # config = {'managers': ['pkcon']}
-
-    # config = {'managers': ['pkcon', 'yay', 'pacman']}
-
-    # config = {
-    #     'managers': ['pkcon', 'yay', 'pacman', 'gem', 'pikaur'],
-    #     'format': '{pkcon}'
-    # }
-
-    module_test(Py3status, config=config)
+    module_test(Py3status)

--- a/py3status/modules/updates.py
+++ b/py3status/modules/updates.py
@@ -295,9 +295,9 @@ class Py3status:
         log += '- {}\n'.format(pprint.pformat(managers, indent=2))
         log += '- {}\n'.format(pprint.pformat(placeholders, indent=2))
 
-        self._init_managers(custom, placeholders, False)
-        self._init_managers(managers, placeholders, multiple)
-        self._init_managers(others, placeholders, True)
+        self._init_managers(custom, custom, placeholders, False)
+        self._init_managers(custom, managers, placeholders, multiple)
+        self._init_managers(custom, others, placeholders, True)
 
         if not self.format:
             auto = "[\?not_zero {name} [\?color={lower} {{{lower}}}]]"
@@ -309,12 +309,14 @@ class Py3status:
         log += '== Running... ' + ', '.join([x[0] for x in self.formats])
         self.py3.log(log)
 
-    def _init_managers(self, managers, placeholders, multiple):
+    def _init_managers(self, custom, managers, placeholders, multiple):
+        if custom == managers:
+            return
         for name, command in managers:
             name_lowercased = name.lower()
-            if placeholders and name_lowercased not in placeholders:
+            if any([name_lowercased in x[1] for x in custom]):
                 continue
-            if any([name_lowercased in x[1] for x in self.formats]):
+            if placeholders and name_lowercased not in placeholders:
                 continue
             if self.py3.check_commands(command.split()[0]):
                 try:


### PR DESCRIPTION
Hi. I made a new module `updates`. :information_source: 

The `format`, if left unconfigured, will be auto-configured based on checked binaries.
* Tested okay on Arch Linux along with different AUR checkers. Often, users will not install both of them so it can be displaying one, two, or more... or users can configure the `format` if they wish to keep them all installed.
* Tested okay on Ubuntu. I feel this is okay on Debian too.
* Tested okay on Solus.
* Other placeholders comes from my rejected `*_updates` PRs. They should work okay. Untested.
* If there are no updates, `No Updates` will be displayed. The (auto) `format` uses something like `[\?not_zero {package}]|No Updates`. See second module in the screenshot. 

Supports (tested): `apt`, `cower`, `eopkg`, `pacman`, `yay`.
Supports (untested): `apk`, `xbps`, `zypper`.
Not Implemented: `dnf`, `pkg`, and many more.

![updates-2018-10-21](https://user-images.githubusercontent.com/852504/47263617-69e68f00-d4ca-11e8-808c-786a72168609.png)

![2018-10-31](https://user-images.githubusercontent.com/852504/47813655-b8412c80-dd19-11e8-8cf0-21917703bdd8.png)
