### PR TITLE
simplify include_paths early to valid paths

### DIFF
--- a/py3status/cli.py
+++ b/py3status/cli.py
@@ -248,18 +248,23 @@ def parse_cli():
     # make include path to search for user modules if None
     if not options.include_paths:
         options.include_paths = [
-            "{}/.i3/py3status/".format(home_path),
-            "{}/.config/i3/py3status/".format(home_path),
+            "{}/.i3/py3status".format(home_path),
+            "{}/.config/i3/py3status".format(home_path),
             "{}/i3status/py3status".format(xdg_home_path),
             "{}/i3/py3status".format(xdg_home_path),
         ]
+
+    include_paths = []
+    for path in options.include_paths:
+        path = os.path.abspath(path)
+        if os.path.isdir(path) and os.listdir(path):
+            include_paths.append(path)
+    options.include_paths = include_paths
 
     # handle py3status list and docstring options
     if options.command:
         import py3status.docstrings as docstrings
 
-        # init
-        options.include_paths = options.include_paths or []
         config = vars(options)
         modules = [x.rsplit(".py", 1)[0] for x in config["module"]]
         # list module names and details

--- a/py3status/core.py
+++ b/py3status/core.py
@@ -193,9 +193,7 @@ class Common:
         NOTE: msg should not end in a '.' for consistency.
         """
         # Get list of paths that our stack trace should be found in.
-        py3_paths = [os.path.dirname(__file__)]
-        user_paths = self.config.get("include_paths", [])
-        py3_paths += [os.path.abspath(path) + "/" for path in user_paths]
+        py3_paths = [os.path.dirname(__file__)] + self.config["include_paths"]
         traceback = None
 
         try:
@@ -442,9 +440,6 @@ class Py3statusWrapper:
         """
         user_modules = {}
         for include_path in self.config["include_paths"]:
-            include_path = os.path.abspath(include_path) + "/"
-            if not os.path.isdir(include_path):
-                continue
             for f_name in sorted(os.listdir(include_path)):
                 if not f_name.endswith(".py"):
                     continue

--- a/py3status/docstrings.py
+++ b/py3status/docstrings.py
@@ -57,9 +57,6 @@ def core_module_docstrings(
     if include_user:
         # include user modules
         for include_path in sorted(config["include_paths"]):
-            include_path = os.path.abspath(include_path) + "/"
-            if not os.path.isdir(include_path):
-                continue
             for file in sorted(os.listdir(include_path)):
                 if not file.endswith(".py"):
                     continue


### PR DESCRIPTION
Simplify `include_paths` early to valid paths so we don't have to fix or check anything later.