### PR TITLE
frame: add safeformat for the separator

### DIFF
--- a/py3status/modules/frame.py
+++ b/py3status/modules/frame.py
@@ -107,6 +107,8 @@ class Py3status:
         # get the child modules output.
         output = []
         if self.open:
+            if self.format_separator:
+                format_separator = self.py3.safe_format(self.format_separator)
             for item in self.items:
                 out = self.py3.get_output(item)[:]
                 if self.format_separator is None:
@@ -116,9 +118,8 @@ class Py3status:
                         last_item = out[-1].copy()
                         last_item["separator"] = True
                         out[-1] = last_item
-                else:
-                    if self.format_separator:
-                        out += [{"full_text": self.format_separator}]
+                elif self.format_separator:
+                    out += format_separator
                 output += out
             urgent = False
 


### PR DESCRIPTION
This avoids hardcoding `frame` in `module.py` which is 9a339ff. 

If you want `markup = 'pango'` in `general {}`, then all modules including `frame` will get a pango markup. Sure, `frame` acts funny, but I believe it to be correct (a single pango markup composite).

With new option `None`, you can cancel this out by adding `markup = None` to `frame` module... which will behave same as hardcoded `frame` in `module.py`. Option `'none'` is raw from i3bar.

`format_separator` is fixed too in this PR.. to support `format_separator = '\?color=violet \|'` instead of spaces or non-colorized symbols/characters. Using (fixed) `format_separator` will work fine for pango markup too. Users could use this to mimic real separators or make different ones.

I do not see a way to keep both real separators and `markup = pango`, but with this PR, users still can use `pango` markup if they want to instead of us hardcoded blocking this.

Some things to try.
```python
order += "frame span"
frame span {
    static_string {}
    loadavg {}
    hddtemp {}

    format = "<span fgcolor='#00ffff'><sup>FRAME</sup></span> {output}"
    # format = "<small><i><u>FRAME</u></i></small> {output}"

    # format_separator = None
    format_separator = '\?color=violet \|'
    
    markup = 'pango'
    # markup = 'none'
    # markup = None    # real separators
}
```