### PR TITLE
systemd: new module from scratch

### DIFF
--- a/py3status/modules/systemd.py
+++ b/py3status/modules/systemd.py
@@ -1,20 +1,37 @@
 # -*- coding: utf-8 -*-
 """
-Display status of a service on your system.
+Display systemd1 unit properties of a service.
 
 Configuration parameters:
     cache_timeout: refresh interval for this module (default 5)
-    format: display format for this module (default '{unit}: {status}')
-    unit: specify the systemd unit to use (default 'dbus.service')
+    format: display format for this module
+        *(default '{Id} [\?if=LoadState=not-found&color=degraded '
+        '{LoadState}|[\?color=ActiveState {ActiveState}]]')*
+    thresholds: specify color thresholds to use
+        (default [('inactive', 'bad'), ('active', 'good')])
+    unit: specify a systemd1 unit to use (default 'sshd.service')
 
-Format of status string placeholders:
-    {unit} unit name, eg sshd
-    {status} unit status, eg active, inactive, not-found
+Format placeholders:
+    {ActiveState}   eg inactive, active
+    {Description}   eg OpenSSH Daemon
+    {Id}            eg sshd.service
+    {LoadState}     eg loaded, not-found
+
+    Use...
+    ```
+    dbus-send --print-reply --system --type=method_call \
+        --dest=org.freedesktop.systemd1 \
+        /org/freedesktop/systemd1/unit/sshd_2eservice \
+        org.freedesktop.DBus.Properties.GetAll string:''
+    ```
+    for a full list of systemd1 `sshd.service` unit properties to use.
+    Not all of systemd1 unit properties will be supported or usable. For
+    different systemd1 units, you can find out with d-feet or other tools.
 
 Color options:
-    color_good: unit active
-    color_bad: unit inactive
-    color_degraded: unit not-found
+    color_good: systemd1 unit active
+    color_bad: systemd1 unit inactive
+    color_degraded: systemd1 unit not-found
 
 Examples:
 ```
@@ -27,57 +44,126 @@ systemd vpn {
 }
 ```
 
-Requires:
-    pydbus: pythonic dbus library
+Examples:
+```
+# legacy theme
+systemd {
+    format = '[\?if=LoadState=not-found&color=degraded {Id} {LoadState}'
+    format += '|[\?color=ActiveState {Id} {ActiveState}]]'
+}
+
+# replace sshd.service with sshd
+systemd {
+    # custom name or icon
+    format = 'sshd [\?if=LoadState=not-found&color=degraded {LoadState}'
+    format += '|[\?color=ActiveState {ActiveState}]]'
+        OR
+    # cut off the length
+    format = '[\?max_length=-8 {Id}] [\?if=LoadState=not-found&color=degraded'
+    format += ' {LoadState}|[\?color=ActiveState {ActiveState}]]'
+}
+
+# show if inactive or active
+systemd {
+    # show if inactive
+    format = '[\?if=LoadState=not-found {Id} [\?color=degraded {LoadState}]]'
+    format += '[\?if=ActiveState=inactive {Id} [\?color=bad {ActiveState}]]'
+        OR
+    # show if active
+    format = '[\?if=LoadState=not-found {Id} [\?color=degraded {LoadState}]]'
+    format += '[\?if=ActiveState=active {Id} [\?color=good {ActiveState}]]'
+}
+
+# show if active and disabled or inactive and enabled
+systemd {
+    format = '[\?if=LoadState=not-found {Id} [\?color=degraded {LoadState}]]'
+    format += '[\?if=ActiveState=active [\?if=UnitFileState=disabled '
+    format += '{Id} [\?color=ActiveState {ActiveState}]]]'
+    format += '[\?if=ActiveState=inactive [\?if=UnitFileState=enabled '
+    format += '{Id} [\?color=ActiveState {ActiveState}]]]'
+}
+```
 
 @author Adrian Lopez <adrianlzt@gmail.com>
 @license BSD
 
 SAMPLE OUTPUT
-{'color': '#00FF00', 'full_text': 'sshd.service: active'}
+[
+    {'full_text': 'sshd.service '},
+    {'color': '#00FF00', 'full_text': 'active'}
+]
 
 inactive
-{'color': '#FF0000', 'full_text': 'sshd.service: inactive'}
+[
+    {'full_text': 'sshd.service '},
+    {'color': '#FF0000', 'full_text': 'inactive'}
+]
 
 not-found
-{'color': '#FFFF00', 'full_text': 'sshd.service: not-found'}
+[
+    {'full_text': 'sshd.service '},
+    {'color': '#FFFF00', 'full_text': 'not-found'}
+]
+
 """
 
-from pydbus import SystemBus
+import dbus
+
+SYSTEMD1 = "org.freedesktop.systemd1"
+UNIT = "org.freedesktop.systemd1.Unit"
+PROP = "org.freedesktop.DBus.Properties"
+MANAGER = "org.freedesktop.systemd1.Manager"
 
 
 class Py3status:
     """
     """
+
     # available configuration parameters
     cache_timeout = 5
