### PR TITLE
simplify module options by hiding request_timeout configs

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -761,3 +761,22 @@ an event
     This feature will only activate when ``pyudev`` is installed on the system.
     This is an optional dependency of py3status and is therefore not enforced
     by all package managers.
+
+
+Request Timeout
+--------------------------------------------------------------
+
+.. note::
+    New in version 3.16
+
+Request Timeout for URL request based modules can be specified in the
+module configuration. To find out if your module supports that, look for
+``self.py3.request`` in the code. Otherwise, we will use ``10``.
+
+.. code-block:: py3status
+    :caption: Example
+
+    # stop waiting for a response after 10 seconds
+    exchange_rate {
+        request_timeout = 10
+    }

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -763,15 +763,19 @@ an event
     by all package managers.
 
 
-Request Timeout
---------------------------------------------------------------
+HTTP request timeout
+--------------------
 
 .. note::
     New in version 3.16
 
-Request Timeout for URL request based modules can be specified in the
-module configuration. To find out if your module supports that, look for
-``self.py3.request`` in the code. Otherwise, we will use ``10``.
+You can configure the HTTP request timeout of all modules relying on HTTP
+requests (and using the ``self.py3.request`` helper) using the generic
+`request_timeout` option (defaults to ``10`` seconds).
+
+All modules are encouraged to use the ``self.py3.request`` helper, so if the
+module you use does not document a specific timeout option it means that it is
+eligible to be tuned using the `request_timeout` option.
 
 .. code-block:: py3status
     :caption: Example

--- a/py3status/modules/air_quality.py
+++ b/py3status/modules/air_quality.py
@@ -135,7 +135,6 @@ class Py3status:
 
     def post_config_hook(self):
         self.auth_token = {"token": self.auth_token}
-        self.request_timeout = 10
         self.url = "https://api.waqi.info/feed/%s/" % self.location
         self.init_datetimes = []
         for word in self.format_datetime:
@@ -150,9 +149,7 @@ class Py3status:
 
     def _get_aqi_data(self):
         try:
-            return self.py3.request(
-                self.url, params=self.auth_token, timeout=self.request_timeout
-            ).json()
+            return self.py3.request(self.url, params=self.auth_token).json()
         except self.py3.RequestException:
             return None
 

--- a/py3status/modules/bitcoin_price.py
+++ b/py3status/modules/bitcoin_price.py
@@ -104,7 +104,6 @@ class Py3status:
             "YEN": "¥",
         }
         self.last_price = 0
-        self.request_timeout = 10
         self.url = "https://api.bitcoincharts.com/v1/markets.json"
 
     def _get_price(self, data, market, field):
@@ -119,7 +118,7 @@ class Py3status:
     def bitcoin_price(self):
         # get the data from bitcoincharts api
         try:
