### PR TITLE
external_script: notifications

### DIFF
--- a/py3status/modules/external_script.py
+++ b/py3status/modules/external_script.py
@@ -10,7 +10,8 @@ code such as #FF0000 for red).
 The script should not have any parameters, but it could work.
 
 Configuration parameters:
-    button_refresh: button to refresh the module (default 2)
+    button_show_notification: button to show notification with full output
+        (default None)
     cache_timeout: how often we refresh this module in seconds
         (default 15)
     format: see placeholders below (default '{output}')
@@ -51,7 +52,7 @@ class Py3status:
     """
     """
     # available configuration parameters
-    button_refresh = 2
+    button_show_notification = None
     cache_timeout = 15
     format = '{output}'
     localize = True
@@ -105,7 +106,7 @@ class Py3status:
 
     def on_click(self, event):
         button = event["button"]
-        if button != self.button_refresh:
+        if button == self.button_show_notification:
             self.py3.notify_user(self.output)
             self.py3.prevent_refresh()
 

--- a/py3status/modules/external_script.py
+++ b/py3status/modules/external_script.py
@@ -23,7 +23,7 @@ Configuration parameters:
         (default False)
 
 Format placeholders:
-    {line} number of lines in the output
+    {lines} number of lines in the output
     {output} output of script given by "script_path"
 
 i3status.conf example:
@@ -101,7 +101,7 @@ class Py3status:
             output = ''
 
         response['full_text'] = self.py3.safe_format(
-            self.format, {'output': output, 'line': len(output_lines)})
+            self.format, {'output': output, 'lines': len(output_lines)})
         return response
 
     def on_click(self, event):


### PR DESCRIPTION
In light of new Zen #1582, I'm submitting a simple implementation for the pattern I use with `external_script`. In my mind is good enough until we come up with some sophisticated support for notifications in core. This replaces #1439.

-----

Before:

* external_script shows only first line of output, no way to see entire output
* refreshes on any button click

After:

* external_script still shows first line of output, but on click you get a notification with full output
* refreshes only on `button_refresh`, i.e. left click shows notification and doesn't trigger refresh
* also added `line` format placeholder to show the total number of lines in the output (could rename if you want, `line` was proposed in #1439).

Why:

I use `external_script` with the same pattern for different purposes. Don't expect you to understand what exactly they are doing, just showing you a repeating pattern for which I'm implementing this PR.

<details>
<summary>Examples of why I need this for <code>external_script</code></summary>

* Check updates for official packages:
    * I have a script that outputs updates, one line per package
    * In status bar I have `official updates: 3` (this is why I need `line` placeholder)
    * On click I show notification that shows names of those 3 packages
    * I don't want left click to refresh the module, because script is slow to execute, thus need for `button_refresh`, but I want to refresh on middle click

* Check updates for unofficial packages:
    * I have a script that outputs updates, one line per package
    * In status bar I have `unofficial updates: 3`
    * On click I show notification that shows names of those 3 packages
    * I want left click to only show notification, and middle click to refresh

* Check updates for VCS packages:
    * I have a script that outputs updates, one line per package
    * In status bar I have `VCS updates: 3`
    * On click I show notification that shows names of those 3 packages
    * I want left click to only show notification, and middle click to refresh

* Check which packages need to be rebuild because of updated dependencies:
    * I have a script that outputs them, one line per package
    * In status bar I have `packages to rebuild: 3`
    * On click I show notification that shows names of those 3 packages
    * I want left click to only show notification, and middle click to refresh

* Check which configs need to be updated because of updated packages:
    * I have a script that outputs them, one line per config
    * In status bar I have `configs to update: 3`
    * On click I show notification that shows names of those 3 configs
    * I want left click to only show notification, and middle click to refresh

</details>