### PR TITLE
screenshot: catch up with the standards

### DIFF
--- a/py3status/modules/screenshot.py
+++ b/py3status/modules/screenshot.py
@@ -2,17 +2,9 @@
 """
 Take screenshots and upload them to a given server.
 
-Display a 'SHOT' button in your i3bar allowing you to take a screenshot and
-directly send (if wanted) the file to your online server.
-When the screenshot has been taken, 'SHOT' is replaced by the file_name.
-
-By default, this modules uses the 'gnome-screenshot' program to take the screenshot,
-but this can be configured with the `screenshot_command` configuration parameter.
-
 Configuration parameters:
-    cache_timeout: how often to update in seconds (default 5)
     file_length: generated file_name length (default 4)
-    save_path: Directory where to store your screenshots. (default '~/Pictures/')
+    save_path: Directory where to store your screenshots (default '~/Pictures')
     screenshot_command: the command used to generate the screenshot
         (default 'gnome-screenshot -f')
     upload_path: the remote path where to push the screenshot (default None)
@@ -39,6 +31,9 @@ screenshot {
 
 SAMPLE OUTPUT
 {'color': '#00FF00', 'full_text': 'SHOT'}
+
+basename
+{'color': '#00FF00', 'full_text': 'qs60.jpg'}
 """
 
 import os
@@ -51,46 +46,47 @@ class Py3status:
     """
 
     # available configuration parameters
-    cache_timeout = 5
     file_length = 4
-    save_path = "~/Pictures/"
+    save_path = "~/Pictures"
     screenshot_command = "gnome-screenshot -f"
     upload_path = None
     upload_server = None
     upload_user = None
 
     class Meta:
-        deprecated = {"remove": [{"param": "push", "msg": "obsolete"}]}
+        deprecated = {
+            "remove": [
+                {"param": "push", "msg": "obsolete"},
+                {"param": "cache_timeout", "msg": "obsolete"},
+            ]
+        }
 
     def post_config_hook(self):
         self.save_path = os.path.expanduser(self.save_path)
-        self.full_text = ""
+        self.full_text = "SHOT"
+        self.chars = string.ascii_lowercase + string.digits
 
-    def _filename_generator(self, size=6, chars=string.ascii_lowercase + string.digits):
-        return "".join(random.choice(chars) for _ in range(size))
+    def _generator(self, size=6):
+        return "".join(random.choice(self.chars) for _ in range(size))
 
     def screenshot(self):
-        if self.full_text == "":
-            self.full_text = "SHOT"
-
-        response = {
-            "cached_until": self.py3.time_in(self.cache_timeout),
+        return {
+            "cached_until": self.py3.time_in(self.py3.CACHE_FOREVER),
             "color": self.py3.COLOR_GOOD,
             "full_text": self.full_text,
         }
-        return response
 
     def on_click(self, event):
-        file_name = self._filename_generator(self.file_length) + ".jpg"
-        file_path = os.path.join(self.save_path, file_name)
-        self.full_text = file_name
+        basename = self._generator(self.file_length) + ".jpg"
+        pathname = os.path.join(self.save_path, basename)
+        self.shot_data["basename"] = basename
 
-        self.py3.command_run(" ".join([self.screenshot_command, file_path]))
+        self.py3.command_run(" ".join([self.screenshot_command, pathname]))
 
         if self.upload_server and self.upload_user and self.upload_path:
             self.py3.command_run(
                 "scp {} {}@{}:{}".format(
-                    file_path, self.upload_user, self.upload_server, self.upload_path
+                    pathname, self.upload_user, self.upload_server, self.upload_path
                 )
             )
 

--- a/py3status/modules/screenshot.py
+++ b/py3status/modules/screenshot.py
@@ -4,6 +4,8 @@ Take screenshots and upload them to a given server.
 
 Configuration parameters:
     file_length: generated file_name length (default 4)
+    format: display format for this module
+        (default '\?color=good [{basename}|\?show SHOT]')
     save_path: Directory where to store your screenshots (default '~/Pictures')
     screenshot_command: the command used to generate the screenshot
         (default 'gnome-screenshot -f')
@@ -11,8 +13,8 @@ Configuration parameters:
     upload_server: your server address (default None)
     upload_user: your ssh user (default None)
 
-Color options:
-    color_good: Displayed color
+Format placeholders:
+    {basename} generated basename, eg qs60.jpg
 
 Examples:
 ```
@@ -47,6 +49,7 @@ class Py3status:
 
     # available configuration parameters
     file_length = 4
+    format = "\?color=good [{basename}|\?show SHOT]"
     save_path = "~/Pictures"
     screenshot_command = "gnome-screenshot -f"
     upload_path = None
@@ -62,8 +65,8 @@ class Py3status:
         }
 
     def post_config_hook(self):
+        self.shot_data = {}
         self.save_path = os.path.expanduser(self.save_path)
-        self.full_text = "SHOT"
         self.chars = string.ascii_lowercase + string.digits
 
     def _generator(self, size=6):
@@ -72,8 +75,7 @@ class Py3status:
     def screenshot(self):
         return {
             "cached_until": self.py3.time_in(self.py3.CACHE_FOREVER),
-            "color": self.py3.COLOR_GOOD,
-            "full_text": self.full_text,
+            "full_text": self.py3.safe_format(self.format, self.shot_data),
         }
 
     def on_click(self, event):

--- a/py3status/modules/screenshot.py
+++ b/py3status/modules/screenshot.py
@@ -40,10 +40,10 @@ screenshot {
 SAMPLE OUTPUT
 {'color': '#00FF00', 'full_text': 'SHOT'}
 """