-            data = self.py3.request(self.url, timeout=self.request_timeout).json()
+            data = self.py3.request(self.url).json()
         except self.py3.RequestException:
             return {
                 "cached_until": self.py3.time_in(self.cache_timeout),

--- a/py3status/modules/coin_market.py
+++ b/py3status/modules/coin_market.py
@@ -116,7 +116,6 @@ class Py3status:
         self.first_use = True
         self.convert = self.limit = None
         self.url = self.reset_url = "https://api.coinmarketcap.com/v1/ticker/"
-        self.request_timeout = 10
 
         # convert the datetime?
         self.init_datetimes = []
@@ -151,7 +150,7 @@ class Py3status:
         if reset:
             self.url = self.reset_url
         try:
-            data = self.py3.request(self.url, timeout=self.request_timeout).json()
+            data = self.py3.request(self.url).json()
         except self.py3.RequestException:
             data = {}
         return data

--- a/py3status/modules/getjson.py
+++ b/py3status/modules/getjson.py
@@ -57,6 +57,17 @@ class Py3status:
     """
     """
 
+    class Meta:
+        deprecated = {
+            "rename": [
+                {
+                    "param": "timeout",
+                    "new": "request_timeout",
+                    "msg": "obsolete parameter use `request_timeout`",
+                }
+            ]
+        }
+
     # available configuration parameters
     cache_timeout = 30
     delimiter = "-"
@@ -66,13 +77,12 @@ class Py3status:
     def post_config_hook(self):
         if not self.url:
             raise Exception(STRING_ERROR)
-        self.request_timeout = getattr(self, "timeout", 10)
 
     def getjson(self):
         """
         """
         try:
-            json_data = self.py3.request(self.url, timeout=self.request_timeout).json()
+            json_data = self.py3.request(self.url).json()
             json_data = self.py3.flatten_dict(json_data, self.delimiter, True)
         except self.py3.RequestException:
             json_data = None

--- a/py3status/modules/getjson.py
+++ b/py3status/modules/getjson.py
@@ -12,7 +12,6 @@ Configuration parameters:
     cache_timeout: refresh interval for this module (default 30)
     delimiter: the delimiter between parent and child objects (default '-')
     format: display format for this module (default None)
-    timeout: time to wait for a response, in seconds (default 5)
     url: specify URL to fetch JSON from (default None)
 
 Format placeholders:
@@ -62,18 +61,18 @@ class Py3status:
     cache_timeout = 30
     delimiter = "-"
     format = None
-    timeout = 5
     url = None
 
     def post_config_hook(self):
         if not self.url:
             raise Exception(STRING_ERROR)
+        self.request_timeout = getattr(self, "timeout", 10)
 
     def getjson(self):
         """
         """
         try:
-            json_data = self.py3.request(self.url, timeout=self.timeout).json()
+            json_data = self.py3.request(self.url, timeout=self.request_timeout).json()
             json_data = self.py3.flatten_dict(json_data, self.delimiter, True)
         except self.py3.RequestException:
             json_data = None

--- a/py3status/modules/github.py
+++ b/py3status/modules/github.py
@@ -136,7 +136,7 @@ class Py3status:
         else:
             auth = None
         try:
-            info = self.py3.request(url, timeout=10, auth=auth)
+            info = self.py3.request(url, auth=auth)
         except (self.py3.RequestException):
             return
         if info and info.status_code == 200:
@@ -165,9 +165,7 @@ class Py3status:
             url = self.url_api + "/repos/" + self.repo + "/notifications"
         url += "?per_page=100"
         try:
-            info = self.py3.request(
-                url, timeout=10, auth=(self.username, self.auth_token)
-            )
+            info = self.py3.request(url, auth=(self.username, self.auth_token))
         except (self.py3.RequestException):
             return
         if info.status_code == 200:
@@ -187,7 +185,7 @@ class Py3status:
                 return len(info.json())
             try:
                 last_page_info = self.py3.request(
-                    last_url, timeout=10, auth=(self.username, self.auth_token)
+                    last_url, auth=(self.username, self.auth_token)
                 )
             except self.py3.RequestException:
                 return

--- a/py3status/modules/gitlab.py
+++ b/py3status/modules/gitlab.py
@@ -95,7 +95,6 @@ class Py3status:
         pipelines = "/pipelines"
         # url stuffs. header, timeout, dict, etc
         self.headers = {"PRIVATE-TOKEN": self.auth_token}
-        self.request_timeout = 10
         self.url = {
             "single_project": single_project,
             "merge_requests": single_project + merge_requests,
@@ -117,9 +116,7 @@ class Py3status:
 
     def _get_data(self, url):
         try:
-            return self.py3.request(
-                url, timeout=self.request_timeout, headers=self.headers
-            )
+            return self.py3.request(url, headers=self.headers)
         except self.py3.RequestException:
             return {}
 

--- a/py3status/modules/pingdom.py
+++ b/py3status/modules/pingdom.py
@@ -13,7 +13,6 @@ Configuration parameters:
     login: pingdom login (default '')
     max_latency: maximal latency before coloring the output (default 500)
     password: pingdom password (default '')
-    request_timeout: pindgom API request timeout (default 15)
 
 Format placeholders:
     {pingdom} pingdom response times
@@ -52,7 +51,9 @@ class Py3status:
     login = ""
     max_latency = 500
     password = ""
-    request_timeout = 15
+
+    def post_config_hook(self):
+        self.request_timeout = getattr(self, "request_timeout", 10)
 
     def pingdom(self):
         response = {

--- a/py3status/modules/pingdom.py
+++ b/py3status/modules/pingdom.py
@@ -13,6 +13,7 @@ Configuration parameters:
     login: pingdom login (default '')
     max_latency: maximal latency before coloring the output (default 500)
     password: pingdom password (default '')
+    request_timeout: pindgom API request timeout (default 10)
 
 Format placeholders:
     {pingdom} pingdom response times
@@ -51,9 +52,7 @@ class Py3status:
     login = ""
     max_latency = 500
     password = ""
-
-    def post_config_hook(self):
-        self.request_timeout = getattr(self, "request_timeout", 10)
+    request_timeout = 10
 
     def pingdom(self):
         response = {

--- a/py3status/modules/velib_metropole.py
+++ b/py3status/modules/velib_metropole.py
@@ -149,7 +149,6 @@ class Py3status:
         self.cache_station_keys = {}
         self.first_request = True
         self.idle_time = 0
-        self.request_timeout = 10
         self.scrolling = False
         self.station_data = {}
 
@@ -178,9 +177,7 @@ class Py3status:
 
     def _get_velib_data(self):
         try:
-            return self.py3.request(
-                VELIB_ENDPOINT, params=self.gps, timeout=self.request_timeout
-            ).json()
+            return self.py3.request(VELIB_ENDPOINT, params=self.gps).json()
         except self.py3.RequestException:
             return None
 

--- a/py3status/modules/weather_owm.py
+++ b/py3status/modules/weather_owm.py
@@ -152,8 +152,6 @@ Configuration parameters:
         then the offset in minutes. If this is set, it disables the
         automatic timezone detection from the Timezone API.
         (default None)
-    request_timeout: The timeout in seconds for contacting the API's.
-        (default 10)
     thresholds: Configure temperature colors based on limits
         The numbers specified inherit the unit of the temperature as configured.
         The default below is intended for Fahrenheit. If the set value is empty
@@ -358,7 +356,6 @@ class Py3status:
     lang = "en"
     location = None
     offset_gmt = None
-    request_timeout = 10
     thresholds = THRESHOLDS
     unit_rain = "in"
     unit_snow = "in"
@@ -412,6 +409,9 @@ class Py3status:
                 " Go to https://openweathermap.org/appid to"
                 " get an API Key."
             )
+
+        # Get request timeout
+        self.request_timeout = getattr(self, "request_timeout", 10)
 
         # Generate our icon array
         self.icons = self._get_icons()

--- a/py3status/modules/weather_owm.py
+++ b/py3status/modules/weather_owm.py
@@ -410,9 +410,6 @@ class Py3status:
                 " get an API Key."
             )
 
-        # Get request timeout
-        self.request_timeout = getattr(self, "request_timeout", 10)
-
         # Generate our icon array
         self.icons = self._get_icons()
 
@@ -438,7 +435,7 @@ class Py3status:
 
     def _make_req(self, url, params=None):
         # Make a request expecting a JSON response
-        req = self.py3.request(url, params=params, timeout=self.request_timeout)
+        req = self.py3.request(url, params=params)
         if req.status_code != 200:
             data = req.json()
             raise OWMException(

--- a/py3status/modules/whatismyip.py
+++ b/py3status/modules/whatismyip.py
@@ -19,7 +19,6 @@ Configuration parameters:
     icon_on: what to display when online (default '●')
     mode: default mode to display is 'ip' or 'status' (click to toggle)
         (default 'ip')
-    timeout: how long before deciding we're offline (default 5)
     url_geo: IP to check for geo location (must output json)
         (default 'https://ifconfig.co/json')
 
@@ -69,7 +68,6 @@ class Py3status:
     icon_off = u"■"
     icon_on = u"●"
     mode = "ip"
-    timeout = 5
     url_geo = URL_GEO_NEW_DEFAULT
 
     class Meta:
@@ -96,6 +94,9 @@ class Py3status:
         if self.expected is None:
             self.expected = {}
 
+        # Get request timeout
+        self.request_timeout = getattr(self, "timeout", 10)
+
         # Backwards compatibility
         self.substitutions = {}
         if self.url_geo == URL_GEO_NEW_DEFAULT:
@@ -109,7 +110,7 @@ class Py3status:
 
     def _get_my_ip_info(self):
         try:
-            info = self.py3.request(self.url_geo, timeout=self.timeout).json()
+            info = self.py3.request(self.url_geo, timeout=self.request_timeout).json()
             for old, new in self.substitutions.items():
                 info[old] = info.get(new)
             return info

--- a/py3status/modules/whatismyip.py
+++ b/py3status/modules/whatismyip.py
@@ -87,15 +87,17 @@ class Py3status:
                     "new": "icon_off",
                     "msg": "obsolete parameter, use `icon_off` instead",
                 },
+                {
+                    "param": "timeout",
+                    "new": "request_timeout",
+                    "msg": "obsolete parameter use `request_timeout`",
+                },
             ],
         }
 
     def post_config_hook(self):
         if self.expected is None:
             self.expected = {}
