### PR TITLE
Enhanced diskdata

### DIFF
--- a/py3status/modules/diskdata.py
+++ b/py3status/modules/diskdata.py
@@ -152,57 +152,6 @@ class Py3status:
 
         self.thresholds_init = self.py3.get_color_names_list(self.format)
 
-    def diskdata(self):
-        self.values = {
-            "disk": ",".join(d.name for d in self._disks) if not self._all else "all"
-        }
-        threshold_data = {}
-
-        if self.py3.format_contains(self.format, ["read", "write", "total"]):
-            diskstats = self._get_diskstats()
-            current_time = time()
-
-            timedelta = current_time - self.last_time
-            read = (diskstats[0] - self.last_diskstats[0]) / timedelta
-            write = (diskstats[1] - self.last_diskstats[1]) / timedelta
-            total = read + write
-
-            self.last_diskstats = diskstats
-            self.last_time = current_time
-
-            self.values["read"] = self._format_rate(read)
-            self.values["total"] = self._format_rate(total)
-            self.values["write"] = self._format_rate(write)
-            threshold_data.update({"read": read, "write": write, "total": total})
-
-        if self.py3.format_contains(self.format, ["free", "used*", "total_space"]):
-            free, used, used_percent, total_space = self._get_free_space()
-
-            self.values["free"] = self.py3.safe_format(
-                self.format_space, {"value": free}
-            )
-            self.values["used"] = self.py3.safe_format(
-                self.format_space, {"value": used}
-            )
-            self.values["used_percent"] = self.py3.safe_format(
-                self.format_space, {"value": used_percent}
-            )
-            self.values["total_space"] = self.py3.safe_format(
-                self.format_space, {"value": total_space}
-            )
-            threshold_data.update(
-                {"free": free, "used": used, "used_percent": used_percent}
-            )
-
-        for x in self.thresholds_init:
-            if x in threshold_data:
-                self.py3.threshold_get_color(threshold_data[x], x)
-
-        return {
-            "cached_until": self.py3.time_in(self.cache_timeout),
-            "full_text": self.py3.safe_format(self.format, self.values),
-        }
-
     def _get_free_space(self):
 
         total = 0
@@ -286,6 +235,57 @@ class Py3status:
                 line = stat.split()
                 if int(line[1]) == 0:
                     self._add_monitored_disk("/dev/" + line[2])
+
+    def diskdata(self):
+        self.values = {
+            "disk": ",".join(d.name for d in self._disks) if not self._all else "all"
+        }
+        threshold_data = {}
+
+        if self.py3.format_contains(self.format, ["read", "write", "total"]):
+            diskstats = self._get_diskstats()
+            current_time = time()
+
+            timedelta = current_time - self.last_time
+            read = (diskstats[0] - self.last_diskstats[0]) / timedelta
+            write = (diskstats[1] - self.last_diskstats[1]) / timedelta
+            total = read + write
+
+            self.last_diskstats = diskstats
+            self.last_time = current_time
+
+            self.values["read"] = self._format_rate(read)
+            self.values["total"] = self._format_rate(total)
+            self.values["write"] = self._format_rate(write)
+            threshold_data.update({"read": read, "write": write, "total": total})
+
+        if self.py3.format_contains(self.format, ["free", "used*", "total_space"]):
+            free, used, used_percent, total_space = self._get_free_space()
+
+            self.values["free"] = self.py3.safe_format(
+                self.format_space, {"value": free}
+            )
+            self.values["used"] = self.py3.safe_format(
+                self.format_space, {"value": used}
+            )
+            self.values["used_percent"] = self.py3.safe_format(
+                self.format_space, {"value": used_percent}
+            )
+            self.values["total_space"] = self.py3.safe_format(
+                self.format_space, {"value": total_space}
+            )
+            threshold_data.update(
+                {"free": free, "used": used, "used_percent": used_percent}
+            )
+
+        for x in self.thresholds_init:
+            if x in threshold_data:
+                self.py3.threshold_get_color(threshold_data[x], x)
+
+        return {
+            "cached_until": self.py3.time_in(self.cache_timeout),
+            "full_text": self.py3.safe_format(self.format, self.values),
+        }
 
 
 if __name__ == "__main__":

--- a/py3status/modules/diskdata.py
+++ b/py3status/modules/diskdata.py
@@ -4,8 +4,8 @@ Display disk information.
 
 Configuration parameters:
     cache_timeout: refresh interval for this module. (default 10)
-    disk: show stats for space-separated list of mountpoints,
-        disks or partitions, i.e. `sda1 /home /dev/sdd`.
+    disk: mountpoints, disks or partitions list to show stats
+        for, i.e. `["sda1", "/home", "/dev/sdd"]`.
         None for all disks, filtered by `type` parameter.
         (default None)
     format: display format for this module.
