### PR TITLE
cli: fix FIXME:float->int interval, omit %(default)s

### DIFF
--- a/py3status/cli.py
+++ b/py3status/cli.py
@@ -58,7 +58,7 @@ def parse_cli():
         action="store",
         default=i3status_config_file_default,
         dest="i3status_conf",
-        help="load config (default %(default)s)",
+        help="load config",
         metavar="FILE",
         type=str,
     )
@@ -100,9 +100,9 @@ def parse_cli():
         action="store",
         default=1,
         dest="interval",
-        help="refresh interval in seconds for py3status",
+        help="refresh interval for py3status",
         metavar="INT",
-        type=float,
+        type=int,
     )
     parser.add_argument(
         "-s", "--standalone", action="store_true", help="run py3status without i3status"

--- a/py3status/core.py
+++ b/py3status/core.py
@@ -451,8 +451,7 @@ class Py3statusWrapper:
         config["gevent"] = options.gevent
         if options.include_paths:
             config["include_paths"] = options.include_paths
-        # FIXME we allow giving interval as a float and then make it an int!
-        config["interval"] = int(options.interval)
+        config["interval"] = options.interval
         config["log_file"] = options.log_file
         config["standalone"] = options.standalone
         config["i3status_config_path"] = options.i3status_conf


### PR DESCRIPTION
I have this `FIXME` commit that never got addressed.
1) I'm fixing `FIXME we allow giving interval as a float and then make it an int!` by requiring `int` value. Anything else will get invalid.
2) Omitting `(default %(default)s)` in favor of `argparse.ArgumentDefaultsHelpFormatter`'s stuff.