### PR TITLE
Add support unicode character output from dropbox-cli

### DIFF
--- a/py3status/modules/dropboxd_status.py
+++ b/py3status/modules/dropboxd_status.py
@@ -72,7 +72,7 @@ class Py3status:
             raise Exception(STRING_NOT_INSTALLED)
 
     def dropbox(self):
-        status = self.py3.command_output('dropbox-cli status').splitlines()[0]
+        status = self.py3.command_output('dropbox-cli status', localized=True).splitlines()[0]
 
         if status == "Dropbox isn't running!":
             color = self.py3.COLOR_BAD


### PR DESCRIPTION
Recent versions of `dropbox-cli` may include a Unicode circle in the output, e.g.

```
Syncing "foo" • 28 mins
Downloading "foo" (5,382 KB/sec, 28 mins)
```

which breaks the `dropboxd_status` module since the wrong encoding is passed to `Popen`.

Defaulting to the system encoding should resolve this.