-
-        # Get request timeout
-        self.request_timeout = getattr(self, "timeout", 10)
 
         # Backwards compatibility
         self.substitutions = {}
@@ -110,7 +112,7 @@ class Py3status:
 
     def _get_my_ip_info(self):
         try:
-            info = self.py3.request(self.url_geo, timeout=self.request_timeout).json()
+            info = self.py3.request(self.url_geo).json()
             for old, new in self.substitutions.items():
                 info[old] = info.get(new)
             return info

--- a/py3status/py3.py
+++ b/py3status/py3.py
@@ -1216,7 +1216,7 @@ class Py3:
         params=None,
         data=None,
         headers=None,
-        timeout=10,
+        timeout=None,
         auth=None,
         cookiejar=None,
     ):
@@ -1250,6 +1250,9 @@ class Py3:
 
         if headers is None:
             headers = {}
+
+        if timeout is None:
+            timeout = getattr(self._py3status_module, "request_timeout", 10)
 
         if "User-Agent" not in headers:
             headers["User-Agent"] = "py3status/{} {}".format(version, self._uid)

--- a/py3status/py3.py
+++ b/py3status/py3.py
@@ -1216,7 +1216,7 @@ class Py3:
         params=None,
         data=None,
         headers=None,
-        timeout=None,
+        timeout=10,
         auth=None,
         cookiejar=None,
     ):


### PR DESCRIPTION
I believe we shouldn't bother users with this particular config. By defaulting `timeout=10` in `py3.py`, we can simplify several things. The modules with exposed config are left alone but will be hidden this time to allow some transition time.

I made one adjustment to `exchange_rate`, from 20 to 10, since this module is broken for long time so I think maybe it is okay to do that (i.e. to use the default value instead)... I also wonder if we want to default `pingdom` with the default value too, but `pingdom`'s request need to be fixed too. Not me.

Addresses #1519 (request_timeout,  self.py3.request)

P.S. In case you didn't notice, I'm really trying to kill many issues as I can here. 

EDIT: I changed ~~`pingdom` and `getjson`'s~~ ~~nearly~~ all `request_timeout` to 10. 