### PR TITLE
parse_config: raise error on invalid modules

### DIFF
--- a/py3status/parse_config.py
+++ b/py3status/parse_config.py
@@ -644,6 +644,8 @@ class ConfigParser:
                 value = self.assignment(token)
                 # order is treated specially to create a list
                 if self.level == 1 and name == "order":
+                    if not value:
+                        self.error("Invalid module")
                     self.check_module_name(value, offset=1)
                     dictionary.setdefault(name, []).append(value)
                 # assignment of  module definition


### PR DESCRIPTION
We check for invalid ~~(empty)~~ modules so py3status does not die with a vague message.
```python
order += ""  # IndexError: list index out of range
order += None  # AttributeError: 'NoneType' object has no attribute 'split'
```
Vague message is:
```
Error: status_command process exited unexpectedly (exit 2)
```

Addresses https://github.com/ultrabug/py3status/issues/1523. 