### PR TITLE
py3: notify_user module name in the title

### DIFF
--- a/py3status/py3.py
+++ b/py3status/py3.py
@@ -523,7 +523,7 @@ class Py3:
         self._module.prevent_refresh = True
 
     def notify_user(
-        self, msg, level="info", rate_limit=5, title="py3status", icon=None
+        self, msg, level="info", rate_limit=5, title=None, icon=None
     ):
         """
         Send a notification to the user.
@@ -532,9 +532,12 @@ class Py3:
         should not be repeated.
         icon must be an icon path or icon name.
         """
+        module_name = self._module.module_full_name
         if isinstance(msg, Composite):
             msg = msg.text()
-        if isinstance(title, Composite):
+        if title is None:
+            title = 'py3status: {}'.format(module_name)
+        elif isinstance(title, Composite):
             title = title.text()
         # force unicode for python2 str
         if self._is_python_2:
@@ -543,7 +546,6 @@ class Py3:
             if isinstance(title, str):
                 title = title.decode("utf-8")
         if msg:
-            module_name = self._module.module_full_name
             self._py3_wrapper.notify_user(
                 msg=msg,
                 level=level,


### PR DESCRIPTION
This clears up minor confusion about the origin of the notifications.
* Notifications coming from py3status will have `py3status` title.
* Notifications coming from modules will have `py3status: module_name` title.
   * Before `py3status` vs After `py3status: pomodoro`.

    I thought about removing `py3status` prefix, but that seems like a bad idea because of module names such as `google_calendar`, `i3pystatus`, `i3block`, `github`, `gitlab`, etc.

    Soon or later, modules like `usbguard`, `pomodoro`, etc can be updated with different titles such as capitalizing `Pomodoro` rather than (current) `py3status` or (this pr) `py3status: pomodoro`. 