### PR TITLE
twitch: clean up some code

### DIFF
--- a/py3status/modules/twitch.py
+++ b/py3status/modules/twitch.py
@@ -7,13 +7,11 @@ if a channel is currently streaming or not.
 
 Configuration parameters:
     cache_timeout: how often we refresh this module in seconds
-        (default 10)
+        (default 60)
     client_id: Your client id. Create your own key at https://dev.twitch.tv
         (default None)
     format: Display format when online
         (default "{stream_name} is live!")
-    format_invalid: Display format when streamer does not exist
-        (default "{stream_name} does not exist!")
     format_offline: Display format when offline
         (default "{stream_name} is offline.")
     stream_name: name of streamer(twitch.tv/<stream_name>)
@@ -46,20 +44,27 @@ offline
 
 import requests
 
+STRING_MISSING = "missing {}"
+
 
 class Py3status:
     """
     """
 
     # available configuration parameters
-    cache_timeout = 10
+    cache_timeout = 60
     client_id = None
     format = "{stream_name} is live!"
-    format_invalid = "{stream_name} does not exist!"
     format_offline = "{stream_name} is offline."
     stream_name = None
 
+    class Meta:
+        deprecated = {"remove": [{"param": "format_invalid", "msg": "obsolete"}]}
+
     def post_config_hook(self):
+        for config_name in ["client_id", "stream_name"]:
+            if not getattr(self, config_name, None):
+                raise Exception(STRING_MISSING.format(config_name))
         self._display_name = None
 
     def _get_display_name(self):
@@ -68,41 +73,26 @@ class Py3status:
         self._display_name = display_name_request.json().get("display_name")
 
     def twitch(self):
-        if self.stream_name is None:
-            return {
-                "full_text": "stream_name missing",
-                "cached_until": self.py3.CACHE_FOREVER,
-            }
+        if not self._display_name:
+            self._get_display_name()
 
         r = requests.get(
             "https://api.twitch.tv/kraken/streams/" + self.stream_name,
             headers={"Client-ID": self.client_id},
         )
-        if not self._display_name:
-            self._get_display_name()
-        if "error" in r.json():
-            colour = self.py3.COLOR_BAD
-            format = self.format_invalid
-            stream_name = self.stream_name
-        elif r.json().get("stream") is None:
-            colour = self.py3.COLOR_BAD
-            format = self.format_offline
-            stream_name = self._display_name
-        elif r.json().get("stream") is not None:
-            colour = self.py3.COLOR_GOOD
+        if r.json().get("stream"):
+            color = self.py3.COLOR_GOOD
             format = self.format
-            stream_name = self._display_name
         else:
-            colour = self.py3.COLOR_BAD
-            format = "An unknown error has occurred."
-            stream_name = None
+            color = self.py3.COLOR_BAD
+            format = self.format_offline
 
-        full_text = self.py3.safe_format(format, {"stream_name": stream_name})
+        full_text = self.py3.safe_format(format, {"stream_name": self._display_name})
 
         response = {
             "cached_until": self.py3.time_in(self.cache_timeout),
             "full_text": full_text,
-            "color": colour,
+            "color": color,
         }
         return response
 
@@ -111,7 +101,6 @@ if __name__ == "__main__":
     """
     Run module in test mode.
     """
-    config = {"stream_name": "moo"}
     from py3status.module_test import module_test
 
-    module_test(Py3status, config=config)
+    module_test(Py3status)


### PR DESCRIPTION
This cleans up some Twitch code.
* Remove dead config `format_invalid`. Not triggerable. 
* Use exception in `post_config_hook` instead.
* `An unknown error has occurred.` can never happen because of `None` / `not None`.
* Larry the cow need to stop mooing madly in my terminal.
* EDIT: Change `cache_timeout` from `10` to `60`.
