### PR TITLE
net_rate: prevent log flooding on weird network interface state

### DIFF
--- a/py3status/modules/net_rate.py
+++ b/py3status/modules/net_rate.py
@@ -162,7 +162,7 @@ class Py3status:
             # get the deltas into variable
             delta = deltas[interface] if interface else None
 
-        except (TypeError, ValueError):
+        except (TypeError, ValueError, KeyError):
             delta = None
             interface = None
             hide = self.hide_if_zero


### PR DESCRIPTION
When i'm offline, after resuming my laptop, I can get lot of garbage from net_rate.
A quick working fix is done by handle KeyError too. 
ps: Error was on line 163.