### PR TITLE
py3: threshold_get_color to set color=None on exception

### DIFF
--- a/py3status/py3.py
+++ b/py3status/py3.py
@@ -1197,7 +1197,7 @@ class Py3:
                         else:
                             break
             except TypeError:
-                pass
+                color = None
 
         # save color so it can be accessed via safe_format()
         if name:


### PR DESCRIPTION
I saw this in `velib_metropole` when I was addressing `format` thresholds. 

A color got assigned on `L1993`... and it failed (TypeError), it would use that color instead of `None`. 

https://github.com/ultrabug/py3status/blob/69dedeb8400ade2e8bb1742c284cb067bf2f8211/py3status/py3.py#L1193-L1200