### PR TITLE
add i3/sway directive

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -89,13 +89,8 @@ You can see the help of py3status by issuing `py3status -h`:
 
     usage: py3status [-h] [-b] [-c FILE] [-d] [-g] [-i PATH] [-l FILE] [-s]
                      [-t INT] [-m] [-u PATH] [-v] [--wm WINDOW_MANAGER]
-                     {list} ...
 
     The agile, python-powered, i3status wrapper
-
-    positional arguments:
-       {list} ...
-         list               list modules
 
     optional arguments:
       -h, --help            show this help message and exit

--- a/README.rst
+++ b/README.rst
@@ -22,7 +22,7 @@ Using py3status, you can take control of your i3bar easily by:
 
 About
 =====
-You will love `py3status` if you're using `i3wm <http://i3wm.org>`_ and are frustrated by the i3status `limitations <https://faq.i3wm.org/question/459/external-scriptsprograms-in-i3status-without-loosing-colors/>`_ on your i3bar such as:
+You will love `py3status` if you're using `i3wm <https://i3wm.org>`_ (or `sway <https://swaywm.org>`_) and are frustrated by the i3status `limitations <https://faq.i3wm.org/question/459/external-scriptsprograms-in-i3status-without-loosing-colors/>`_ on your i3bar such as:
 
 * you cannot hack into it easily
 * you want more than the built-in modules and their limited configuration
@@ -87,24 +87,34 @@ Options
 You can see the help of py3status by issuing `py3status -h`:
 ::
 
-    -h, --help            show this help message and exit
-    -b, --dbus-notify     use notify-send to send user notifications rather than
-                          i3-nagbar, requires a notification daemon eg dunst
-    -c I3STATUS_CONF, --config I3STATUS_CONF
-                          path to i3status config file
-    -d, --debug           be verbose in syslog
-    -i INCLUDE_PATHS, --include INCLUDE_PATHS
-                          include user-written modules from those directories
-                          (default ~/.i3/py3status)
-    -l LOG_FILE, --log-file LOG_FILE
-                          path to py3status log file
-    -n INTERVAL, --interval INTERVAL
-                          update interval in seconds (default 1 sec)
-    -s, --standalone      standalone mode, do not use i3status
-    -t CACHE_TIMEOUT, --timeout CACHE_TIMEOUT
-                          default injection cache timeout in seconds (default 60
-                          sec)
-    -v, --version         show py3status version and exit
+    usage: py3status [-h] [-b] [-c FILE] [-d] [-g] [-i PATH] [-l FILE] [-s]
+                     [-t INT] [-m] [-u PATH] [-v] [--wm WINDOW_MANAGER]
+                     {list} ...
+
+    The agile, python-powered, i3status wrapper
+
+    positional arguments:
+       {list} ...
+         list               list modules
+
+    optional arguments:
+      -h, --help            show this help message and exit
+      -b, --dbus-notify     send notifications via dbus instead of i3-nagbar
+                            (default: False)
+      -c, --config FILE     load config (default: /home/alexys/.i3/i3status.conf)
+      -d, --debug           enable debug logging in syslog and --log-file
+                            (default: False)
+      -g, --gevent          enable gevent monkey patching (default: False)
+      -i, --include PATH    append additional user-defined module paths (default:
+                            None)
+      -l, --log-file FILE   enable logging to FILE (default: None)
+      -s, --standalone      run py3status without i3status (default: False)
+      -t, --timeout INT     default module cache timeout in seconds (default: 60)
+      -m, --disable-click-events
+                            disable all click events (default: False)
+      -u, --i3status PATH   specify i3status path (default: /usr/bin/i3status)
+      -v, --version         show py3status version and exit (default: False)
+      --wm WINDOW_MANAGER   specify window manager i3 or sway (default: i3)
 
 Control
 =======

--- a/doc/intro.rst
+++ b/doc/intro.rst
@@ -16,7 +16,7 @@ About
 -----
 
 You will love py3status if you're using `i3wm
-<http://i3wm.org>`_ and are frustrated by the i3status
+<https://i3wm.org>`_ (or `sway <https://swaywm.org>`_) and are frustrated by the i3status
 limitations on your i3bar such as:
 
 * you cannot hack into it easily
