### PR TITLE
fix flake8 W605 errors in core and disable test for modules

### DIFF
--- a/fastentrypoints.py
+++ b/fastentrypoints.py
@@ -39,7 +39,7 @@ http://github.com/ninjaaron/fast-entry_points
 from setuptools.command import easy_install
 import re
 
-TEMPLATE = """\
+TEMPLATE = r"""\
 # -*- coding: utf-8 -*-
 # EASY-INSTALL-ENTRY-SCRIPT: '{3}','{4}','{5}'
 __requires__ = '{3}'
@@ -89,7 +89,7 @@ def main():
     import sys
 
     dests = sys.argv[1:] or ["."]
-    filename = re.sub("\.pyc$", ".py", __file__)
+    filename = re.sub(r"\.pyc$", ".py", __file__)
 
     for dst in dests:
         shutil.copy(filename, dst)

--- a/py3status/docstrings.py
+++ b/py3status/docstrings.py
@@ -20,7 +20,7 @@ def parse_readme():
     returns a dict of {<module_name>: <documentation>}
     """
     name = None
-    re_mod = re.compile('^\#\#\# <a name="(?P<name>[a-z_0-9]+)"></a>')
+    re_mod = re.compile(r'^\#\#\# <a name="(?P<name>[a-z_0-9]+)"></a>')
     readme_file = os.path.join(modules_directory(), "README.md")
     modules_dict = {}
     with open(readme_file) as f:
@@ -118,23 +118,23 @@ def create_readme(data):
     return "".join(out)
 
 
-re_listing = re.compile("^\w.*:$")
+re_listing = re.compile(r"^\w.*:$")
 
 # match in README.md
-re_to_param = re.compile("^  - `([a-z]\S+)`($|[ \t])")
-re_to_status = re.compile("^  - `({\S+})`($|[ \t])")
-re_to_item = re.compile("^\s+-")
-re_to_data = re.compile("^\*\*(author|license|source)\*\*($|[ \t])")
+re_to_param = re.compile(r"^  - `([a-z]\S+)`($|[ \t])")
+re_to_status = re.compile(r"^  - `({\S+})`($|[ \t])")
+re_to_item = re.compile(r"^\s+-")
+re_to_data = re.compile(r"^\*\*(author|license|source)\*\*($|[ \t])")
 re_to_tag = re.compile("&lt;([^.]*)&gt;")
-re_to_defaults = re.compile("\*(\(default.*\))\*")
+re_to_defaults = re.compile(r"\*(\(default.*\))\*")
 
 # match in module docstring
-re_from_param = re.compile("^    ([a-z<]\S+):($|[ \t])(.*)$")
-re_from_status = re.compile("^\s+({\S+})($|[ \t])(.*)$")
-re_from_item = re.compile("^\s+-(?=\s)")
+re_from_param = re.compile(r"^    ([a-z<]\S+):($|[ \t])(.*)$")
+re_from_status = re.compile(r"^\s+({\S+})($|[ \t])(.*)$")
+re_from_item = re.compile(r"^\s+-(?=\s)")
 re_from_data = re.compile("^@(author|license|source)($|[ \t])")
 re_from_tag = re.compile("((`[^`]*`)|[<>&])")
-re_from_defaults = re.compile("(\(default.*\))\s*$")
+re_from_defaults = re.compile(r"(\(default.*\))\s*$")
 
 # for rst
 re_lone_backtick = re.compile("(?<!`)`(?!`)")

--- a/py3status/formatter.py
+++ b/py3status/formatter.py
@@ -126,7 +126,7 @@ class Formatter:
 
                     # we cannot use urlencode because it will escape things
                     # like `!`
-                    output.append("\?{} ".format("&".join(items)))
+                    output.append(r"\?{} ".format("&".join(items)))
                     continue
             value = token.group(0)
             output.append(value)
@@ -436,7 +436,7 @@ class Condition:
 
 
 class BlockConfig:
-    """
+    r"""
     Block commands eg [\?color=bad ...] are stored in this object
     """
 

--- a/py3status/parse_config.py
+++ b/py3status/parse_config.py
@@ -135,17 +135,17 @@ class ConfigParser:
         "#.*$"  # comments
         "|(?P<function>"  # functions of the form `name(payload[,type])`
         "" + FUNCTIONS + r"\(\s*(([^)\\]|\\.)*?)"  # nasty '' but flake8
