### PR TITLE
i3status: add -u, --i3status to specify i3status path

### DIFF
--- a/py3status/cli.py
+++ b/py3status/cli.py
@@ -1,5 +1,6 @@
 import argparse
 import os
+import subprocess
 
 
 def parse_cli():
@@ -11,6 +12,13 @@ def parse_cli():
 
     # get home path
     home_path = os.path.expanduser("~")
+
+    # get i3status path
+    try:
+        command = ["which", "i3status"]
+        i3status_path = subprocess.check_output(command).decode().strip()
+    except subprocess.CalledProcessError:
+        i3status_path = None
 
     # i3status config file default detection
     # respect i3status' file detection order wrt issue #43
@@ -124,6 +132,16 @@ def parse_cli():
         default=False,
         dest="disable_click_events",
         help="disable all click events",
+    )
+    parser.add_argument(
+        "-u",
+        "--i3status",
+        action="store",
+        default=i3status_path,
+        dest="i3status_path",
+        help="specify i3status path",
+        metavar="PATH",
+        type=str,
     )
     parser.add_argument(
         "-v", "--version", action="store_true", help="show py3status version and exit"

--- a/py3status/core.py
+++ b/py3status/core.py
@@ -455,6 +455,7 @@ class Py3statusWrapper:
         config["interval"] = int(options.interval)
         config["log_file"] = options.log_file
         config["standalone"] = options.standalone
+        config["i3status_path"] = options.i3status_path
         config["i3status_config_path"] = options.i3status_conf
         config["disable_click_events"] = options.disable_click_events
         if options.cli_command:

--- a/py3status/i3status.py
+++ b/py3status/i3status.py
@@ -272,6 +272,7 @@ class I3status(Thread):
             "wireless",
         ]
         self.i3status_pipe = None
+        self.i3status_path = py3_wrapper.config["i3status_path"]
         self.json_list = None
         self.json_list_ts = None
         self.last_output = None
@@ -424,7 +425,7 @@ class I3status(Thread):
                 self.write_tmp_i3status_config(tmpfile)
 
                 i3status_pipe = Popen(
-                    ["i3status", "-c", tmpfile.name],
+                    [self.i3status_path, "-c", tmpfile.name],
                     stdout=PIPE,
                     stderr=PIPE,
                     # Ignore the SIGTSTP signal for this subprocess


### PR DESCRIPTION
This adds `-u, --i3status` for @Dettorer and other users to specify custom `i3status` path. If we can't `which i3status`, then it usually mean `i3status is not installed` so we'll try `Popen([None, "-c", ...)` too which will give us same error as old `i3status`. Anything more is not necessary.

Addresses #1600.  