@@ -177,27 +177,34 @@ You can see the help of py3status by issuing ``py3status --help``:
 
 .. code-block:: shell
 
-    -h, --help            show this help message and exit
-    -b, --dbus-notify     use notify-send to send user notifications rather than
-                          i3-nagbar, requires a notification daemon eg dunst
-    -c I3STATUS_CONF, --config I3STATUS_CONF
-                          path to i3status config file
-    -d, --debug           be verbose in syslog
-    -g, --gevent          enable gevent monkey patching (default False)
-    -i INCLUDE_PATHS, --include INCLUDE_PATHS
-                          include user-written modules from those directories
-                          (default ~/.i3/py3status)
-    -l LOG_FILE, --log-file LOG_FILE
-                          path to py3status log file
-    -n INTERVAL, --interval INTERVAL
-                          update interval in seconds (default 1 sec)
-    -s, --standalone      standalone mode, do not use i3status
-    -t CACHE_TIMEOUT, --timeout CACHE_TIMEOUT
-                          default injection cache timeout in seconds (default 60
-                          sec)
-    -m, --disable-click-events
-                          disable all click events
-    -v, --version         show py3status version and exit
+    usage: py3status [-h] [-b] [-c FILE] [-d] [-g] [-i PATH] [-l FILE] [-s]
+                     [-t INT] [-m] [-u PATH] [-v] [--wm WINDOW_MANAGER]
+                     {list} ...
+
+    The agile, python-powered, i3status wrapper
+
+    positional arguments:
+       {list} ...
+         list               list modules
+
+    optional arguments:
+      -h, --help            show this help message and exit
+      -b, --dbus-notify     send notifications via dbus instead of i3-nagbar
+                            (default: False)
+      -c, --config FILE     load config (default: /home/alexys/.i3/i3status.conf)
+      -d, --debug           enable debug logging in syslog and --log-file
+                            (default: False)
+      -g, --gevent          enable gevent monkey patching (default: False)
+      -i, --include PATH    append additional user-defined module paths (default:
+                            None)
+      -l, --log-file FILE   enable logging to FILE (default: None)
+      -s, --standalone      run py3status without i3status (default: False)
+      -t, --timeout INT     default module cache timeout in seconds (default: 60)
+      -m, --disable-click-events
+                            disable all click events (default: False)
+      -u, --i3status PATH   specify i3status path (default: /usr/bin/i3status)
+      -v, --version         show py3status version and exit (default: False)
+      --wm WINDOW_MANAGER   specify window manager i3 or sway (default: i3)
 
 Control
 ^^^^^^^

--- a/doc/intro.rst
+++ b/doc/intro.rst
@@ -179,13 +179,8 @@ You can see the help of py3status by issuing ``py3status --help``:
 
     usage: py3status [-h] [-b] [-c FILE] [-d] [-g] [-i PATH] [-l FILE] [-s]
                      [-t INT] [-m] [-u PATH] [-v] [--wm WINDOW_MANAGER]
-                     {list} ...
 
     The agile, python-powered, i3status wrapper
-
-    positional arguments:
-       {list} ...
-         list               list modules
 
     optional arguments:
       -h, --help            show this help message and exit

--- a/py3status/argparsers.py
+++ b/py3status/argparsers.py
@@ -254,11 +254,12 @@ def parse_cli_args():
     options.python_version = python_version()
     options.version = version
     if options.print_version:
-        msg = "py3status version {version} (python {python_version})"
+        msg = "py3status version {version} (python {python_version}) on {wm}"
         print(msg.format(**vars(options)))
         parser.exit()
 
     # get wm