-        "(\s*,\s*" + CONVERSIONS + ")?\s*\))"
-        "|(?P<operator>[()[\]{},:]|\+?=)"  # operators
+        r"(\s*,\s*" + CONVERSIONS + r")?\s*\))"
+        r"|(?P<operator>[()[\]{},:]|\+?=)"  # operators
         "|(?P<literal>"
         r'("(?:[^"\\]|\\.)*")'  # double quoted string
         r"|('(?:[^'\\]|\\.)*')"  # single quoted string
-        "|([a-z_][a-z0-9_\-]*(:[a-z0-9_]+)?)"  # token
-        "|(-?\d+\.\d*)|(-?\.\d+)"  # float
-        "|(-?\d+)"  # int
+        r"|([a-z_][a-z0-9_\-]*(:[a-z0-9_]+)?)"  # token
+        r"|(-?\d+\.\d*)|(-?\.\d+)"  # float
+        r"|(-?\d+)"  # int
         ")"
         r"|(?P<newline>\n)"  # newline
-        "|(?P<unknown>\S+)"  # unknown token
+        r"|(?P<unknown>\S+)"  # unknown token
     ]
 
     def __init__(self, config, py3_wrapper):
@@ -353,7 +353,7 @@ class ConfigParser:
         value_type = match.group(6) or "auto"
 
         # fix any escaped closing parenthesis
