### PR TITLE
i3status: use None or i3status

### DIFF
--- a/py3status/cli.py
+++ b/py3status/cli.py
@@ -15,8 +15,11 @@ def parse_cli():
 
     # get i3status path
     try:
-        command = ["which", "i3status"]
-        i3status_path = subprocess.check_output(command).decode().strip()
+        with open(os.devnull, "w") as devnull:
+            command = ["which", "i3status"]
+            i3status_path = (
+                subprocess.check_output(command, stderr=devnull).decode().strip()
+            )
     except subprocess.CalledProcessError:
         i3status_path = None
 
@@ -154,6 +157,10 @@ def parse_cli():
 
         print("py3status version {} (python {})".format(version, python_version()))
         sys.exit(0)
+
+    # make it i3status if None
+    if not options.i3status_path:
+        options.i3status_path = "i3status"
 
     # all done
     return options


### PR DESCRIPTION
Regardless of its state, don't use `do_not_disturb` module when you're testing things. It was hiding this an error message from me... I ran into this error message for first time after removing `do_not_disturb` from my config. This is why I like `state = None`. ;-) 