### PR TITLE
tor_rate: hide socket error if we assume tor is not always running

### DIFF
--- a/py3status/modules/tor_rate.py
+++ b/py3status/modules/tor_rate.py
@@ -102,27 +102,22 @@ class Py3status:
         else:
             text = self.py3.safe_format(self.format, self._get_rates())
 
-        return {
-            "cached_until": self.py3.time_in(self.cache_timeout),
-            "full_text": text
-        }
+        return {"cached_until": self.py3.time_in(self.cache_timeout), "full_text": text}
 
     def _get_rates(self):
         up, up_unit = self.py3.format_units(
-            self._up, unit=self.rate_unit, si=self.si_units)
+            self._up, unit=self.rate_unit, si=self.si_units
+        )
         down, down_unit = self.py3.format_units(
-            self._down, unit=self.rate_unit, si=self.si_units)
+            self._down, unit=self.rate_unit, si=self.si_units
+        )
         return {
-            "up":
-            self.py3.safe_format(self.format_value, {
-                "rate": up,
-                "unit": up_unit
-            }),
-            "down":
-            self.py3.safe_format(self.format_value, {
-                "rate": down,
-                "unit": down_unit
-            }),
+            "up": self.py3.safe_format(
+                self.format_value, {"rate": up, "unit": up_unit}
+            ),
+            "down": self.py3.safe_format(
+                self.format_value, {"rate": down, "unit": down_unit}
+            ),
         }
 
     def _handle_event(self, event):
@@ -131,11 +126,11 @@ class Py3status:
 
     def _register_event_handler(self):
         self._control = Controller.from_port(
-            address=self.control_address, port=self.control_port)
+            address=self.control_address, port=self.control_port
+        )
         if self.control_password:
             self._control.authenticate(password=self.control_password)
-        self._control.add_event_listener(lambda e: self._handle_event(e),
-                                         EventType.BW)
+        self._control.add_event_listener(lambda e: self._handle_event(e), EventType.BW)
         self._handler_active = True
 
 


### PR DESCRIPTION
Hi guys,

I hide "Error: Failed to establish control connection!" with hide_if_not_running param for user which assume tor is not running sometimes. 

ping @maximbaz 