### PR TITLE
autodoc: fix warnings

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -97,7 +97,7 @@ todo_include_todos = True
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['_static']
+# html_static_path = ['_static']
 
 
 # -- Options for HTMLHelp output ------------------------------------------

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -137,7 +137,7 @@ You can specify the following options in module configuration.
  is not reached. Either ``left`` (default), ``center``, or ``right``.
 
 .. code-block:: py3status
-     # example
+
     static_string {
         min_length = 15
         position = 'center'

--- a/doc/intro.rst
+++ b/doc/intro.rst
@@ -89,11 +89,15 @@ NixOS
 ^^^^^
 
 To have it globally persistent add to your NixOS configuration file py3status as a Python 3.6 package with
-::
+
+.. code-block:: shell
+
     (python36.withPackages(ps: with ps; [ py3status ]))
 
 If you are, and you probably are, using `i3 <https://i3wm.org/>`_ you might want a section in your `/etc/nixos/configuration.nix` that looks like this:
-::
+
+.. code-block:: shell
+
     services.xserver.windowManager.i3 = {
       enable = true;
       extraPackages = with pkgs; [

--- a/doc/writing_modules.rst
+++ b/doc/writing_modules.rst
@@ -808,6 +808,7 @@ Such modules can then be tested independently by running
 ``python /path/to/module.py``.
 
 .. code-block:: bash
+
     $ python loadavg.py
     [{'full_text': 'Loadavg ', 'separator': False,
     'separator_block_width': 0, 'cached_until': 1538755796.0},
@@ -818,6 +819,7 @@ We also can produce an output similar to i3bar output in terminal with
 ``python /path/to/module.py --term``.
 
 .. code-block:: bash
+
     $ python loadavg.py --term
     Loadavg 1.41 1.61 1.82
     Loadavg 1.41 1.61 1.82

--- a/py3status/modules/mail.py
+++ b/py3status/modules/mail.py
@@ -37,8 +37,8 @@ IMAP Subscriptions:
     `'pattern'` will match folders containing `pattern`.
     `'^pattern'` will match folders beginning with `pattern`.
     `'pattern$'` will match folders ending with `pattern`.
-    `'^((?![Ss][Pp][Aa][Mm]).)*$'` will match all folders except
-        for every possible case of `spam` folders.
+    `'^((?![Ss][Pp][Aa][Mm]).)*$'` will match all folders
+    except for every possible case of `spam` folders.
 
     For more documentation, see https://docs.python.org/3/library/re.html
     and/or any regex builder on the web. Don't forget to escape characters.


### PR DESCRIPTION
It's not useful to paste output... especially without colors. I'm listing warnings only.
```
 ...
py3status/doc/configuration.rst:139: WARNING: Error in "code-block" directive:
    maximum 1 argument(s) allowed, 12 supplied.
py3status/doc/intro.rst:93: WARNING: Unexpected indentation.
py3status/doc/intro.rst:97: WARNING: Unexpected indentation.
modules-info.inc:3136: WARNING: Unexpected indentation.
py3status/doc/writing_modules.rst:810: WARNING: Error in "code-block" directive:
    maximum 1 argument(s) allowed, 20 supplied.
py3status/doc/writing_modules.rst:820: WARNING: Error in "code-block" directive:
    maximum 1 argument(s) allowed, 18 supplied.
copying static files... WARNING: html_static_path entry 'py3status/doc/_static'
     does not exist

build succeeded, 7 warnings.
```