+
 import os
 import random
 import string
-import subprocess
 
 
 class Py3status:
@@ -85,14 +85,14 @@ class Py3status:
         file_path = os.path.join(self.save_path, file_name)
         self.full_text = file_name
 
-        command = "{} {}".format(self.screenshot_command, file_path)
-        subprocess.Popen(command.split())
+        self.py3.command_run(" ".join([self.screenshot_command, file_path]))
 
         if self.upload_server and self.upload_user and self.upload_path:
-            command = "scp {} {}@{}:{}".format(
-                file_path, self.upload_user, self.upload_server, self.upload_path
+            self.py3.command_run(
+                "scp {} {}@{}:{}".format(
+                    file_path, self.upload_user, self.upload_server, self.upload_path
+                )
             )
-            subprocess.Popen(command.split())
 
 
 if __name__ == "__main__":

--- a/py3status/modules/screenshot.py
+++ b/py3status/modules/screenshot.py
@@ -53,8 +53,21 @@ class Py3status:
         self.save_path = os.path.expanduser(self.save_path)
         self.full_text = ""
 
-    def on_click(self, event):
+    def _filename_generator(self, size=6, chars=string.ascii_lowercase + string.digits):
+        return "".join(random.choice(chars) for _ in range(size))
 
+    def screenshot(self):
+        if self.full_text == "":
+            self.full_text = "SHOT"
+
+        response = {
+            "cached_until": self.py3.time_in(self.cache_timeout),
+            "color": self.py3.COLOR_GOOD,
+            "full_text": self.full_text,
+        }
+        return response
+
+    def on_click(self, event):
         file_name = self._filename_generator(self.file_length)
 
         command = "%s %s/%s%s" % (
@@ -78,20 +91,6 @@ class Py3status:
                 self.upload_path,
             )
             subprocess.Popen(command.split())
-
-    def _filename_generator(self, size=6, chars=string.ascii_lowercase + string.digits):
-        return "".join(random.choice(chars) for _ in range(size))
-
-    def screenshot(self):
-        if self.full_text == "":
-            self.full_text = "SHOT"
-
-        response = {
-            "cached_until": self.py3.time_in(self.cache_timeout),
-            "color": self.py3.COLOR_GOOD,
-            "full_text": self.full_text,
-        }
-        return response
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Dunno if we have users using this module. Anyway...
* Deprecate `push` in favor of other existing configs.
* Use `py3.command_run` helpers.
* Deprecate `cache_timeout` in favor of `CACHE_FOREVER`.
* Add `format`. Expose `{basename}` placeholder.
* Minor code cleanup. Everything should still be same. Thx.