### PR TITLE
rename cli.py to argparsers.py

### DIFF
--- a/py3status/__init__.py
+++ b/py3status/__init__.py
@@ -17,9 +17,9 @@ except NameError:
 
 
 def main():
-    from py3status.cli import parse_cli
+    from py3status.argparsers import parse_cli_args
 
-    options = parse_cli()
+    options = parse_cli_args()
     # detect gevent option early because monkey patching should be done before
     # everything else starts kicking
     if options.gevent:

--- a/py3status/argparsers.py
+++ b/py3status/argparsers.py
@@ -41,7 +41,7 @@ examples:
 """
 
 
-def parse_cli():
+def parse_cli_args():
     """
     Parse the command line arguments
     """


### PR DESCRIPTION
Personal opinion to use `argparsers`. It's not always clear which file to open... `cli` or `command`.