### PR TITLE
py3: get_color_names_list to return an empty list on false value

### DIFF
--- a/py3status/py3.py
+++ b/py3status/py3.py
@@ -698,6 +698,8 @@ class Py3:
 
         :param format_strings: Accepts a format string or a list of format strings.
         """
+        if not format_strings:
+            return []
         if not getattr(self._py3status_module, "thresholds", None):
             return []
         if isinstance(format_strings, basestring):


### PR DESCRIPTION
When it comes to empty strings, we tends to use `(default None)` instead of `(default '')` everywhere. This would prevent an exception with some `format* = None` configs. The main `format` config is usually excluded because it is already defined 99% of the time. 