### PR TITLE
allow test_modules to use udev_monitor

### DIFF
--- a/py3status/module_test.py
+++ b/py3status/module_test.py
@@ -6,8 +6,14 @@ from py3status.core import Common, Module
 
 
 class MockPy3statusWrapper:
+    """
+    """
     class EventThread:
         def process_event(self, *arg, **kw):
+            pass
+
+    class UdevMonitor:
+        def subscribe(self, *arg):
             pass
 
     def __init__(self, config):
@@ -21,6 +27,7 @@ class MockPy3statusWrapper:
             "log_file": True,
         }
         self.events_thread = self.EventThread()
+        self.udev_monitor = self.UdevMonitor()
         self.i3status_thread = None
         self.lock = Event()
         self.output_modules = {}


### PR DESCRIPTION
Before.
```
$ python3 xrandr.py
Module `test_module` could not be loaded
'MockPy3statusWrapper' object has no attribute 'udev_monitor'
```
After.
```
$ python3 xrandr.py
{'full_text': 'DP-2+DP-3', 'color': '#00FF00', 'cached_until': 1540554427.0}
{'full_text': 'DP-2+DP-3', 'color': '#00FF00', 'cached_until': 1540554428.0}
^C
```
```
$ python3 xrandr.py --term
DP-2+DP-3
DP-2+DP-3
^C
```
