### PR TITLE
vpn_status: handle multiple simultaneous vpn connections

### DIFF
--- a/py3status/modules/vpn_status.py
+++ b/py3status/modules/vpn_status.py
@@ -91,12 +91,13 @@ class Py3status:
         sleep(0.3)
         # Check if any active connections are a VPN
         bus = SystemBus()
+        ids = []
         for name in self.active:
             conn = bus.get(".NetworkManager", name)
             if conn.Vpn:
-                return conn.Id
+                ids.append(conn.Id)
         # No active VPN
-        return None
+        return ids
 
     def _check_pid(self):
         """Returns True if pidfile exists, False otherwise."""
@@ -124,7 +125,7 @@ class Py3status:
         else:
             vpn = self._get_vpn_status()
             if vpn:
-                name = vpn
+                name = ', '.join(vpn)
                 color = self.py3.COLOR_GOOD
 
         # Format and create the response dict


### PR DESCRIPTION
Hi, 

The `vpn_status` module currently only displays one VPN name, even if multiple connections are active.

This PR makes it display the full list of connected VPNs:
![screenshot2018-12-1601 47 59](https://user-images.githubusercontent.com/9559159/50048747-21171500-00cc-11e9-870e-dfb0a467d0b1.png)
![screenshot2018-12-1601 48 25](https://user-images.githubusercontent.com/9559159/50048748-23796f00-00cc-11e9-9643-0571739cded9.png)
