### PR TITLE
formatter, py3: use color invisible to hide blocks

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -348,7 +348,6 @@ is also possible to use css3 color names eg ``red``
         color_charging = '#FFFF00'
     }
 
-
 Configuring thresholds
 ----------------------
 
@@ -398,6 +397,26 @@ Some modules may allow more than one threshold to be defined.  If all the thresh
                 (30, "bad"),
             ],
         }
+    }
+
+.. note::
+    New in version 3.17
+
+You can specify ``hidden`` color to hide a block.
+
+.. code-block:: py3status
+    :caption: Example
+
+    # hide a block when ``1avg`` (i.e., 12.4) is less than 20 percent
+    format = "[\?color=1avg [\?color=darkgray&show 1min] {1min}]"
+    loadavg {
+       thresholds = [
+            (0, "hidden"),
+           (20, "good"),
+           (40, "degraded"),
+           (60, "#ffa500"),
+           (80, "bad"),
+       ]
     }
 
 Formatter

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -419,6 +419,15 @@ You can specify ``hidden`` color to hide a block.
        ]
     }
 
+    # hide cpu block when ``cpu_used_percent`` is less than 50 percent
+    # hide mem block when ``mem_used_percent`` is less than 50 percent
+    sysdata {
+        thresholds = [
+            (50, "hidden"),
+            (75, "bad"),
+        ]
+    }
+
 Formatter
 ---------
 

--- a/py3status/formatter.py
+++ b/py3status/formatter.py
@@ -623,6 +623,8 @@ class Block:
                 or getattr(module, threshold_color_name, None)
                 or getattr(module.py3, color_name.upper(), None)
             )
+            if color == "hidden":
+                return False, []
 
         text = u""
         out = []

--- a/py3status/modules/sysdata.py
+++ b/py3status/modules/sysdata.py
@@ -81,16 +81,6 @@ class Py3status:
     zone = None
 
     class Meta:
-        def deprecate_function(config):
-            # support old thresholds
-            return {
-                "thresholds": [
-                    (0, "good"),
-                    (config.get("med_threshold", 40), "degraded"),
-                    (config.get("high_threshold", 75), "bad"),
-                ]
-            }
-
         def update_deprecated_placeholder_format(config):
             padding = config.get("padding", 0)
             precision = config.get("precision", 2)
@@ -115,7 +105,6 @@ class Py3status:
             }
 
         deprecated = {
-            "function": [{"function": deprecate_function}],
             "rename_placeholder": [
                 {
                     "placeholder": "cpu_usage",
@@ -134,14 +123,6 @@ class Py3status:
                 },
             ],
             "remove": [
-                {
-                    "param": "high_threshold",
-                    "msg": "obsolete, set using thresholds parameter",
-                },
-                {
-                    "param": "med_threshold",
-                    "msg": "obsolete, set using thresholds parameter",
-                },
                 {"param": "padding", "msg": "obsolete, use the format_* parameters"},
                 {"param": "precision", "msg": "obsolete, use the format_* parameters"},
             ],

--- a/py3status/py3.py
+++ b/py3status/py3.py
@@ -153,9 +153,13 @@ class Py3:
             # that was explicitly set to None as a True value.  Ones that are
             # not set should be treated as None
             if name.startswith("color_"):
-                if hasattr(param, "none_setting"):
+                _name = name[6:].lower()
+                # use color "hidden" to hide blocks
+                if _name == "hidden":
+                    param = "hidden"
+                elif hasattr(param, "none_setting"):
                     # see if named color and use if it is
-                    param = COLOR_NAMES.get(name[6:].lower())
+                    param = COLOR_NAMES.get(_name)
                 elif param is None:
                     param = self._none_color
             # if a non-color parameter and was not set then set to default


### PR DESCRIPTION
>But if you want @ultrabug's opinion, can you please submit a PR and blackstar it?

If the color is `invisible`, it is used to invalidate the block. This addresses #934.

And a slew of imaginable conflicts.
* I imagine there are conflicts between old formatter and new formatter 4.0 rfc.
* I imagine there are conflicts between old formatter blocks versus new formatter thresholds colors.
* I imagine there are conflicts between collaborators. 