+    options.wm_name = options.wm
     options.wm = {
         "i3": {"msg": "i3-msg", "nag": "i3-nagbar"},
         "sway": {"msg": "swaymsg", "nag": "swaynag"},

--- a/py3status/argparsers.py
+++ b/py3status/argparsers.py
@@ -60,6 +60,13 @@ def parse_cli_args():
     except subprocess.CalledProcessError:
         i3status_path = None
 
+    # get swaymsg or i3-msg
+    with open(os.devnull, "w") as devnull:
+        if subprocess.call(["pgrep", "-x", "sway"], stdout=devnull) == 0:
+            wm = "sway"
+        else:
+            wm = "i3"
+
     # i3status config file default detection
     # respect i3status' file detection order wrt issue #43
     i3status_config_file_candidates = [
@@ -190,6 +197,14 @@ def parse_cli_args():
         dest="print_version",
         help="show py3status version and exit",
     )
+    parser.add_argument(
+        "--wm",
+        action="store",  # add comment to preserve formatting
+        dest="wm",
+        default=wm,
+        choices=["i3", "sway"],
+        help=argparse.SUPPRESS,
+    )
     # deprecations
     parser.add_argument("-n", "--interval", help=argparse.SUPPRESS)
 
@@ -240,6 +255,12 @@ def parse_cli_args():
         msg = "py3status version {version} (python {python_version})"
         print(msg.format(**vars(options)))
         parser.exit()
+
+    # get wm
+    options.wm = {
+        "i3": {"msg": "i3-msg", "nag": "i3-nagbar"},
+        "sway": {"msg": "swaymsg", "nag": "swaynag"},
+    }[options.wm]
 
     # make it i3status if None
     if not options.i3status_path:

--- a/py3status/argparsers.py
+++ b/py3status/argparsers.py
@@ -60,12 +60,12 @@ def parse_cli_args():
     except subprocess.CalledProcessError:
         i3status_path = None
 
-    # get swaymsg or i3-msg
+    # get window manager
     with open(os.devnull, "w") as devnull:
-        if subprocess.call(["pgrep", "-x", "sway"], stdout=devnull) == 0:
-            wm = "sway"
-        else:
+        if subprocess.call(["pgrep", "i3"], stdout=devnull) == 0:
             wm = "i3"
+        else:
+            wm = "sway"
 
     # i3status config file default detection
     # respect i3status' file detection order wrt issue #43
@@ -201,10 +201,12 @@ def parse_cli_args():
         "--wm",
         action="store",  # add comment to preserve formatting
         dest="wm",
+        metavar="WINDOW_MANAGER",
         default=wm,
         choices=["i3", "sway"],
-        help=argparse.SUPPRESS,
+        help="specify window manager i3 or sway",
     )
+
     # deprecations
     parser.add_argument("-n", "--interval", help=argparse.SUPPRESS)
 

--- a/py3status/core.py
+++ b/py3status/core.py
@@ -528,6 +528,8 @@ class Py3statusWrapper:
         except:  # noqa e722
             pass
 
+        self.log("window manager: {}".format(self.config["wm_name"]))
+
         if self.config["debug"]:
             self.log("py3status started with config {}".format(self.config))
 

--- a/py3status/core.py
+++ b/py3status/core.py
@@ -675,10 +675,10 @@ class Py3statusWrapper:
             else:
                 py3_config = self.config.get("py3_config", {})
                 nagbar_font = py3_config.get("py3status", {}).get("nagbar_font")
+                wm_nag = self.config["wm"]["nag"]
+                cmd = [wm_nag, "-m", msg, "-t", level]
                 if nagbar_font:
-                    cmd = ["i3-nagbar", "-f", nagbar_font, "-m", msg, "-t", level]
-                else:
-                    cmd = ["i3-nagbar", "-m", msg, "-t", level]
+                    cmd += ["-f", nagbar_font]
             Popen(cmd, stdout=open("/dev/null", "w"), stderr=open("/dev/null", "w"))
         except Exception as err:
             self.log("notify_user error: %s" % err)

--- a/py3status/events.py
+++ b/py3status/events.py
@@ -151,19 +151,20 @@ class Events(Thread):
                 command = command.replace("$OUTPUT", shell_quote(full_text))
 
             # this is a i3 message
-            self.i3_msg(module_name, command)
+            self.wm_msg(module_name, command)
             # to make the bar more responsive to users we ask for a refresh
             # of the module or of i3status if the module is an i3status one
             self.py3_wrapper.refresh_modules(module_name)
 
-    def i3_msg(self, module_name, command):
+    def wm_msg(self, module_name, command):
         """
-        Execute the given i3 message and log its output.
+        Execute the message with i3-msg or swaymsg and log its output.
         """
