### PR TITLE
usbguard: simpler implementation

### DIFF
--- a/py3status/modules/usbguard.py
+++ b/py3status/modules/usbguard.py
@@ -3,7 +3,6 @@
 Allow or Reject newly plugged USB devices using USBGuard.
 
 Configuration parameters:
-    allow_urgent: display urgency (default True)
     format: display format for this module
         (default '[{format_device}]')
     format_button_allow: display format for allow button filter
@@ -58,7 +57,6 @@ class Py3status:
     """
 
     # available configuration parameters
-    allow_urgent = True
     format = "[{format_device}]"
     format_button_allow = "\[Allow\]"
     format_button_reject = "\[Reject\]"
@@ -161,7 +159,7 @@ class Py3status:
         return {
             "cached_until": self.py3.CACHE_FOREVER,
             "full_text": self.py3.safe_format(self.format, usbguard_data),
-            "urgent": self.allow_urgent,
+            "urgent": True,
         }
 
     def on_click(self, event):

--- a/py3status/modules/usbguard.py
+++ b/py3status/modules/usbguard.py
@@ -1,195 +1,77 @@
 # -*- coding: utf-8 -*-
 """
-Allow, Block, and Reject USB devices.
-
-USBGuard is a software framework for implementing USB device authorization
-policies. For more information, see https://usbguard.github.io/
+Allow or Reject newly plugged USB devices using USBGuard.
 
 Configuration parameters:
-    allow_urgent: display urgency on unread messages (default False)
-    button_next: mouse button to switch next device (default 4)
-    button_previous: mouse button to switch previous device (default 5)
-    filters: specify a list of filters to use:
-        (default ['None', 'any', 'allow', 'block'])
     format: display format for this module
-        *(default '[{format_device_list} ]{format_button_device} '
-        '{format_button_filter}[\?color=darkgray&show \|]'
-        '{format_button_permanent}')*
-    format_button_allow: display format for allow button
-        (default '[\?if=!policy=allow&color=good Allow]')
-    format_button_block: display format for block button
-        (default '[\?if=!policy=block&color=degraded Block]')
-    format_button_device: display format for device button
-        (default '[\?color=deepskyblue&show Device] {device}/{devices}')
-    format_button_filter: display format for filter button
-        *(default '[\?color=deepskyblue&show Filter ]'
-        '[\?if=filter=allow Allow|[\?if=filter=block '
-        'Block|[\?if=filter=None None|Any]]]')*
-    format_button_permanent: display format for permanent button
-        *(default '[\?if=permanent&color=white Permanently'
-        '|\?color=darkgray Permanently]')*
-    format_button_reject: display format for reject button
-        (default '\?color=bad Reject')
+        (default '[{format_device}]')
+    format_button_allow: display format for allow button filter
+        (default '\[Allow\]')
+    format_button_reject: display format for reject button filter
+        (default '\[Reject\]')
     format_device: display format for USB devices