-    format = '{unit}: {status}'
-    unit = 'dbus.service'
+    format = (
+        "{Id} [\?if=LoadState=not-found&color=degraded {LoadState}"
+        "|[\?color=ActiveState {ActiveState}]]"
+    )
+    thresholds = [("inactive", "bad"), ("active", "good")]
+    unit = "sshd.service"
+
+    class Meta:
+        deprecated = {
+            "rename_placeholder": [
+                {
+                    "placeholder": "status",
+                    "new": "ActiveState",
+                    "format_strings": ["format"],
+                }
+            ]
+        }
 
     def post_config_hook(self):
-        bus = SystemBus()
-        systemd = bus.get('org.freedesktop.systemd1')
-        self.systemd_unit = bus.get('.systemd1', systemd.LoadUnit(self.unit))
+        self.placeholders = self.py3.get_placeholders_list(self.format)
+        self.thresholds_init = self.py3.get_color_names_list(self.format)
+
+        bus = dbus.SystemBus()
+        systemd = bus.get_object(SYSTEMD1, "/org/freedesktop/systemd1")
+        manager = dbus.Interface(systemd, dbus_interface=MANAGER)
+        proxy = bus.get_object(SYSTEMD1, manager.LoadUnit(self.unit))
+        self.systemd_unit = dbus.Interface(proxy, dbus_interface=UNIT)
 
     def systemd(self):
-        status = self.systemd_unit.Get('org.freedesktop.systemd1.Unit', 'ActiveState')
-        exists = self.systemd_unit.Get('org.freedesktop.systemd1.Unit', 'LoadState')
+        systemd_data = self.systemd_unit.GetAll(UNIT, dbus_interface=PROP)
 
-        if exists == 'not-found':
-            color = self.py3.COLOR_DEGRADED
-            status = exists
-        elif status == 'active':
-            color = self.py3.COLOR_GOOD
-        elif status == 'inactive':
-            color = self.py3.COLOR_BAD
-        else:
-            color = self.py3.COLOR_DEGRADED
+        for x in self.placeholders:
+            if x in systemd_data:
+                if isinstance(systemd_data[x], (list, tuple)):
+                    systemd_data[x] = ", ".join(systemd_data[x])
+
+        for x in self.thresholds_init:
+            if x in systemd_data:
+                self.py3.threshold_get_color(systemd_data[x], x)
 
         return {
-            'cached_until': self.py3.time_in(self.cache_timeout),
-            'color': color,
-            'full_text': self.py3.safe_format(
-                self.format, {'unit': self.unit, 'status': status})
+            "cached_until": self.py3.time_in(self.cache_timeout),
+            "full_text": self.py3.safe_format(self.format, systemd_data),
         }
 
 
@@ -86,4 +172,5 @@ if __name__ == "__main__":
     Run module in test mode.
     """
     from py3status.module_test import module_test
+
     module_test(Py3status)


### PR DESCRIPTION
This addresses the issues in (2) `systemd` pull requests.

* Replaces #1381, **Hide service extension**.
    * We replace boolean config with the format.
    * Single format for full customization. Colors included.
    * Allow more things to happen in the future (ie formatters).
    * Users can specify: SSH, ssh, sshd, [sshd], OpenSSH etc.
* Replaces #1382, **Suppress output if unit is in default state**.
    * We replace string config with the format.
    * Single format for full customization. Colors included.
    * Allow more things to happen in the future (ie formatters).
    * Format allows us to do more than (4) hide_if_default options.
    * More than 50+ placeholders. Not all of them will be supported or usable.

This is also here because @tobes puts out a dbus helper for modules.
* If he want to, he can use this PR with a diff below to help himself making a better dbus helper... for `systemd` without `cache_timeout` and other modules. Note: The diff seems identical to the `Upower` one, but it does not work. I acknowledge it is not finished. Cheers.
```diff
diff --git a/py3status/modules/systemd.py b/py3status/modules/systemd.py
index caa2bde7..dfbcb53f 100644
--- a/py3status/modules/systemd.py
+++ b/py3status/modules/systemd.py
@@ -3,7 +3,6 @@
 Display systemd1 unit properties of a service.
 
 Configuration parameters:
-    cache_timeout: refresh interval for this module (default 5)
     format: display format for this module
         *(default '{Id} [\?if=LoadState=not-found&color=degraded '
         '{LoadState}|[\?color=ActiveState {ActiveState}]]')*
@@ -120,7 +119,6 @@ class Py3status:
     """
 
     # available configuration parameters
-    cache_timeout = 5
     format = (
         "{Id} [\?if=LoadState=not-found&color=degraded {LoadState}"
         "|[\?color=ActiveState {ActiveState}]]"
@@ -148,6 +146,7 @@ class Py3status:
         manager = dbus.Interface(systemd, dbus_interface=MANAGER)
         proxy = bus.get_object(SYSTEMD1, manager.LoadUnit(self.unit))
         self.systemd_unit = dbus.Interface(proxy, dbus_interface=UNIT)
+        self.py3.dbus_subscribe(".systemd1", "update")
 
     def systemd(self):
         systemd_data = self.systemd_unit.GetAll(UNIT, dbus_interface=PROP)
@@ -162,7 +161,7 @@ class Py3status:
                 self.py3.threshold_get_color(systemd_data[x], x)
 
         return {
-            "cached_until": self.py3.time_in(self.cache_timeout),
+            "cached_until": self.py3.time_in(self.py3.CACHE_FOREVER),
             "full_text": self.py3.safe_format(self.format, systemd_data),
         }
 
```