-        i3_msg_pipe = Popen(["i3-msg", command], stdout=PIPE)
+        wm_msg = self.config["wm"]["msg"]
+        pipe = Popen([wm_msg, command], stdout=PIPE)
         self.py3_wrapper.log(
-            'i3-msg module="{}" command="{}" stdout={}'.format(
-                module_name, command, i3_msg_pipe.stdout.read()
+            '{} module="{}" command="{}" stdout={}'.format(
+                wm_msg, module_name, command, pipe.stdout.read()
             )
         )
 

--- a/py3status/module_test.py
+++ b/py3status/module_test.py
@@ -26,6 +26,7 @@ class MockPy3statusWrapper:
             "minimum_interval": 0.1,
             "testing": True,
             "log_file": True,
+            "wm": {"msg": "i3-msg", "nag": "i3-nagbar"},
         }
         self.events_thread = self.EventThread()
         self.udev_monitor = self.UdevMonitor()

--- a/py3status/modules/google_calendar.py
+++ b/py3status/modules/google_calendar.py
@@ -235,7 +235,7 @@ class Py3status:
             Have to restart i3 after getting credentials to prevent bad output.
             This only has to be done once on the first run of the module.
             """
-            self.py3.command_run("i3-msg restart")
+            self.py3.command_run("{} restart".format(self.py3.get_wm()["msg"]))
 
         return credentials
 

--- a/py3status/modules/google_calendar.py
+++ b/py3status/modules/google_calendar.py
@@ -235,7 +235,7 @@ class Py3status:
             Have to restart i3 after getting credentials to prevent bad output.
             This only has to be done once on the first run of the module.
             """
-            self.py3.command_run("{} restart".format(self.py3.get_wm()["msg"]))
+            self.py3.command_run("{} restart".format(self.py3.wm_msg))
 
         return credentials
 

--- a/py3status/modules/scratchpad_counter.py
+++ b/py3status/modules/scratchpad_counter.py
@@ -52,7 +52,7 @@ class Py3status:
         }
 
     def post_config_hook(self):
-        self.tree_command = "{} -t get_tree".format(self.py3.get_wm()["msg"])
+        self.tree_command = "{} -t get_tree".format(self.py3.wm_msg)
 
     def scratchpad_counter(self):
         tree = loads(self.py3.command_output(self.tree_command))

--- a/py3status/modules/scratchpad_counter.py
+++ b/py3status/modules/scratchpad_counter.py
@@ -51,8 +51,11 @@ class Py3status:
             ]
         }
 
+    def post_config_hook(self):
+        self.tree_command = "{} -t get_tree".format(self.py3.get_wm()["msg"])
+
     def scratchpad_counter(self):
-        tree = loads(self.py3.command_output("i3-msg -t get_tree"))
+        tree = loads(self.py3.command_output(self.tree_command))
         count = len(find_scratch(tree).get("floating_nodes", []))
 
         response = {"cached_until": self.py3.time_in(self.cache_timeout)}

--- a/py3status/modules/window_title.py
+++ b/py3status/modules/window_title.py
@@ -48,7 +48,7 @@ class Py3status:
     max_width = 120
 
     def post_config_hook(self):
