### PR TITLE
arch_updates: remove include_aur in favor of auto, refactoring

### DIFF
--- a/py3status/modules/arch_updates.py
+++ b/py3status/modules/arch_updates.py
@@ -3,9 +3,9 @@
 Display number of pending updates for Arch Linux.
 
 Configuration parameters:
-    cache_timeout: How often we refresh this module in seconds (default 600)
-    format: display format for this module, see Examples below (default None)
-    hide_if_zero: Don't show on bar if True (default False)
+    cache_timeout: refresh interval for this module (default 600)
+    format: display format for this module, otherwise auto (default None)
+    hide_if_zero: don't show on bar if True (default False)
     include_aur: Check for AUR updates with auracle or yay (default False)
 
 Format placeholders:
@@ -33,7 +33,7 @@ arch_updates {
 SAMPLE OUTPUT
 {'full_text': 'UPD: 5'}
 
-arch_updates_aur
+aur
 {'full_text': 'UPD: 15/4'}
 """
 
@@ -69,34 +69,34 @@ class Py3status:
             command = self.py3.check_commands(aurs)
             if command:
                 self._check_aur_updates = getattr(
-                    self, "_check_aur_updates_{}".format(command)
+                    self, "_get_aur_updates_{}".format(command)
                 )
             else:
                 self.include_aur = False
                 self.py3.notify_user(STRING_NOT_INSTALLED.format(", ".join(aurs)))
 
-    def _check_pacman_updates(self):
+    def _get_pacman_updates(self):
         try:
             updates = self.py3.command_output(["checkupdates"])
             return len(updates.splitlines())
         except self.py3.CommandError:
             return None
 
-    def _check_aur_updates_auracle(self):
+    def _get_aur_updates_auracle(self):
         try:
             updates = self.py3.command_output(["auracle", "sync"])
             return len(updates.splitlines())
         except self.py3.CommandError:
             return None
 
-    def _check_aur_updates_cower(self):
+    def _get_aur_updates_cower(self):
         try:
             self.py3.command_output(["cower", "-u"])
         except self.py3.CommandError as ce:
             return len(ce.output.splitlines())
         return None
 
-    def _check_aur_updates_yay(self):
+    def _get_aur_updates_yay(self):
         try:
             updates = self.py3.command_output(["yay", "-Qua"])
             return len(updates.splitlines())
@@ -107,10 +107,10 @@ class Py3status:
         pacman_updates = aur_updates = total = None
 
         if self.include_pacman:
-            pacman_updates = self._check_pacman_updates()
+            pacman_updates = self._get_pacman_updates()
 
         if self.include_aur:
-            aur_updates = self._check_aur_updates()
+            aur_updates = self._get_aur_updates()
 
         if pacman_updates is not None or aur_updates is not None:
             total = (pacman_updates or 0) + (aur_updates or 0)

--- a/py3status/modules/arch_updates.py
+++ b/py3status/modules/arch_updates.py
@@ -69,12 +69,9 @@ class Py3status:
         else:
             raise Exception(STRING_NOT_INSTALLED.format("pacman, aur"))
 
-        m = "_get_{}_updates"
-        self._get_pacman_updates = getattr(self, m.format(helper["pacman"]))
-        self._get_aur_updates = getattr(self, m.format(helper["aur"]))
-
-    def _get_None_updates(self):
-        pass
+        for key in helper:
+            value = getattr(self, "_get_{}_updates".format(helper[key]), None)
+            setattr(self, "_get_{}_updates".format(key), value)
 
     def _get_checkupdates_updates(self):
         try:
@@ -105,9 +102,11 @@ class Py3status:
             return None
 
     def arch_updates(self):
-        pacman = self._get_pacman_updates()
-        aur = self._get_aur_updates()
-        total, full_text = None, None
+        pacman, aur, total, full_text = None, None, None, None
+        if self._get_pacman_updates:
+            pacman = self._get_pacman_updates()
+        if self._get_aur_updates:
+            aur = self._get_aur_updates()
 
         if pacman is not None or aur is not None:
             total = (pacman or 0) + (aur or 0)

--- a/py3status/modules/arch_updates.py
+++ b/py3status/modules/arch_updates.py
@@ -75,30 +75,6 @@ class Py3status:
                 self.include_aur = False
                 self.py3.notify_user(STRING_NOT_INSTALLED.format(", ".join(aurs)))
 
-    def arch_updates(self):
-        pacman_updates = aur_updates = total = None
-
-        if self.include_pacman:
-            pacman_updates = self._check_pacman_updates()
-
-        if self.include_aur:
-            aur_updates = self._check_aur_updates()
-
-        if pacman_updates is not None or aur_updates is not None:
-            total = (pacman_updates or 0) + (aur_updates or 0)
-
-        if self.hide_if_zero and total == 0:
-            full_text = ""
-        else:
-            full_text = self.py3.safe_format(
-                self.format,
-                {"aur": aur_updates, "pacman": pacman_updates, "total": total},
-            )
-        return {
-            "cached_until": self.py3.time_in(self.cache_timeout),
-            "full_text": full_text,
-        }
-
     def _check_pacman_updates(self):
         try:
             updates = self.py3.command_output(["checkupdates"])
@@ -126,6 +102,30 @@ class Py3status:
             return len(updates.splitlines())
         except self.py3.CommandError:
             return None
+
+    def arch_updates(self):
+        pacman_updates = aur_updates = total = None
+
+        if self.include_pacman:
+            pacman_updates = self._check_pacman_updates()
+
+        if self.include_aur:
+            aur_updates = self._check_aur_updates()
+
+        if pacman_updates is not None or aur_updates is not None:
+            total = (pacman_updates or 0) + (aur_updates or 0)
+
+        if self.hide_if_zero and total == 0:
+            full_text = ""
+        else:
+            full_text = self.py3.safe_format(
+                self.format,
+                {"aur": aur_updates, "pacman": pacman_updates, "total": total},
+            )
+        return {
+            "cached_until": self.py3.time_in(self.cache_timeout),
+            "full_text": full_text,
+        }
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
First commit moves main method down.
Second commit renames things (i.e. fluffy changes).
Third commit moves lot of things around to detect `pacman`, `aur`, `format`, better.

As a result of this...
* Users can use `aur` alone without `pacman`. 
* If users specified `pacman`, `aur`, `total` placeholders in `format` and the binaries are not installed, it'll throw error. I imagine users are happy with auto format anyway.
* Same as before... If the `format` is not specified, it'll determine the `format` based on installed binaries... just more balanced/accurate.
* It's more balanced/accurate in a sense that we can add more than one `pacman` command other than `checkupdates` (if we can find out what it is)... essentially treating this same as `aur` code.

I thought about adding `thresholds` too... which is something I did in `updates` module. Thoughts? 

EDIT: I forget... Real feature... this removes annoying `include_aur` in favor of auto. 