-        param = param.replace("\)", ")")
+        param = param.replace(r"\)", ")")
 
         CONFIG_FUNCTIONS = {
             "base64": self.make_function_value_private,

--- a/py3status/py3.py
+++ b/py3status/py3.py
@@ -769,7 +769,7 @@ class Py3:
     def safe_format(
         self, format_string, param_dict=None, force_composite=False, attr_getter=None
     ):
-        """
+        r"""
         Parser for advanced formatting.
 
         Unknown placeholders will be shown in the output eg ``{foo}``.

--- a/tests/test_formatter.py
+++ b/tests/test_formatter.py
@@ -436,65 +436,65 @@ def test_55():
 def test_56():
     run_formatter(
         # commands
-        {"format": "{missing}|\?show Anon", "expected": "Anon"}
+        {"format": r"{missing}|\?show Anon", "expected": "Anon"}
     )
 
 
 def test_57():
     run_formatter(
-        {"format": "Hello [{missing}|[\?show Anon]]!", "expected": "Hello Anon!"}
+        {"format": r"Hello [{missing}|[\?show Anon]]!", "expected": "Hello Anon!"}
     )
 
 
 def test_58():
-    run_formatter({"format": "[\?if=yes Hello]", "expected": "Hello"})
+    run_formatter({"format": r"[\?if=yes Hello]", "expected": "Hello"})
 
 
 def test_58a():
-    run_formatter({"format": "\?if=yes Hello", "expected": "Hello"})
+    run_formatter({"format": r"\?if=yes Hello", "expected": "Hello"})
 
 
 def test_59():
-    run_formatter({"format": "[\?if=no Hello]", "expected": ""})
+    run_formatter({"format": r"[\?if=no Hello]", "expected": ""})
 
 
 def test_59a():
-    run_formatter({"format": "\?if=no Hello", "expected": ""})
+    run_formatter({"format": r"\?if=no Hello", "expected": ""})
 
 
 def test_60():
-    run_formatter({"format": "[\?if=missing Hello]", "expected": ""})
+    run_formatter({"format": r"[\?if=missing Hello]", "expected": ""})
 
 
 def test_61():
-    run_formatter({"format": "[\?if=!yes Hello]", "expected": ""})
+    run_formatter({"format": r"[\?if=!yes Hello]", "expected": ""})
 
 
 def test_62():
-    run_formatter({"format": "[\?if=!no Hello]", "expected": "Hello"})
+    run_formatter({"format": r"[\?if=!no Hello]", "expected": "Hello"})
 
 
 def test_63():
-    run_formatter({"format": "[\?if=!missing Hello]", "expected": "Hello"})
+    run_formatter({"format": r"[\?if=!missing Hello]", "expected": "Hello"})
 
 
 def test_64():
-    run_formatter({"format": "[\?if=yes Hello[ {name}]]", "expected": "Hello Björk"})
+    run_formatter({"format": r"[\?if=yes Hello[ {name}]]", "expected": "Hello Björk"})
 
 
 def test_65():
-    run_formatter({"format": "[\?if=no Hello[ {name}]]", "expected": ""})
+    run_formatter({"format": r"[\?if=no Hello[ {name}]]", "expected": ""})
 
 
 def test_66():
     run_formatter(
-        {"format": "[\?max_length=10 Hello {name} {number}]", "expected": "Hello Björ"}
+        {"format": r"[\?max_length=10 Hello {name} {number}]", "expected": "Hello Björ"}
     )
 
 
 def test_67():
     run_formatter(
-        {"format": "\?max_length=9 Hello {name} {number}", "expected": "Hello Bjö"}
+        {"format": r"\?max_length=9 Hello {name} {number}", "expected": "Hello Bjö"}
     )
 
 
@@ -598,12 +598,12 @@ def test_78():
 
 
 def test_else_true():
-    run_formatter({"format": "[\?if=yes Hello|Goodbye]", "expected": "Hello"})
+    run_formatter({"format": r"[\?if=yes Hello|Goodbye]", "expected": "Hello"})
 
 
 def test_else_false():
     run_formatter(
-        {"format": "[\?if=no Hello|Goodbye|Something else]", "expected": "Goodbye"}
+        {"format": r"[\?if=no Hello|Goodbye|Something else]", "expected": "Goodbye"}
     )
 
 
@@ -617,20 +617,20 @@ def test_composite_looks_empty():
 def test_color_name_1():
     run_formatter(
         {
-            "format": "\?color=bad color",
+            "format": r"\?color=bad color",
             "expected": [{"full_text": "color", "color": "#FF0000"}],
         }
     )
 
 
 def test_color_name_2():
-    run_formatter({"format": "\?color=no_name color", "expected": "color"})
+    run_formatter({"format": r"\?color=no_name color", "expected": "color"})
 
 
 def test_color_name_3():
     run_formatter(
         {
-            "format": "\?color=#FF00FF color",
+            "format": r"\?color=#FF00FF color",
             "expected": [{"full_text": "color", "color": "#FF00FF"}],
         }
     )
@@ -639,7 +639,7 @@ def test_color_name_3():
 def test_color_name_4():
     run_formatter(
         {
-            "format": "\?color=#ff00ff color",
+            "format": r"\?color=#ff00ff color",
             "expected": [{"full_text": "color", "color": "#FF00FF"}],
         }
     )
@@ -648,7 +648,7 @@ def test_color_name_4():
 def test_color_name_4a():
     run_formatter(
         {
-            "format": "[\?color=#ff00ff&show color]",
+            "format": r"[\?color=#ff00ff&show color]",
             "expected": [{"full_text": "color", "color": "#FF00FF"}],
         }
     )
@@ -657,7 +657,7 @@ def test_color_name_4a():
 def test_color_name_5():
     run_formatter(
         {
-            "format": "\?color=#F0F color",
+            "format": r"\?color=#F0F color",
             "expected": [{"full_text": "color", "color": "#FF00FF"}],
         }
     )
@@ -666,7 +666,7 @@ def test_color_name_5():
 def test_color_name_5a():
     run_formatter(
         {
-            "format": "[\?color=#F0F&show color]",
+            "format": r"[\?color=#F0F&show color]",
             "expected": [{"full_text": "color", "color": "#FF00FF"}],
         }
     )
@@ -675,24 +675,24 @@ def test_color_name_5a():
 def test_color_name_6():
     run_formatter(
         {
-            "format": "\?color=#f0f color",
+            "format": r"\?color=#f0f color",
             "expected": [{"full_text": "color", "color": "#FF00FF"}],
         }
     )
 
 
 def test_color_name_7():
-    run_formatter({"format": "\?color=#BADHEX color", "expected": "color"})
+    run_formatter({"format": r"\?color=#BADHEX color", "expected": "color"})
 
 
 def test_color_name_7a():
-    run_formatter({"format": "[\?color=#BADHEX&show color]", "expected": "color"})
+    run_formatter({"format": r"[\?color=#BADHEX&show color]", "expected": "color"})
 
 
 def test_color_1():
     run_formatter(
         {
-            "format": "[\?color=bad {name}]",
+            "format": r"[\?color=bad {name}]",
             "expected": [{"full_text": u"Björk", "color": "#FF0000"}],
         }
     )
@@ -701,7 +701,7 @@ def test_color_1():
 def test_color_1a():
     run_formatter(
         {
-            "format": "\?color=bad {name}",
+            "format": r"\?color=bad {name}",
             "expected": [{"full_text": u"Björk", "color": "#FF0000"}],
         }
     )
@@ -710,7 +710,7 @@ def test_color_1a():
 def test_color_2():
     run_formatter(
         {
-            "format": "[\?color=good Name [\?color=bad {name}] hello]",
+            "format": r"[\?color=good Name [\?color=bad {name}] hello]",
             "expected": [
                 {"full_text": "Name ", "color": "#00FF00"},
                 {"full_text": u"Björk", "color": "#FF0000"},
@@ -723,7 +723,7 @@ def test_color_2():
 def test_color_3():
     run_formatter(
         {
-            "format": "[\?max_length=20&color=good Name [\?color=bad {name}] hello]",
+            "format": r"[\?max_length=20&color=good Name [\?color=bad {name}] hello]",
             "expected": [
                 {"full_text": "Name ", "color": "#00FF00"},
                 {"full_text": u"Björk", "color": "#FF0000"},
@@ -736,7 +736,7 @@ def test_color_3():
 def test_color_4():
     run_formatter(
         {
-            "format": "[\?max_length=8&color=good Name [\?color=bad {name}] hello]",
+            "format": r"[\?max_length=8&color=good Name [\?color=bad {name}] hello]",
             "expected": [
                 {"full_text": "Name ", "color": "#00FF00"},
                 {"full_text": u"Bjö", "color": "#FF0000"},
@@ -748,7 +748,7 @@ def test_color_4():
 def test_color_5():
     run_formatter(
         {
-            "format": "[\?color=bad {name}][\?color=good {name}]",
+            "format": r"[\?color=bad {name}][\?color=good {name}]",
             "expected": [
                 {"full_text": u"Björk", "color": "#FF0000"},
                 {"full_text": u"Björk", "color": "#00FF00"},
@@ -760,7 +760,7 @@ def test_color_5():
 def test_color_6():
     run_formatter(
         {
-            "format": "[\?color=bad {name}] [\?color=good {name}]",
+            "format": r"[\?color=bad {name}] [\?color=good {name}]",
             "expected": [
                 {"full_text": u"Björk ", "color": "#FF0000"},
                 {"full_text": u"Björk", "color": "#00FF00"},
@@ -772,7 +772,7 @@ def test_color_6():
 def test_color_7():
     run_formatter(
         {
-            "format": "\?color=bad {simple}",
+            "format": r"\?color=bad {simple}",
             "expected": [{"full_text": "NY 12:34", "color": "#FF0000"}],
         }
     )
@@ -781,7 +781,7 @@ def test_color_7():
 def test_color_7a():
     run_formatter(
         {
-            "format": "[\?color=bad {simple}]",
+            "format": r"[\?color=bad {simple}]",
             "expected": [{"full_text": "NY 12:34", "color": "#FF0000"}],
         }
     )
@@ -790,7 +790,7 @@ def test_color_7a():
 def test_color_8():
     run_formatter(
         {
-            "format": "\?color=bad {complex}",
+            "format": r"\?color=bad {complex}",
             "expected": [{"full_text": "LA 09:34NY 12:34", "color": "#FF0000"}],
         }
     )
@@ -799,7 +799,7 @@ def test_color_8():
 def test_color_8a():
     run_formatter(
         {
-            "format": "[\?color=#FF00FF {complex}]",
+            "format": r"[\?color=#FF00FF {complex}]",
             "expected": [{"full_text": "LA 09:34NY 12:34", "color": "#FF00FF"}],
         }
     )
@@ -808,7 +808,7 @@ def test_color_8a():
 def test_color_9():
     run_formatter(
         {
-            "format": "\?color=good {complex2}",
+            "format": r"\?color=good {complex2}",
             "expected": [
                 {"color": "#FF0000", "full_text": "LA 09:34"},
                 {"color": "#00FF00", "full_text": "NY 12:34"},
@@ -820,7 +820,7 @@ def test_color_9():
 def test_color_9a():
     run_formatter(
         {
-            "format": "[\?color=good {complex2}]",
+            "format": r"[\?color=good {complex2}]",
             "expected": [
                 {"color": "#FF0000", "full_text": "LA 09:34"},
                 {"color": "#00FF00", "full_text": "NY 12:34"},
@@ -876,7 +876,7 @@ def test_composite_3():
 def test_composite_4():
     run_formatter(
         {
-            "format": "\?color=good {simple} {composite_basic} {complex}",
+            "format": r"\?color=good {simple} {composite_basic} {complex}",
             "expected": [
                 {"full_text": "NY 12:34 ", "color": "#00FF00"},
                 {"color": "#FF0000", "full_text": "red "},
@@ -892,7 +892,7 @@ def test_composite_4():
 def test_composite_5():
     run_formatter(
         {
-            "format": "[\?color=#FF00FF {simple} {composite_basic} {complex2}]",
+            "format": r"[\?color=#FF00FF {simple} {composite_basic} {complex2}]",
             "expected": [
                 {"full_text": "NY 12:34 ", "color": "#FF00FF"},
                 {"color": "#FF0000", "full_text": "red "},
@@ -923,21 +923,21 @@ def test_attr_getter():
 
 
 def test_min_length_1():
-    run_formatter({"format": "\?min_length=9 Hello", "expected": "    Hello"})
+    run_formatter({"format": r"\?min_length=9 Hello", "expected": "    Hello"})
 
 
 def test_min_length_2():
-    run_formatter({"format": "[\?min_length=9&show Hello]", "expected": "    Hello"})
+    run_formatter({"format": r"[\?min_length=9&show Hello]", "expected": "    Hello"})
 
 
 def test_min_length_3():
-    run_formatter({"format": "[\?min_length=9 [{name}]]", "expected": u"    Björk"})
+    run_formatter({"format": r"[\?min_length=9 [{name}]]", "expected": u"    Björk"})
 
 
 def test_min_length_4():
     run_formatter(
         {
-            "format": "[\?min_length=9 [\?color=good {name}]]",
+            "format": r"[\?min_length=9 [\?color=good {name}]]",
             "expected": [{"color": "#00FF00", "full_text": u"    Björk"}],
         }
     )
@@ -946,7 +946,7 @@ def test_min_length_4():
 def test_min_length_5():
     run_formatter(
         {
-            "format": "\?min_length=9 [\?color=bad {number}][\?color=good {name}]",
+            "format": r"\?min_length=9 [\?color=bad {number}][\?color=good {name}]",
             "expected": [
                 {"full_text": "  42", "color": "#FF0000"},
                 {"full_text": u"Björk", "color": "#00FF00"},
@@ -958,7 +958,7 @@ def test_min_length_5():
 def test_min_length_6():
     run_formatter(
         {
-            "format": "[\?min_length=9 [\?color=bad {number}][\?color=good {name}]]",
+            "format": r"[\?min_length=9 [\?color=bad {number}][\?color=good {name}]]",
             "expected": [
                 {"full_text": "  42", "color": "#FF0000"},
                 {"full_text": u"Björk", "color": "#00FF00"},
@@ -992,49 +992,49 @@ def test_numeric_strings_6():
 
 
 def test_not_zero_1():
-    run_formatter({"format": "[\?not_zero {zero}]", "expected": ""})
+    run_formatter({"format": r"[\?not_zero {zero}]", "expected": ""})
 
 
 def test_not_zero_2():
-    run_formatter({"format": "[\?not_zero {zero_str}]", "expected": ""})
+    run_formatter({"format": r"[\?not_zero {zero_str}]", "expected": ""})
 
 
 def test_not_zero_3():
-    run_formatter({"format": "[\?not_zero {zero_float}]", "expected": ""})
+    run_formatter({"format": r"[\?not_zero {zero_float}]", "expected": ""})
 
 
 def test_not_zero_4():
-    run_formatter({"format": "[\?not_zero {yes}]", "expected": "True"})
+    run_formatter({"format": r"[\?not_zero {yes}]", "expected": "True"})
 
 
 def test_not_zero_5():
-    run_formatter({"format": "[\?not_zero {no}]", "expected": ""})
+    run_formatter({"format": r"[\?not_zero {no}]", "expected": ""})
 
 
 def test_not_zero_6():
-    run_formatter({"format": "[\?not_zero {number}]", "expected": "42"})
+    run_formatter({"format": r"[\?not_zero {number}]", "expected": "42"})
 
 
 def test_not_zero_7():
-    run_formatter({"format": "[\?not_zero {pi}]", "expected": "3.14159265359"})
+    run_formatter({"format": r"[\?not_zero {pi}]", "expected": "3.14159265359"})
 
 
 def test_not_zero_8():
-    run_formatter({"format": "[\?not_zero {name}]", "expected": u"Björk"})
+    run_formatter({"format": r"[\?not_zero {name}]", "expected": u"Björk"})
 
 
 def test_not_zero_9():
-    run_formatter({"format": "[\?not_zero {str_nan}]", "expected": "I'm not a number"})
+    run_formatter({"format": r"[\?not_zero {str_nan}]", "expected": "I'm not a number"})
 
 
 def test_not_zero_10():
     run_formatter(
-        {"format": "[\?not_zero {zero} {str_nan}]", "expected": "0 I'm not a number"}
+        {"format": r"[\?not_zero {zero} {str_nan}]", "expected": "0 I'm not a number"}
     )
 
 
 def test_not_zero_11():
-    run_formatter({"format": "[\?not_zero {zero_str} {zero}]", "expected": ""})
+    run_formatter({"format": r"[\?not_zero {zero_str} {zero}]", "expected": ""})
 
 
 def test_bad_composite_color():
@@ -1042,41 +1042,41 @@ def test_bad_composite_color():
 
 
 def test_soft_1():
-    run_formatter({"format": "{name}[\?soft  ]{name}", "expected": "Björk Björk"})
+    run_formatter({"format": r"{name}[\?soft  ]{name}", "expected": "Björk Björk"})
 
 
 def test_soft_2():
-    run_formatter({"format": "{name}[\?soft  ]{empty}", "expected": "Björk"})
+    run_formatter({"format": r"{name}[\?soft  ]{empty}", "expected": "Björk"})
 
 
 def test_soft_3():
-    run_formatter({"format": "{empty}[\?soft  ]{empty}", "expected": ""})
+    run_formatter({"format": r"{empty}[\?soft  ]{empty}", "expected": ""})
 
 
 def test_soft_4():
-    run_formatter({"format": "[\?soft  ]", "expected": ""})
+    run_formatter({"format": r"[\?soft  ]", "expected": ""})
 
 
 def test_soft_5():
     run_formatter(
-        {"format": "{number}[\?soft  {name} ]{number}", "expected": "42 Björk 42"}
+        {"format": r"{number}[\?soft  {name} ]{number}", "expected": "42 Björk 42"}
     )
 
 
 def test_soft_6():
-    run_formatter({"format": "{number}[\?soft  {name} ]{empty}", "expected": "42"})
+    run_formatter({"format": r"{number}[\?soft  {name} ]{empty}", "expected": "42"})
 
 
 def test_soft_7():
-    run_formatter({"format": "\?soft {number}", "expected": "42"})
+    run_formatter({"format": r"\?soft {number}", "expected": "42"})
 
 
 def test_module_true():
-    run_formatter({"format": "[\?if=module_true something]", "expected": "something"})
+    run_formatter({"format": r"[\?if=module_true something]", "expected": "something"})
 
 
 def test_module_false():
-    run_formatter({"format": "[\?if=module_false something]", "expected": ""})
+    run_formatter({"format": r"[\?if=module_false something]", "expected": ""})
 
 
 def test_module_true_value():
@@ -1088,41 +1088,41 @@ def test_module_false_value():
 
 
 def test_zero_format_1():
-    run_formatter({"format": "[\?not_zero {zero_almost}]", "expected": "0.0001"})
+    run_formatter({"format": r"[\?not_zero {zero_almost}]", "expected": "0.0001"})
 
 
 def test_zero_format_2():
-    run_formatter({"format": "[\?not_zero {zero_almost:d}]", "expected": ""})
+    run_formatter({"format": r"[\?not_zero {zero_almost:d}]", "expected": ""})
 
 
 def test_zero_format_3():
-    run_formatter({"format": "[\?not_zero {zero_almost:.3f}]", "expected": ""})
+    run_formatter({"format": r"[\?not_zero {zero_almost:.3f}]", "expected": ""})
 
 
 def test_zero_format_4():
-    run_formatter({"format": "[\?not_zero {zero_almost:.4f}]", "expected": "0.0001"})
+    run_formatter({"format": r"[\?not_zero {zero_almost:.4f}]", "expected": "0.0001"})
 
 
 def test_inherit_not_zero_1():
-    run_formatter({"format": "\?not_zero [{zero}]", "expected": ""})
+    run_formatter({"format": r"\?not_zero [{zero}]", "expected": ""})
 
 
 def test_inherit_not_zero_2():
-    run_formatter({"format": "[\?not_zero [{zero}]]", "expected": ""})
+    run_formatter({"format": r"[\?not_zero [{zero}]]", "expected": ""})
 
 
 def test_inherit_not_zero_3():
-    run_formatter({"format": "[\?not_zero [[[{zero}]]]]", "expected": ""})
+    run_formatter({"format": r"[\?not_zero [[[{zero}]]]]", "expected": ""})
 
 
 def test_inherit_show_1():
-    run_formatter({"format": "\?show [[[hello]]]", "expected": "hello"})
+    run_formatter({"format": r"\?show [[[hello]]]", "expected": "hello"})
 
 
 def test_inherit_color_1():
     run_formatter(
         {
-            "format": "\?color=#F0F [[[{number}]]]",
+            "format": r"\?color=#F0F [[[{number}]]]",
             "expected": [{"color": u"#FF00FF", "full_text": u"42"}],
         }
     )
@@ -1131,104 +1131,104 @@ def test_inherit_color_1():
 def test_inherit_color_2():
     run_formatter(
         {
-            "format": "\?color=#F0F [[\?color=good [{number}]]]",
+            "format": r"\?color=#F0F [[\?color=good [{number}]]]",
             "expected": [{"color": u"#00FF00", "full_text": u"42"}],
         }
     )
 
 
 def test_conditions_1():
-    run_formatter({"format": "\?if=number=42 cool beans", "expected": "cool beans"})
+    run_formatter({"format": r"\?if=number=42 cool beans", "expected": "cool beans"})
 
 
 def test_conditions_2():
-    run_formatter({"format": "\?if=number=4 cool beans", "expected": ""})
+    run_formatter({"format": r"\?if=number=4 cool beans", "expected": ""})
 
 
 def test_conditions_3():
-    run_formatter({"format": "\?if=!number=42 cool beans", "expected": ""})
+    run_formatter({"format": r"\?if=!number=42 cool beans", "expected": ""})
 
 
 def test_conditions_4():
-    run_formatter({"format": "\?if=!number=4 cool beans", "expected": "cool beans"})
+    run_formatter({"format": r"\?if=!number=4 cool beans", "expected": "cool beans"})
 
 
 def test_conditions_5():
-    run_formatter({"format": "\?if=missing=4 cool beans", "expected": ""})
+    run_formatter({"format": r"\?if=missing=4 cool beans", "expected": ""})
 
 
 def test_conditions_6():
-    run_formatter({"format": "\?if=name=Björk cool beans", "expected": "cool beans"})
+    run_formatter({"format": r"\?if=name=Björk cool beans", "expected": "cool beans"})
 
 
 def test_conditions_7():
-    run_formatter({"format": "\?if=name=Jimmy cool beans", "expected": ""})
+    run_formatter({"format": r"\?if=name=Jimmy cool beans", "expected": ""})
 
 
 def test_conditions_8():
-    run_formatter({"format": "\?if=name= cool beans", "expected": ""})
+    run_formatter({"format": r"\?if=name= cool beans", "expected": ""})
 
 
 def test_conditions_9():
-    run_formatter({"format": "\?if=number= cool beans", "expected": ""})
+    run_formatter({"format": r"\?if=number= cool beans", "expected": ""})
 
 
 def test_conditions_10():
     run_formatter(
-        {"format": "\?if=pi=3.14159265359 cool beans", "expected": "cool beans"}
+        {"format": r"\?if=pi=3.14159265359 cool beans", "expected": "cool beans"}
     )
 
 
 def test_conditions_11():
-    run_formatter({"format": "\?if=pi=3 cool beans", "expected": ""})
+    run_formatter({"format": r"\?if=pi=3 cool beans", "expected": ""})
 
 
 def test_conditions_12():
-    run_formatter({"format": "\?if=yes=3 cool beans", "expected": "cool beans"})
+    run_formatter({"format": r"\?if=yes=3 cool beans", "expected": "cool beans"})
 
 
 def test_conditions_13():
-    run_formatter({"format": "\?if=no=3 cool beans", "expected": ""})
+    run_formatter({"format": r"\?if=no=3 cool beans", "expected": ""})
 
 
 def test_conditions_14():
-    run_formatter({"format": "\?if=number>3 cool beans", "expected": "cool beans"})
+    run_formatter({"format": r"\?if=number>3 cool beans", "expected": "cool beans"})
 
 
 def test_conditions_15():
-    run_formatter({"format": "\?if=number<50 cool beans", "expected": "cool beans"})
+    run_formatter({"format": r"\?if=number<50 cool beans", "expected": "cool beans"})
 
 
 def test_conditions_16():
-    run_formatter({"format": "\?if=number>50 cool beans", "expected": ""})
+    run_formatter({"format": r"\?if=number>50 cool beans", "expected": ""})
 
 
 def test_conditions_17():
-    run_formatter({"format": "\?if=number<3 cool beans", "expected": ""})
+    run_formatter({"format": r"\?if=number<3 cool beans", "expected": ""})
 
 
 def test_conditions_18():
-    run_formatter({"format": "\?if=name<Andrew cool beans", "expected": ""})
+    run_formatter({"format": r"\?if=name<Andrew cool beans", "expected": ""})
 
 
 def test_conditions_19():
-    run_formatter({"format": "\?if=name>Andrew cool beans", "expected": "cool beans"})
+    run_formatter({"format": r"\?if=name>Andrew cool beans", "expected": "cool beans"})
 
 
 def test_conditions_20():
-    run_formatter({"format": "\?if=name<John cool beans", "expected": "cool beans"})
+    run_formatter({"format": r"\?if=name<John cool beans", "expected": "cool beans"})
 
 
 def test_conditions_21():
-    run_formatter({"format": "\?if=name>John cool beans", "expected": ""})
+    run_formatter({"format": r"\?if=name>John cool beans", "expected": ""})
 
 
 def test_conditions_22():
-    run_formatter({"format": "\?if=missing>John cool beans", "expected": ""})
+    run_formatter({"format": r"\?if=missing>John cool beans", "expected": ""})
 
 
 def test_conditions_23():
-    run_formatter({"format": "[\?if=None=None cool] beans", "expected": " beans"})
+    run_formatter({"format": r"[\?if=None=None cool] beans", "expected": " beans"})
 
 
 def test_trailing_zeroes_1():
@@ -1283,7 +1283,7 @@ def test_placeholders_2():
 def test_placeholders_3():
     get_placeholders(
         {
-            "format": "{placeholder}[\?if=test something]",
+            "format": r"{placeholder}[\?if=test something]",
             "expected": {"placeholder", "test"},
         }
     )
@@ -1292,7 +1292,7 @@ def test_placeholders_3():
 def test_placeholders_4():
     get_placeholders(
         {
-            "format": "{placeholder}[\?if=!test=42&color=red something]",
+            "format": r"{placeholder}[\?if=!test=42&color=red something]",
             "expected": {"placeholder", "test"},
         }
     )
@@ -1301,7 +1301,7 @@ def test_placeholders_4():
 def test_placeholders_5():
     get_placeholders(
         {
-            "format": "\{placeholder\}[\?if=test&color=red something]",
+            "format": r"\{placeholder\}[\?if=test&color=red something]",
             "expected": {"test"},
         }
     )
@@ -1332,9 +1332,9 @@ def test_update_placeholders_2():
 def test_update_placeholders_3():
     update_placeholders(
         {
-            "format": "{placeholder}[\?if=test something]",
+            "format": r"{placeholder}[\?if=test something]",
             "updates": {"test": "new_test"},
-            "expected": "{placeholder}[\?if=new_test something]",
+            "expected": r"{placeholder}[\?if=new_test something]",
         }
     )
 
@@ -1342,9 +1342,9 @@ def test_update_placeholders_3():
 def test_update_placeholders_4():
     update_placeholders(
         {
-            "format": "{placeholder}[\?if=!test=42&color=red something]",
+            "format": r"{placeholder}[\?if=!test=42&color=red something]",
             "updates": {"red": "blue"},
-            "expected": "{placeholder}[\?if=!test=42&color=red something]",
+            "expected": r"{placeholder}[\?if=!test=42&color=red something]",
         }
     )
 
@@ -1352,9 +1352,9 @@ def test_update_placeholders_4():
 def test_update_placeholders_5():
     update_placeholders(
         {
-            "format": "\{placeholder\}{placeholder}[\?if=placeholder&color=red something]",
+            "format": r"\{placeholder\}{placeholder}[\?if=placeholder&color=red something]",
             "updates": {"placeholder": "new_placeholder"},
-            "expected": "\{placeholder\}{new_placeholder}[\?if=new_placeholder&color=red something]",
+            "expected": r"\{placeholder\}{new_placeholder}[\?if=new_placeholder&color=red something]",
         }
     )
 

--- a/tests/test_module_doc.py
+++ b/tests/test_module_doc.py
@@ -31,9 +31,7 @@ IGNORE_ITEM = []
 # Obsolete parameters will not have alphabetical order checked
 OBSOLETE_PARAM = []
 
-RE_PARAM = re.compile(
-    "^  - `(?P<name>[^`]*)`.*?(" "\*\(default (?P<value>(" ".*" "))\)\*)?$"
-)
+RE_PARAM = re.compile(r"^  - `(?P<name>[^`]*)`.*?(\*\(default (?P<value>(.*))\)\*)?$")
 
 AST_LITERAL_TYPES = {"Num": "n", "Str": "s", "NameConstant": "value"}
 

--- a/tox.ini
+++ b/tox.ini
@@ -30,5 +30,11 @@ flake8-ignore =
     E501
     W503
     C901
+    py3status/modules/*.py W605 W504 E999
+filterwarnings =
+    # For Python 2 flake8
+    ignore:.*You passed a bytestring as `filenames`:DeprecationWarning:flake8.options.config
+    # For Python 3.7 flake8
+    ignore:Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated:DeprecationWarning:
 flake8-max-complexity = 18
 flake8-max-line-length = 88


### PR DESCRIPTION
We have a new round of flake8 errors.

Mostly this is due to W605 bad escape chars which are fixed in core

Modules need updating but are ignored for W605.  W504 (operator should be at end of line not beginning) and E999 for 3.6

We also hide some warnings

Flake8 code warning in python2
Module import issue for 3.7

The modules we can look at fixing up in the next cycle or two and then remove the ignore.

