### PR TITLE
battery_level: refresh with udev, increase default cache_timeout

### DIFF
--- a/py3status/modules/battery_level.py
+++ b/py3status/modules/battery_level.py
@@ -10,7 +10,7 @@ Configuration parameters:
         especially useful when using icon fonts (e.g. FontAwesome)
         (default "_▁▂▃▄▅▆▇█")
     cache_timeout: a timeout to refresh the battery state
-        (default 30)
+        (default 60)
     charging_character: a character to represent charging battery
         especially useful when using icon fonts (e.g. FontAwesome)
         (default "⚡")
@@ -36,6 +36,9 @@ Configuration parameters:
     notify_low_level: display notification when battery is running low (when
         the battery level is less than 'threshold_degraded')
         (default False)
+    on_udev_power_supply: dynamic variable to watch for `power_supply` udev subsystem 
+        events to trigger specified action.
+        (default 'refresh')
     sys_battery_path: set the path to your battery(ies), without including its
         number
         (default "/sys/class/power_supply/")
@@ -103,7 +106,7 @@ class Py3status:
     # available configuration parameters
     battery_id = 0
     blocks = BLOCKS
-    cache_timeout = 30
+    cache_timeout = 60
     charging_character = CHARGING_CHARACTER
     format = FORMAT
     format_notify_charging = FORMAT_NOTIFY_CHARGING
@@ -113,6 +116,7 @@ class Py3status:
     measurement_mode = MEASUREMENT_MODE
     notification = False
     notify_low_level = False
+    on_udev_power_supply = "refresh"
     sys_battery_path = SYS_BATTERY_PATH
     threshold_bad = 10
     threshold_degraded = 30

--- a/py3status/modules/battery_level.py
+++ b/py3status/modules/battery_level.py
@@ -36,7 +36,7 @@ Configuration parameters:
     notify_low_level: display notification when battery is running low (when
         the battery level is less than 'threshold_degraded')
         (default False)
-    on_udev_power_supply: dynamic variable to watch for `power_supply` udev subsystem 
+    on_udev_power_supply: dynamic variable to watch for `power_supply` udev subsystem
         events to trigger specified action.
         (default "refresh")
     sys_battery_path: set the path to your battery(ies), without including its

--- a/py3status/modules/battery_level.py
+++ b/py3status/modules/battery_level.py
@@ -38,7 +38,7 @@ Configuration parameters:
         (default False)
     on_udev_power_supply: dynamic variable to watch for `power_supply` udev subsystem 
         events to trigger specified action.
-        (default 'refresh')
+        (default "refresh")
     sys_battery_path: set the path to your battery(ies), without including its
         number
         (default "/sys/class/power_supply/")


### PR DESCRIPTION
cc @ultrabug for another great example of using new udev feature.

With this change, `battery_level` module will refresh instantly as soon as you plug or unplug charging cable. Because of this, there's no need to refresh the module as often as every 30 seconds, I set it to 60 seconds for now.

Guess what, until today I had `cache_timeout` set to `1` because I wanted to instantly know when I plug in my charger. NO MORE.