### PR TITLE
formatter: avoid duplicate soft blocks

### DIFF
--- a/py3status/formatter.py
+++ b/py3status/formatter.py
@@ -639,7 +639,11 @@ class Block:
             convertables = (str, bool, int, float, bytes)
 
         first = True
+        last_block = None
         for index, item in enumerate(output):
+            is_block = isinstance(item, Block)
+            if not is_block and item:
+                last_block = None
             if isinstance(item, convertables) or item is None:
                 text += conversion(item)
                 continue
@@ -656,14 +660,15 @@ class Block:
                 if color:
                     item.composite_update(item, {"color": color}, soft=True)
                 out.extend(item.get_content())
-            elif isinstance(item, Block):
+            elif is_block:
                 # if this is a block then likely it is soft.
                 if not out:
                     continue
                 for x in range(index + 1, len(output)):
                     if output[x] and not isinstance(output[x], Block):
                         valid, _output = item.render(get_params, module, _if=True)
-                        if _output:
+                        if _output and _output != last_block:
+                            last_block = _output
                             out.extend(_output)
                         break
             else:


### PR DESCRIPTION
*This might be moot if we are switching to f-string formatter in the near future.*

Occasionally, we can run into unwanted side effect of having several `[\?soft  ]` in the `format`.
```python
format = "a[\?soft  ][{b}][\?soft  ][{c}][\?soft  ][{d}] World"
# data = {'b': 'b', 'd': 'd'}
# result: "a b  d World"
```
If `c` does not exist or the block is invalid, we print all `[\?soft ]`. With this PR, we skip one or more:
```python
# expected: "a b d World"
```
If `[\?soft -]` is not same as the next `[\?soft :]`, then both soft blocks would be printed.