### PR TITLE
Use python's native way of detecting location of i3status bin

### DIFF
--- a/py3status/cli.py
+++ b/py3status/cli.py
@@ -1,6 +1,6 @@
 import argparse
 import os
-import subprocess
+import shutil
 
 from platform import python_version
 from py3status.version import version
@@ -51,14 +51,7 @@ def parse_cli():
     xdg_dirs_path = os.environ.get("XDG_CONFIG_DIRS", "/etc/xdg")
 
     # get i3status path
-    try:
-        with open(os.devnull, "w") as devnull:
-            command = ["which", "i3status"]
-            i3status_path = (
-                subprocess.check_output(command, stderr=devnull).decode().strip()
-            )
-    except subprocess.CalledProcessError:
-        i3status_path = None
+    i3status_path = shutil.which("i3status")
 
     # i3status config file default detection
     # respect i3status' file detection order wrt issue #43


### PR DESCRIPTION
`which` is not guaranteed to be installed on the system, so let's not depend on it.