### PR TITLE
argparsers: add slash

### DIFF
--- a/py3status/argparsers.py
+++ b/py3status/argparsers.py
@@ -258,7 +258,7 @@ def parse_cli_args():
     for path in options.include_paths:
         path = os.path.abspath(path)
         if os.path.isdir(path) and os.listdir(path):
-            include_paths.append(path)
+            include_paths.append(path + "/")
     options.include_paths = include_paths
 
     # handle py3status list and docstring options


### PR DESCRIPTION
This adds a slash to all existing paths. Fixes the regression I saw from merging https://github.com/ultrabug/py3status/pull/1695. It does not feel ideal to enforce trailing slash, but it'll have to do. 