### PR TITLE
py3-cmd: allow sending click events with modifiers

### DIFF
--- a/py3status/command.py
+++ b/py3status/command.py
@@ -47,7 +47,7 @@ examples:
         py3-cmd click --button 4 --index minutes timer  # up
         py3-cmd click --button 4 --index seconds timer  # up
 
-    width, height, relative_x, relative_y, x, y:
+    height, modifiers, relative_x, relative_y, width, x, y:
         # py3-cmd allows users to specify click events with
         # more options. however, there are no modules that
         # uses the aforementioned options.
@@ -66,6 +66,7 @@ CLICK_OPTIONS = [
     ("button", "specify a button number (default %(default)s)"),
     ("height", "specify a height of the block, in pixel"),
     ("index", "specify an index value often found in modules"),
+    ("modifiers", "specify modifiers, optionally joined by plus signs"),
     ("relative_x", "specify relative X on the block, from the top left"),
     ("relative_y", "specify relative Y on the block, from the top left"),
     ("width", "specify a width of the block, in pixel"),
@@ -304,6 +305,8 @@ def command_parser():
             sp.add_argument(arg, metavar="INT", type=int, help=msg, default=1)
         elif name == "index":
             sp.add_argument(arg, metavar="INDEX", help=msg)
+        elif name == "modifiers":
+            sp.add_argument(arg, metavar="KEY", help=msg)
         else:
             sp.add_argument(arg, metavar="INT", type=int, help=msg)
 
@@ -349,6 +352,12 @@ def command_parser():
         parser.exit()
     elif not options.command:
         parser.error("too few arguments")
+
+    # specify modifiers, optionally joined by plus signs
+    if options.modifiers:
+        options.modifiers = options.modifiers.split("+")
+    else:
+        options.modifiers = []
 
     # ALIAS_DEPRECATION
     alias = options.command in buttons


### PR DESCRIPTION
* [x] Add `core` support for click events modifiers
* [ ] Add `py3-cmd` support for click events modifiers (This PR)

The first commit is for `--modifier Control --modifier Shift --modifier Mod1`
The second commits is for `--modifiers Control+Shift+Mod1`. 

If you like the first commit, I can remove the second commit.
If you like the second commit, I can squash commits or you squash and delete the body.

I like the second commit better. Short and simple.