### PR TITLE
module: add urgent background and borders

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -198,6 +198,9 @@ The following options requires ``i3bar-gaps`` and ``py3status``.
 ``urgent_background``: Specify urgent background color for modules.
 You lose urgent functionality too that can be sometimes utilized by
 container modules, e.g., frame and group.
+``urgent_foreground``: Specify urgent foreground color for modules.
+You lose urgent functionality too that can be sometimes utilized by
+container modules, e.g., frame and group.
 
 
 Configuration obfuscation

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -193,14 +193,37 @@ is not reached. Either ``left`` (default), ``center``, or ``right``.
       position = 'right'
    }
 
-The following options requires ``i3bar-gaps`` and ``py3status``.
+.. note::
+    New in version 3.16
+
+The following options will work on ``i3bar`` and ``py3status``.
 
 ``urgent_background``: Specify urgent background color for modules.
-You lose urgent functionality too that can be sometimes utilized by
-container modules, e.g., frame and group.
 ``urgent_foreground``: Specify urgent foreground color for modules.
+``urgent_border``: Specify urgent border color for modules.
+
+The following options will work on ``i3bar-gaps`` and ``py3status``.
+
+``urgent_border_bottom``: Specify urgent border width for modules
+``urgent_border_left``: Specify urgent border width for modules.
+``urgent_border_right``: Specify urgent border width for modules.
+``urgent_border_top``: Specify urgent border width for modules.
+
 You lose urgent functionality too that can be sometimes utilized by
 container modules, e.g., frame and group.
+
+.. code-block:: py3status
+
+   # customize urgent
+   py3status {
+      urgent_background  = 'blue'
+      urgent_foreground = 'white'
+      urgent_border = 'red'
+      urgent_border_bottom = 1
+      urgent_border_left = 1
+      urgent_border_right = 1
+      urgent_border_top = 1
+   }
 
 
 Configuration obfuscation

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -193,6 +193,13 @@ is not reached. Either ``left`` (default), ``center``, or ``right``.
       position = 'right'
    }
 
+The following options requires ``i3bar-gaps`` and ``py3status``.
+
+``urgent_background``: Specify urgent background color for modules.
+You lose urgent functionality too that can be sometimes utilized by
+container modules, e.g., frame and group.
+
+
 Configuration obfuscation
 -------------------------
 Py3status allows you to hide individual configuration parameters so that they

--- a/py3status/module.py
+++ b/py3status/module.py
@@ -59,6 +59,8 @@ class Module:
         self.testing = self.config.get("testing")
         self.urgent = False
         self.urgent_background = None
+        self.urgent_foreground = None
+        self.urgent_customized = None
 
         # create a nice name for the module that matches what the module is
         # called in the user config
@@ -486,9 +488,13 @@ class Module:
                     del item["urgent"]
             # if urgent we want to set this to all parts
             elif urgent:
-                if self.urgent_background:
-                    item["background"] = self.urgent_background
-                    item["color"] = "#FFFFFF"
+                if self.urgent_customized:
+                    if self.urgent_background:
+                        item["background"] = self.urgent_background
+                    if self.urgent_foreground:
+                        item["color"] = self.urgent_foreground
+                    else:
+                        item["color"] = "#FFFFFF"
                     if "urgent" in item:
                         del item["urgent"]
                 else:
@@ -760,6 +766,21 @@ class Module:
                     err += "a color. Got `{}`.".format(urgent_background)
                     raise ValueError(err)
                 self.urgent_background = color
+
+            # urgent foreground
+            urgent_foreground = fn(self.module_full_name, "urgent_foreground")
+            if not hasattr(urgent_foreground, "none_setting"):
+                color = self.module_class.py3._get_color(urgent_foreground)
+                if not color:
+                    err = "Invalid `urgent_foreground` attribute, should be "
+                    err += "a color. Got `{}`.".format(urgent_foreground)
+                    raise ValueError(err)
+                self.urgent_foreground = color
+
+            # urgent customized
+            self.urgent_customized = any(
+                [self.urgent_foreground, self.urgent_background]
+            )
 
             # get the available methods for execution
             for method in sorted(dir(class_inst)):


### PR DESCRIPTION
RFC. This adds custom urgent backgrounds. Requires `i3-gaps`.

* `timer` looks nice with `urgent_background = 'crimson'`. 

    ```python
    order += "timer"
    timer {
        time = 5
        urgent_background = 'crimson'
    }
    ```
* `github` looks nice with `urgent_background = 'black'`.
* `mail` looks nice with `urgent_background = 'deepskyblue'`. 

You get the idea.