### PR TITLE
Fixed typo in naming ('gradiant' -> 'gradient')

### DIFF
--- a/py3status/py3.py
+++ b/py3status/py3.py
@@ -18,7 +18,7 @@ from py3status.constants import COLOR_NAMES
 from py3status.formatter import Formatter, Composite
 from py3status.request import HttpResponse
 from py3status.storage import Storage
-from py3status.util import Gradiants
+from py3status.util import Gradients
 from py3status.version import version
 
 
@@ -93,7 +93,7 @@ class Py3:
 
     # Shared by all Py3 Instances
     _formatter = None
-    _gradients = Gradiants()
+    _gradients = Gradients()
     _none_color = NoneColor()
     _storage = Storage()
 

--- a/py3status/util.py
+++ b/py3status/util.py
@@ -6,7 +6,7 @@ from colorsys import rgb_to_hsv, hsv_to_rgb
 from math import modf
 
 
-class Gradiants:
+class Gradients:
     """
     Create color gradients
     """


### PR DESCRIPTION
Simple correction of a typo occurring a few times in the code ("gradiant" -> "gradient").