### PR TITLE
arch_updates: fix SPEC VIOLATION: full_text is NULL!

### DIFF
--- a/py3status/modules/arch_updates.py
+++ b/py3status/modules/arch_updates.py
@@ -102,12 +102,12 @@ class Py3status:
             return None
 
     def arch_updates(self):
-        pacman, aur, total, full_text = None, None, None, None
+        pacman, aur, total, full_text = None, None, None, ""
+
         if self._get_pacman_updates:
             pacman = self._get_pacman_updates()
         if self._get_aur_updates:
             aur = self._get_aur_updates()
-
         if pacman is not None or aur is not None:
             total = (pacman or 0) + (aur or 0)
 


### PR DESCRIPTION
I turned on `hide_if_zero = True` to hide `UPD: 0/0` and ran into `SPEC VIOLATION: full_text is NULL!` because I supplied `None` for everything in my `arch_updates` refactoring.

There is a discrepancy between real modules and test modules when supplying `None` or `[]`.