### PR TITLE
module: fix Runner (IndexError) exception

### DIFF
--- a/py3status/module.py
+++ b/py3status/module.py
@@ -168,7 +168,7 @@ class Module:
             return
 
         # only show first line of error
-        msg = msg.splitlines()[0]
+        msg = msg.splitlines()[0] if msg else "('', None)"
 
         errors = [self.module_nice_name, u"{}: {}".format(self.module_nice_name, msg)]
 


### PR DESCRIPTION
It is obvious where and what happened in the log so I fix it there by giving a vague message `('', None)` instead of an empty string for users to see when they toggle on the errors. This addresses https://github.com/ultrabug/py3status/issues/1386. 