-        self.tree_command = "{} -t get_tree".format(self.py3.get_wm()["msg"])
+        self.tree_command = "{} -t get_tree".format(self.py3.wm_msg)
         # empty defaults to replace window properties
         self.empty_defaults = {
             x: "" for x in self.py3.get_placeholders_list(self.format)

--- a/py3status/modules/window_title.py
+++ b/py3status/modules/window_title.py
@@ -48,6 +48,7 @@ class Py3status:
     max_width = 120
 
     def post_config_hook(self):
+        self.tree_command = "{} -t get_tree".format(self.py3.get_wm()["msg"])
         # empty defaults to replace window properties
         self.empty_defaults = {
             x: "" for x in self.py3.get_placeholders_list(self.format)
@@ -66,7 +67,7 @@ class Py3status:
         return {}
 
     def window_title(self):
-        tree = loads(self.py3.command_output("i3-msg -t get_tree"))
+        tree = loads(self.py3.command_output(self.tree_command))
         window_properties = self._find_focused(tree).get(
             "window_properties", self.empty_defaults
         )

--- a/py3status/modules/xrandr.py
+++ b/py3status/modules/xrandr.py
@@ -189,7 +189,6 @@ class Py3status:
         self.active_mode = "extend"
         self.displayed = None
         self.max_width = 0
-        self.wm_msg = self.py3.get_wm()["msg"]
 
     def _get_layout(self):
         """
@@ -394,10 +393,12 @@ class Py3status:
                     if not workspace:
                         continue
                     # switch to workspace
-                    cmd = '{} workspace "{}"'.format(self.wm_msg, workspace)
+                    cmd = '{} workspace "{}"'.format(self.py3.wm_msg, workspace)
                     self.py3.command_run(cmd)
                     # move it to output
-                    cmd = '{} move workspace to output "{}"'.format(self.wm_msg, output)
+                    cmd = '{} move workspace to output "{}"'.format(
+                        self.py3.wm_msg, output
+                    )
                     self.py3.command_run(cmd)
                     # log this
                     self.py3.log(

--- a/py3status/modules/xrandr.py
+++ b/py3status/modules/xrandr.py
@@ -189,6 +189,7 @@ class Py3status:
         self.active_mode = "extend"
         self.displayed = None
         self.max_width = 0
+        self.wm_msg = self.py3.get_wm()["msg"]
 
     def _get_layout(self):
         """
@@ -393,10 +394,10 @@ class Py3status:
                     if not workspace:
                         continue
                     # switch to workspace
-                    cmd = 'i3-msg workspace "{}"'.format(workspace)
+                    cmd = '{} workspace "{}"'.format(self.wm_msg, workspace)
                     self.py3.command_run(cmd)
                     # move it to output
-                    cmd = 'i3-msg move workspace to output "{}"'.format(output)
+                    cmd = '{} move workspace to output "{}"'.format(self.wm_msg, output)
                     self.py3.command_run(cmd)
                     # log this
                     self.py3.log(

--- a/py3status/py3.py
+++ b/py3status/py3.py
@@ -495,6 +495,13 @@ class Py3:
             if module_info:
                 module_info["module"].force_update()
 
+    def get_wm(self):
+        """
+        If i3, return {"msg": "i3-msg", "nag": "i3-nagbar"}.
+        If sway, return {"msg": "swaymsg", "nag": "swaynag"}.
+        """
+        return self._py3_wrapper.config["wm"]
+
     def get_output(self, module_name):
         """
         Return the output of the named module.  This will be a list.

--- a/py3status/py3.py
+++ b/py3status/py3.py
@@ -495,12 +495,13 @@ class Py3:
             if module_info:
                 module_info["module"].force_update()
 
-    def get_wm(self):
+    @property
+    def wm_msg(self):
         """
-        If i3, return {"msg": "i3-msg", "nag": "i3-nagbar"}.
-        If sway, return {"msg": "swaymsg", "nag": "swaynag"}.
+        On i3, will return "i3-msg"
+        On sway, will return "swaymsg"
         """
-        return self._py3_wrapper.config["wm"]
+        return self._py3_wrapper.config["wm"]["msg"]
 
     def get_output(self, module_name):
         """


### PR DESCRIPTION
This should solve compatibility problems with sway #1717. Tested on i3. Untested on sway.

I hide the `--wm` argument too. `py3status --wm [i3|sway]`. This dictates no more than `msg` and `nag` and if necessary, this can be extended more to support other things like `lock`.
* Allowing users to specify `--msg`, `--nag`, `--lock` could be more flexible over `--wm` especially when it comes to `timeout`, `font`, or `lock`-related arguments.

* Speaking of `lock`-related arguments, hardcoding `i3lock` wouldn't bode well.
* Allowing users to specify settings inside py3status/module configuration section for `msg`, `nag`, `lock`, `debug`, `log`, etc could certainty be more flexible and/or overkill, e.g. selective logging, different log path for modules, enable debug only on one or more modules, etc. Everything about this seems excessive.

Anyway, plz criticize my PR. Thx. EDIT: Thoughts on using `--wm`,  `--args` or general/module config? 