### PR TITLE
twitch: use self.py3.request helper 

### DIFF
--- a/py3status/modules/twitch.py
+++ b/py3status/modules/twitch.py
@@ -8,17 +8,17 @@ Configuration parameters:
     client_id: Your client id. Create your own key at https://dev.twitch.tv
         (default None)
     format: Display format when online
-        (default "{stream_name} is live!")
+        (default "{display_name} is live!")
     format_offline: Display format when offline
-        (default "{stream_name} is offline.")
+        (default "{display_name} is offline.")
     stream_name: name of streamer(twitch.tv/<stream_name>)
         (default None)
 
 Format placeholders:
-    {stream_name} name of the streamer
+    {display_name} streamer display name, eg Ultrabug
 
 Color options:
-    color_bad: Stream offline or error
+    color_bad: Stream offline
     color_good: Stream is live
 
 Client ID:
@@ -39,8 +39,6 @@ offline
 {'color': '#FF0000', 'full_text': 'exotic_bug is offline!'}
 """
 
-import requests
-
 STRING_MISSING = "missing {}"
 
 
@@ -51,46 +49,73 @@ class Py3status:
     # available configuration parameters
     cache_timeout = 60
     client_id = None
-    format = "{stream_name} is live!"
-    format_offline = "{stream_name} is offline."
+    format = "{display_name} is live!"
+    format_offline = "{display_name} is offline."
     stream_name = None
 
     class Meta:
-        deprecated = {"remove": [{"param": "format_invalid", "msg": "obsolete"}]}
+        deprecated = {
+            "remove": [{"param": "format_invalid", "msg": "obsolete"}],
+            "rename_placeholder": [
+                {
+                    "placeholder": "stream_name",
+                    "new": "display_name",
+                    "format_strings": ["format"],
+                }
+            ],
+        }
 
     def post_config_hook(self):
         for config_name in ["client_id", "stream_name"]:
             if not getattr(self, config_name, None):
                 raise Exception(STRING_MISSING.format(config_name))
-        self._display_name = None
 
-    def _get_display_name(self):
-        url = "https://api.twitch.tv/kraken/users/" + self.stream_name
-        display_name_request = requests.get(url, headers={"Client-ID": self.client_id})
-        self._display_name = display_name_request.json().get("display_name")
+        self.headers = {"Client-ID": self.client_id}
+        base_api = "https://api.twitch.tv/kraken/"
+        self.url = {
+            "users": base_api + "users/{}".format(self.stream_name),
+            "streams": base_api + "streams/{}".format(self.stream_name),
+        }
+        self.users = {}
+
+    def _get_twitch_data(self, url):
+        try:
+            response = self.py3.request(url, headers=self.headers)
+        except self.py3.RequestException:
+            return {}
+        data = response.json()
+        if not data:
+            data = vars(response)
+            error = data.get("_error_message")
+            if error:
+                self.py3.error("{} {}".format(error, data["_status_code"]))
+        return data
 
     def twitch(self):
-        if not self._display_name:
-            self._get_display_name()
+        twitch_data = self.users
+        current_format = ""
+        color = None
 
-        r = requests.get(
-            "https://api.twitch.tv/kraken/streams/" + self.stream_name,
-            headers={"Client-ID": self.client_id},
-        )
-        if r.json().get("stream"):
-            color = self.py3.COLOR_GOOD
-            format = self.format
-        else:
-            color = self.py3.COLOR_BAD
-            format = self.format_offline
+        if not twitch_data:
+            self.users = self._get_twitch_data(self.url["users"])
+            twitch_data.update(self.users)
 
-        full_text = self.py3.safe_format(format, {"stream_name": self._display_name})
+        streams = self._get_twitch_data(self.url["streams"])
+        if streams:
+            twitch_data.update(streams)
+            if twitch_data["stream"]:
+                color = self.py3.COLOR_GOOD
+                current_format = self.format
+            else:
+                color = self.py3.COLOR_BAD
+                current_format = self.format_offline
 
         response = {
             "cached_until": self.py3.time_in(self.cache_timeout),
-            "full_text": full_text,
-            "color": color,
+            "full_text": self.py3.safe_format(current_format, twitch_data),
         }
+        if color:
+            response["color"] = color
         return response
 
 


### PR DESCRIPTION
This adds `py3.request` helper. We can use `request_timeout` too if we want to. :crossed_fingers: :pray: :prayer_beads: 

* Rename `stream_name` placeholder to upstream `display_name`.
* Both URL uses `py3.request` now. 
* Errors such as `Bad Request 404` will be used instead of broken `format_invalid` config.
* Things looks okay on my side.
* Colors and formats are left alone. Guess we will wait for the new formatter or something.

Plz merge #1698 first.