### PR TITLE
modules: don't set module options on disabled modules

### DIFF
--- a/py3status/module.py
+++ b/py3status/module.py
@@ -72,7 +72,6 @@ class Module:
 
         try:
             self.load_methods(module, user_modules)
-            self.set_module_options(module)
         except Exception as e:
             # Import failed notify user in module error output
             self.disabled = True
@@ -93,6 +92,10 @@ class Module:
                 # be imported
                 self._py3_wrapper.log(msg)
                 self._py3_wrapper.log(str(e))
+
+        # check module/py3status config section
+        if not self.disabled:
+            self.set_module_options(module)
 
     def __repr__(self):
         return "<Module {}>".format(self.module_full_name)


### PR DESCRIPTION
Addressing yet another error / edge case with `get_color`. #1619. Cheers.