### PR TITLE
mpris: fix clementine attributeerror exception

### DIFF
--- a/py3status/modules/mpris.py
+++ b/py3status/modules/mpris.py
@@ -432,7 +432,12 @@ class Py3status:
         state_priority = WORKING_STATES.index(status)
         index = self._mpris_name_index[identity]
         self._mpris_name_index[identity] += 1
-        subscription = player.PropertiesChanged.connect(self._player_monitor(player_id))
+        try:
+            subscription = player.PropertiesChanged.connect(
+                self._player_monitor(player_id)
+            )
+        except AttributeError:
+            subscription = {}
 
         self._mpris_players[player_id] = {
             "_dbus_player": player,


### PR DESCRIPTION
After looking what `subscription` looks like on other music players, I tried this for clementine... and it seems to be working quite well. I'm able to stop, pause, play, quit client, start client, etc.

Addresses https://github.com/ultrabug/py3status/issues/911.