@@ -106,6 +106,11 @@ class Py3status:
             value - value (float)
             unit - unit (string)
         """
+        # deprecation
+        if self.disk is None:
+            self.disk = []
+        elif not isinstance(self.disk, list):
+            self.disk = [self.disk]
         types_info = {
             "disks": {"major": [3, 8, 22]},
             "raid": {"major": [9]},

--- a/py3status/modules/diskdata.py
+++ b/py3status/modules/diskdata.py
@@ -153,7 +153,7 @@ class Py3status:
         with open("/proc/diskstats") as ds:
             for stat in ds:
                 line = stat.split()
-                if int(line[0]) in allowed_types and int(line[1]) == 0:
+                if int(line[0]) in allowed_types:
                     self._add_monitored_disk("/dev/" + line[2])
 
     def post_config_hook(self):
@@ -300,6 +300,7 @@ if __name__ == "__main__":
     """
     Run module in test mode.
     """
+    config = {"disks": ["/nope"]}
     from py3status.module_test import module_test
 
-    module_test(Py3status)
+    module_test(Py3status, config=config)

--- a/py3status/modules/diskdata.py
+++ b/py3status/modules/diskdata.py
@@ -122,7 +122,6 @@ class Py3status:
         self._disks = set()
 
         if not self.disks:
-            self._all = True
             self._set_all_disks()
         else:
             with open("/proc/mounts") as mounts:
@@ -142,7 +141,6 @@ class Py3status:
                 else:
                     self._add_monitored_disk("/dev/" + item)
             if not self._disks:
-                self._all = True
                 self._set_all_disks()
             else:
                 self._all = False
@@ -230,6 +228,7 @@ class Py3status:
             self._disks.add(Disk(device="/dev/" + basename, name=basename))
 
     def _set_all_disks(self):
+        self._all = True
         with open("/proc/diskstats") as ds:
             for stat in ds:
                 line = stat.split()

--- a/py3status/modules/diskdata.py
+++ b/py3status/modules/diskdata.py
@@ -123,7 +123,7 @@ class Py3status:
 
         if not self.disks:
             self._all = True
-            self._get_all_disks()
+            self._set_all_disks()
         else:
             with open("/proc/mounts") as mounts:
                 mounts = [Mount(*x.split()[:2]) for x in mounts.readlines()]
@@ -143,7 +143,7 @@ class Py3status:
                     self._add_monitored_disk("/dev/" + item)
             if not self._disks:
                 self._all = True
-                self._get_all_disks()
+                self._set_all_disks()
             else:
                 self._all = False
 
@@ -229,7 +229,7 @@ class Py3status:
         if os.path.exists("/dev/" + basename):
             self._disks.add(Disk(device="/dev/" + basename, name=basename))
 
-    def _get_all_disks(self):
+    def _set_all_disks(self):
         with open("/proc/diskstats") as ds:
             for stat in ds:
                 line = stat.split()

--- a/py3status/modules/diskdata.py
+++ b/py3status/modules/diskdata.py
@@ -148,7 +148,7 @@ class Py3status:
                     if int(line[0]) in allowed_types and int(line[1]) == 0:
                         self._add_monitored_disk("/dev/" + line[2])
         else:
-            for disk in self.disk.split():
+            for disk in self.disk:
                 # mountpoint or fully qualified device path
                 if disk.startswith("/"):
                     # mountpoint

--- a/py3status/modules/diskdata.py
+++ b/py3status/modules/diskdata.py
@@ -118,7 +118,7 @@ class Py3status:
                         sector_size=int(ss.read().strip()),
                     )
                 )
-        except FileNotFoundError:
+        except:
             pass
 
     def _get_all_disks(self):

--- a/py3status/modules/diskdata.py
+++ b/py3status/modules/diskdata.py
@@ -249,9 +249,9 @@ class Py3status:
         devs = []
 
         disk_names = [d.name for d in self._disks]
-        df = self.py3.command_output("df")
+        _df = self.py3.command_output("df")
         # loop on df output minus header line
-        for line in df.splitlines()[1:]:
+        for line in _df.splitlines()[1:]:
             df = Df(*line.split())
             if self._resolve_disk_name(df.device) in disk_names:
                 if df.device in devs:

--- a/py3status/modules/diskdata.py
+++ b/py3status/modules/diskdata.py
@@ -109,14 +109,17 @@ class Py3status:
         block_device = os.path.realpath("/sys/class/block/" + basename)
         if not block_device.endswith("block/" + basename):
             block_device = os.path.dirname(block_device)
-        with open("{}/queue/hw_sector_size".format(block_device)) as ss:
-            self._disks.add(
-                Disk(
-                    device="/dev/" + basename,
-                    name=basename,
-                    sector_size=int(ss.read().strip()),
+        try:
+            with open("{}/queue/hw_sector_size".format(block_device)) as ss:
+                self._disks.add(
+                    Disk(
+                        device="/dev/" + basename,
+                        name=basename,
+                        sector_size=int(ss.read().strip()),
+                    )
                 )
-            )
+        except FileNotFoundError:
+            pass
 
     def _get_all_disks(self):
 
@@ -300,7 +303,7 @@ if __name__ == "__main__":
     """
     Run module in test mode.
     """
-    config = {"disks": ["/nope"]}
+    config = {"disks": ["sdd"]}
     from py3status.module_test import module_test
 
     module_test(Py3status, config=config)


### PR DESCRIPTION
Hello, today I'd wanted to implement diskdata in my bar but it happened it did not support device mappers, especially when the device i mount from is a link to the real device (ie. /dev/mapper/home -> /dev/dm-1).
Also, I'd like to be able to work with mountpoints for the sake of dotfiles portability across my systems.
So i worked a bit on module so:

 - it is possible to configure a space separate list of devices, partitions or mountpoints (eg. 'sda /home'), symlink gets resolved to the real device
 - it is possible to specify which devices are accounted in "all drive mode", so I can exclude ramdisks from stats
 - disk sector size is now taken from sysfs devices' data

I'd be glad if you accept those changes so I could begin use this module with my py3status :)))

Thank you, regards