### PR TITLE
modules: don't set module options on failed modules

### DIFF
--- a/py3status/module.py
+++ b/py3status/module.py
@@ -72,6 +72,7 @@ class Module:
 
         try:
             self.load_methods(module, user_modules)
+            self.set_module_options(module)
         except Exception as e:
             # Import failed notify user in module error output
             self.disabled = True
@@ -93,7 +94,6 @@ class Module:
                 self._py3_wrapper.log(msg)
                 self._py3_wrapper.log(str(e))
 
-        self.set_module_options(module)
 
     def __repr__(self):
         return "<Module {}>".format(self.module_full_name)


### PR DESCRIPTION
This should fix https://github.com/ultrabug/py3status/pull/1486#issuecomment-449669433.  

If you want to use `self.module_class` for `py3.get_color()`, you require a module to loaded successfully first. Doing `set_module_options(module)` at end of `init`... assuming a module wouldn't fail when it failed... would result in a failed `py3`... Let alone a failed `get_color()` too. 

There are ways we can fail modules. One can fail modules by switching branches between different modules... resulting in failed modules on the bar... or for our users, they can fail by entering wrong names... or are missing modules/paths.

Now, if you have `get_color()` options in the failed module configs too, you would find yourself breaking the bar entirely... This possibly could be the reason for https://github.com/ultrabug/py3status/pull/1557#issuecomment-449670035 too if that's what happened there. 