### PR TITLE
Fix utf8 encoding on py2

### DIFF
--- a/py3status/py3.py
+++ b/py3status/py3.py
@@ -1,4 +1,6 @@
+# -*- coding: utf-8 -*-
 from __future__ import division
+from __future__ import unicode_literals
 
 import collections
 import os
@@ -317,7 +319,7 @@ class Py3:
             d = dict(enumerate(d))
         for k, v in d.items():
             if parent_key:
-                k = u"{}{}{}".format(parent_key, delimiter, k)
+                k = "{}{}{}".format(parent_key, delimiter, k)
             if intermediates:
                 items.append((k, v))
             if isinstance(v, list):
@@ -834,7 +836,7 @@ class Py3:
                 attr_getter=attr_getter,
             )
         except Exception:
-            self._report_exception(u"Invalid format `{}`".format(format_string))
+            self._report_exception("Invalid format `{}`".format(format_string))
             return "invalid format"
 
     def build_composite(
@@ -870,7 +872,7 @@ class Py3:
                 attr_getter=attr_getter,
             )
         except Exception:
-            self._report_exception(u"Invalid format `{}`".format(format_string))
+            self._report_exception("Invalid format `{}`".format(format_string))
             return [{"full_text": "invalid format"}]
 
     def composite_update(self, item, update_dict, soft=False):


### PR DESCRIPTION
While working on my plugin, I noticed that logging utf-8 strings raises a `UnicodeEncodeError` at [line 485](https://github.com/apiraino/py3status/blob/0b3832e1ad131b987bfe36e5c5c3abe3fdb289e8/py3status/py3.py#L485).

I think the issue can be fixed by using in the module:
```
s = "Amthrÿa - Anesthesia Survival"
self.py3.log(s.decode('utf-8'))
```
and applying this patch to `py3.py`, which removes the need to cast string to utf-8 with `u'hey hey'`.

Unfortunately I couldn't easily find a way to write a unit-test for this patch (any help on that would be great!).

Opinions?

Thanks for reviewing!