-        *(default '[{name}|Unknown {id} [\?color=darkgray {usb_id}]]'
-        '[ {format_button_allow}][ {format_button_block}]')*
+        (default '{format_button_reject} [{name}|{usb_id}] {format_button_allow}'
     format_device_separator: show separator if more than one (default ' ')
-    format_notification_message: specify notification message to use
-        (default 'USB ID: {usb_id}\\nName: {name}\\nPort: {port}')
-    format_notification_title: specify notification title to use
-        *(default 'USB Device [\?if=policy=allow Allowed]'
-        '[\?if=policy=block Blocked][\?if=policy=reject Rejected]')*
-    permanent: specify behavior to use, otherwise auto False (default None)
 
 Format placeholders:
     {device}                  number of USB devices
-    {format_button_filter}    button to toggle USB device display filters
-    {format_button_permanent} button to toggle permanent states
     {format_device}           format for USB devices
 
-format_button_filter:
-    {filter}      USB device filter, eg None, any, allow, block
-
-format_button_permanent:
-    {permanent}   permanent boolean, eg False, True
-
 format_device:
-    {id}                   eg 1, 2, 5, 6, 7, 22, 23, 33
-    {policy}               eg allow, block
-    {usb_id}               eg 054c:0268
-    {name}                 eg Poker II, PLAYSTATION(R)3 Controller
-    {serial}               eg 0000:00:00.0
-    {port}                 eg usb1, usb2, usb3, 1-1, 4-1.2.1
-    {interface}            eg 00:00:00:00 00:00:00 00:00:00
-    {hash}                 eg ihYz60+8pxZBi/cm+Q/4Ibrsyyzq/iZ9xtMDAh53sng
-    {parent_hash}          eg npSDT1xuEIOSLNt2RT2EbFrE8XRZoV29t1n7kg6GxXg
-    {format_button_allow}  format for allow button
-    {format_button_block}  format for block button
-    {format_button_reject} format for reject button
-
-format_notification_*:
-    See `format_device`
+    {format_button_allow}     button to allow the device
+    {format_button_reject}    button to reject the device
+    {id}                      eg 1, 2, 5, 6, 7, 22, 23, 33
+    {policy}                  eg allow, block, reject
+    {usb_id}                  eg 054c:0268
+    {name}                    eg Poker II, PLAYSTATION(R)3 Controller
+    {serial}                  eg 0000:00:00.0
+    {port}                    eg usb1, usb2, usb3, 1-1, 4-1.2.1
+    {interface}               eg 00:00:00:00 00:00:00 00:00:00
+    {hash}                    eg ihYz60+8pxZBi/cm+Q/4Ibrsyyzq/iZ9xtMDAh53sng
+    {parent_hash}             eg npSDT1xuEIOSLNt2RT2EbFrE8XRZoV29t1n7kg6GxXg
 
 Requires:
     python-gobject: Python Bindings for GLib/GObject/GIO/GTK+
     usbguard: USB device authorization policy framework
 
-Examples:
-```
-# specify a list of filters: None, any, allow, block
-usbguard {
-    * None: show any devices with any options
-    * any: show any devices
-    * allow: show authorized devices
-    * block: show unauthorized devices
-}
-
-# show block device only, hide button
-usbguard {
-    format_button_filter = ''
-    filters = ['block']
-}
-```
-
-@author Cyril Levis (@cyrinux)
+@author @cyrinux, @lasers, @maximbaz
 @license BSD
 
 SAMPLE OUTPUT
 [
-    {'full_text': 'Poker II '},
-    {'full_text': 'Allow ', 'color': '#00ff00'},
-    {'full_text': 'Block ', 'color': '#ffff00'},
-    {'full_text': 'Reject', 'color': '#ff0000'},
-]
-
-filters
-[
-    {'full_text': 'PLAYSTATION(R)3 Controller '},
-    {'full_text': 'Allow ', 'color': '#00ff00'},
-    {'full_text': 'Block', 'color': '#ffff00'},
-]
-
-unknown
-[
-    {'full_text': 'Unknown 12 '},
-    {'full_text': '8087:0024 ', 'color': '#a9a9a9'},
-    {'full_text': 'Allow ', 'color': '#00ff00'},
-    {'full_text': 'Block', 'color': '#ffff00'},
+    {'full_text': '[Reject] ', 'index': '22/reject', 'separator': False, 'separator_block_width': 0, 'urgent': True, 'cached_until': -1},
+    {'full_text': 'USB Flash Drive ', 'separator': False, 'separator_block_width': 0, 'urgent': True},
+    {'full_text': '[Allow]', 'index': '22/allow', 'urgent': True}
 ]
 """
 
-from copy import deepcopy
 from threading import Thread
-from gi.repository import Gio
+from gi.repository import GLib, Gio
 import re
 
 STRING_USBGUARD_DBUS = "start usbguard-dbus.service"
-STRING_INVALID_FILTER = "invalid filters `{}`"
 
 
 class Py3status:
     """
     """
 
-    # available configuration parameters
-    allow_urgent = False
-    button_next = 4
-    button_previous = 5
-    filters = ["None", "any", "allow", "block"]
-    format = (
-        "[{format_device_list} ]{format_button_device} {format_button_filter}"
-        "[\?color=darkgray&show \|]{format_button_permanent}"
-    )
-    format_button_allow = "[\?if=!policy=allow&color=good Allow]"
-    format_button_block = "[\?if=!policy=block&color=degraded Block]"
-    format_button_device = "[\?color=deepskyblue&show Device] {device}/{devices}"
-    format_button_filter = (
-        "[\?color=deepskyblue&show Filter ]"
-        "[\?if=filter=allow Allow|[\?if=filter=block "
-        "Block|[\?if=filter=None None|Any]]]"
-    )
-    format_button_permanent = (
-        "[\?if=permanent&color=white Permanently" "|\?color=darkgray Permanently]"
-    )
-    format_button_reject = "\?color=bad Reject"
-    format_device = (
-        "[{name}|Unknown {id} [\?color=darkgray {usb_id}]]"
-        "[ {format_button_allow}][ {format_button_block}]"
-    )
+    allow_urgent = True
+    format = "[{format_device}]"
+    format_button_allow = "\[Allow\]"
+    format_button_reject = "\[Reject\]"
+    format_device = "{format_button_reject} [{name}|{usb_id}] {format_button_allow}"
     format_device_separator = " "
-    format_notification_message = "USB ID: {usb_id}\nName: {name}\nPort: {port}"
-    format_notification_title = (
-        "USB Device [\?if=policy=allow Allowed]"
-        "[\?if=policy=block Blocked]"
-        "[\?if=policy=reject Rejected]"
-    )
-    permanent = None
-
-    # playground
 
     def post_config_hook(self):
-        for _filter in self.filters:
-            if _filter not in ["None", "any", "allow", "block"]:
-                raise Exception(STRING_INVALID_FILTER.format(_filter))
-
         self.init = {
             "format_button": self.py3.get_placeholders_list(
                 self.format_device, "format_button_*"
             ),
-            "notifications": (
-                self.format_notification_title or self.format_notification_message
-            ),
-            "permanent": self.permanent is None,
-            "target": {"allow": 0, "block": 1, "reject": 2},
+            "target": {"allow": 0, "reject": 2},
         }
 
-        self.filter_index = 0
-        self.filter_length = len(self.filters)
-        self.device_index = 1
-        self.device_length = 0
-        self.permanent = self.permanent or False
-        self.cache_devices = {}
-        self.device_keys = [
+        self.keys = [
             ("serial", re.compile(r"\S*serial \"(\S+)\"\S*")),
             ("policy", re.compile(r"^(\S+)")),
             ("usb_id", re.compile(r"id (\S+)")),
@@ -200,182 +82,94 @@ class Py3status:
             ("interface", re.compile(r"with-interface \{ (.*) \}$")),
         ]
 
-        try:
-            self.bus = Gio.bus_get_sync(Gio.BusType.SYSTEM, None)
-            self.proxy = Gio.DBusProxy.new_sync(
-                self.bus,
-                Gio.DBusProxyFlags.NONE,
+        self._init_dbus()
+
+    def _init_dbus(self):
+        self.bus = Gio.bus_get_sync(Gio.BusType.SYSTEM, None)
+        self.proxy = Gio.DBusProxy.new_sync(
+            self.bus,
+            Gio.DBusProxyFlags.NONE,
+            None,
+            "org.usbguard",
+            "/org/usbguard/Devices",
+            "org.usbguard.Devices",
+            None,
+        )
+        for signal in ["DevicePolicyChanged", "DevicePresenceChanged"]:
+            self.bus.signal_subscribe(
                 None,
-                "org.usbguard",
-                "/org/usbguard/Devices",
                 "org.usbguard.Devices",
+                signal,
                 None,
+                None,
+                0,
+                lambda *args: self.py3.update(),
             )
-            for signal in ["DevicePolicyChanged", "DevicePresenceChanged"]:
-                self.bus.signal_subscribe(
-                    None, "org.usbguard.Devices", signal, None, None, 0, self.py3.update
-                )
+
+        thread = Thread(target=lambda: GLib.MainLoop().run())
+        thread.daemon = True
+        thread.start()
+
+    def _get_devices(self):
+        try:
+            raw_devices = self.proxy.listDevices("(s)", "match")
         except Exception:
             raise Exception(STRING_USBGUARD_DBUS)
 
-        self.thread = Thread(target=self._start_loop)
-        self.thread.daemon = True
-        # self.thread.start()
+        devices = []
+        for device_id, string in raw_devices:
+            device = {"id": device_id}
+            for name, regex in self.keys:
+                value = regex.findall(string) or None
+                if value:
+                    value = value[0]
+                    value = value.encode("latin-1").decode("unicode_escape")
+                    value = value.encode("latin-1").decode("utf-8")
+                device[name] = value
+            if device["policy"] == "block":
+                devices.append(device)
 
-    def _start_loop(self):
-        pass
+        return devices
 
-    def _get_devices(self, device_filter):
-        if device_filter in ["any", "None"]:
-            device_filter = "match"
-
-        devices = self.proxy.listDevices("(s)", device_filter)
-        new_devices = []
-
-        for device_id, device_string in devices:
-            try:
-                device = self.cache_devices[device_string]
-            except KeyError:
-                device = {"id": device_id}
-                for name, regex in self.device_keys:
-                    value = regex.findall(device_string) or None
-                    if value:
-                        value = (
-                            value[0]
-                            .encode("latin-1")
-                            .decode("unicode_escape")
-                            .encode("latin-1")
-                            .decode()
-                        )
-                    device[name] = value
-                self.cache_devices[device_string] = device
-            new_devices.append(device)
-
-        return deepcopy(new_devices)
-
-    def _manipulate_devices(self, devices, device_filter):
-        new_device = []
-        format_device_list = None
-        self.device_length = len(devices)
-        for index, device in enumerate(devices, 1):
-            if device_filter == "any":
-                pass
-            elif device_filter == "None":
-                device["policy"] = None
-            elif device["policy"] != device_filter:
-                continue
-            for x in self.init["format_button"]:
-                composite = self.py3.safe_format(getattr(self, x), device)
-                device[x] = self.py3.composite_update(
-                    composite, {"index": "{}/{}".format(device["id"], x.split("_")[-1])}
+    def _format_device(self, devices):
+        device_info = []
+        for device in devices:
+            for btn in self.init["format_button"]:
+                composite = self.py3.safe_format(getattr(self, btn), device)
+                device[btn] = self.py3.composite_update(
+                    composite,
+                    {"index": "{}/{}".format(device["id"], btn.split("_")[-1])},
                 )
 
-            device_composite = self.py3.safe_format(self.format_device, device)
-            if index == self.device_index:
-                format_device_list = device_composite
-
-            new_device.append(device_composite)
+            device_info.append(self.py3.safe_format(self.format_device, device))
 
         format_device_separator = self.py3.safe_format(self.format_device_separator)
-        format_device = self.py3.composite_join(format_device_separator, new_device)
+        format_device = self.py3.composite_join(format_device_separator, device_info)
 
-        return format_device, format_device_list
-
-    def _notify_user(self, device):
-        format_notification_message = self.py3.safe_format(
-            self.format_notification_message, device
-        )
-        format_notification_title = self.py3.safe_format(
-            self.format_notification_title, device
-        )
-        self.py3.notify_user(
-            msg=format_notification_message,
-            title=format_notification_title,
-            icon="/usr/share/icons/hicolor/scalable/apps/usbguard-icon.svg",
-        )
+        return format_device
 
     def usbguard(self):
-        filter_name = self.filters[self.filter_index]
-        device_data = self._get_devices(filter_name)
-        format_device, format_device_list = self._manipulate_devices(
-            device_data, filter_name
-        )
-
-        if self.device_index > self.device_length:
-            self.device_index = self.device_length
-
-        format_button_device = self.py3.safe_format(
-            self.format_button_device,
-            {"device": self.device_index, "devices": self.device_length},
-        )
-        self.py3.composite_update(format_button_device, {"index": "button_device"})
-
-        format_button_filter = self.py3.safe_format(
-            self.format_button_filter, {"filter": filter_name}
-        )
-        self.py3.composite_update(format_button_filter, {"index": "button_filter"})
-        format_button_permanent = self.py3.safe_format(self.format_button_permanent)
-        self.py3.composite_update(
-            format_button_permanent, {"index": "button_permanent"}
-        )
+        self.devices = self._get_devices()
 
         usbguard_data = {
-            "device": len(device_data),
-            "format_button_filter": format_button_filter,
-            "format_button_permanent": format_button_permanent,
-            "format_device": format_device,
-            "format_button_device": format_button_device,
-            "format_device_list": format_device_list,
+            "device": len(self.devices),
+            "format_device": self._format_device(self.devices),
         }
 
-        response = {
-            "cached_until": self.py3.time_in(10),
+        return {
+            "cached_until": self.py3.CACHE_FOREVER,
             "full_text": self.py3.safe_format(self.format, usbguard_data),
+            "urgent": self.allow_urgent,
         }
-
-        if self.allow_urgent:
-            response["urgent"] = True
-
-        self.device_data = device_data
-        return response
 
     def on_click(self, event):
-        index = event["index"]
-        button = event["button"]
-        if isinstance(index, int):
+        if not isinstance(event["index"], str):
             return
-        elif index == "button_device":
-            if button == self.button_next:
-                self.device_index += 1
-                self.device_index %= self.device_length + 1
-            elif button == self.button_previous:
-                self.device_index -= 1
-                self.device_index %= self.device_length + 1
-        elif index == "button_filter":
-            if button == self.button_next:
-                self.filter_index += 1
-                self.filter_index %= self.filter_length
-            elif button == self.button_previous:
-                self.filter_index -= 1
-                self.filter_index %= self.filter_length
-        elif index == "button_permanent":
-            self.permanent = not self.permanent
-        else:
-            device_id, policy_name = index.split("/")
-            device_id = int(device_id)
 
-            if self.init["notifications"]:
-                for device in self.device_data:
-                    if device["id"] == device_id:
-                        device["policy"] = policy_name
-                        self._notify_user(device)
-                        break
-
-            policy = self.init["target"][policy_name]
-            self.proxy.applyDevicePolicy("(uub)", device_id, policy, self.permanent)
-            if self.init["permanent"]:
-                self.permanent = False
-            self.device_index = 0
+        device_id, policy_name = event["index"].split("/")
+        device_id = int(device_id)
+        policy = self.init["target"][policy_name]
+        self.proxy.applyDevicePolicy("(uub)", device_id, policy, False)
 
 
 if __name__ == "__main__":

--- a/py3status/modules/usbguard.py
+++ b/py3status/modules/usbguard.py
@@ -3,6 +3,7 @@
 Allow or Reject newly plugged USB devices using USBGuard.
 
 Configuration parameters:
+    allow_urgent: display urgency (default True)
     format: display format for this module
         (default '[{format_device}]')
     format_button_allow: display format for allow button filter
@@ -10,7 +11,7 @@ Configuration parameters:
     format_button_reject: display format for reject button filter
         (default '\[Reject\]')
     format_device: display format for USB devices
-        (default '{format_button_reject} [{name}|{usb_id}] {format_button_allow}'
+        (default '{format_button_reject} [{name}|{usb_id}] {format_button_allow}')
     format_device_separator: show separator if more than one (default ' ')
 
 Format placeholders:
@@ -56,6 +57,7 @@ class Py3status:
     """
     """
 
+    # available configuration parameters
     allow_urgent = True
     format = "[{format_device}]"
     format_button_allow = "\[Allow\]"

--- a/py3status/modules/usbguard.py
+++ b/py3status/modules/usbguard.py
@@ -34,12 +34,12 @@ Requires:
     python-gobject: Python Bindings for GLib/GObject/GIO/GTK+
     usbguard: USB device authorization policy framework
 
-@author @cyrinux, @lasers, @maximbaz
+@author @cyrinux, @maximbaz
 @license BSD
 
 SAMPLE OUTPUT
 [
-    {'full_text': '[Reject] ', 'urgent': True, 'cached_until': -1},
+    {'full_text': '[Reject] ', 'urgent': True},
     {'full_text': 'USB Flash Drive ', 'urgent': True},
     {'full_text': '[Allow]', 'urgent': True}
 ]

--- a/py3status/modules/usbguard.py
+++ b/py3status/modules/usbguard.py
@@ -162,7 +162,7 @@ class Py3status:
         }
 
     def on_click(self, event):
-        if not isinstance(event["index"], str):
+        if isinstance(event["index"], int):
             return
 
         device_id, policy_name = event["index"].split("/")


### PR DESCRIPTION
Addressing `usbguard` module as per discussions in #1566 and #1656, this reduces the functionality to what @cyrinux and I actually use in this module. Let's extend this module on specific user requests.

This also fixes #1656, module is finally refreshing instantly and yet we are able to return to `"cached_until": self.py3.CACHE_FOREVER`.

The diff is a bit simpler if you disable whitespace changes (`?w=1`).