### PR TITLE
fix typo cache_until with cached_until

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -726,7 +726,7 @@ class Py3status:
         return {
             'full_text': full_text,
             'color': color,
-            'cache_until': self.py3.CACHE_FOREVER
+            'cached_until': self.py3.CACHE_FOREVER
         }
 
     def on_click(self, event):

--- a/doc/writing_modules.rst
+++ b/doc/writing_modules.rst
@@ -295,7 +295,7 @@ Example 5: Using color constants
             return {
                 'full_text': full_text,
                 'color': color,
-                'cache_until': self.py3.CACHE_FOREVER
+                'cached_until': self.py3.CACHE_FOREVER
             }
 
         def on_click(self, event):

--- a/py3status/modules/wifi.py
+++ b/py3status/modules/wifi.py
@@ -122,7 +122,7 @@ class Py3status:
         try:
             iw = self.py3.command_output(self.iw_dev_id_link)
         except self.py3.CommandError:
-            return {'cache_until': self.py3.CACHE_FOREVER,
+            return {'cached_until': self.py3.CACHE_FOREVER,
                     'color': self.py3.COLOR_ERROR or self.py3.COLOR_BAD,
                     'full_text': STRING_ERROR}
         # bitrate
@@ -219,7 +219,7 @@ class Py3status:
                 ))
 
         return {
-            'cache_until': self.py3.time_in(self.cache_timeout),
+            'cached_until': self.py3.time_in(self.cache_timeout),
             'full_text': full_text,
             'color': color,
         }

--- a/py3status/py3.py
+++ b/py3status/py3.py
@@ -80,7 +80,7 @@ class Py3:
 
     CACHE_FOREVER = PY3_CACHE_FOREVER
     """
-    Special constant that when returned for ``cache_until`` will cause the
+    Special constant that when returned for ``cached_until`` will cause the
     module to not update unless externally triggered.
     """
 


### PR DESCRIPTION
Fixing a typo. This addresses #1576.

EDIT: You can blame this person. a06882dac8602ea17fa2ea0e5f0518491ddc99ba