### PR TITLE
screenshots: use abspath instead of realpath

### DIFF
--- a/py3status/screenshots.py
+++ b/py3status/screenshots.py
@@ -244,7 +244,7 @@ def process(name, data, module=True):
     """
 
     path = os.path.join(os.path.dirname(os.path.dirname(
-        os.path.realpath(__file__))), "doc/screenshots"
+        os.path.abspath(__file__))), "doc/screenshots"
     )
     # create dir if not exists
     try:


### PR DESCRIPTION
Removing `f-strings` generates the docs, but no screenshots. I looked at `autodoc.py` and it seems to be parsing everything okay. `make html` also generates everything okay here. I'm not sure what else it could be... Two possibilities.
1) Removing `-0` is absolutely important. 
2) Somebody does not like `os.path.realpath()`.

I'm trying `#2`. :pray: