### PR TITLE
parse_config: raise errors on sections in containers in the order directive

### DIFF
--- a/py3status/events.py
+++ b/py3status/events.py
@@ -238,8 +238,6 @@ class Events(Thread):
 
         default_event = False
         module_info = self.output_modules.get(module_name)
-        if not module_info:
-            return
         module = module_info["module"]
         # execute any configured i3-msg command
         # we do not do this for containers

--- a/py3status/parse_config.py
+++ b/py3status/parse_config.py
@@ -847,7 +847,8 @@ def process_config(config_path, py3_wrapper=None):
     # create config for modules in order
     for name in config_info.get("order", []):
         if name in module_groups:
-            msg = "Module `{}` shouldn't be in the order directive."
+            msg = "Module `{}` should not be listed in the 'order' directive, use"
+            msg += " its parent group instead."
             notify_user(msg.format(name))
             continue
         module_name = name.split(" ")[0]

--- a/py3status/parse_config.py
+++ b/py3status/parse_config.py
@@ -846,6 +846,10 @@ def process_config(config_path, py3_wrapper=None):
 
     # create config for modules in order
     for name in config_info.get("order", []):
+        if name in module_groups:
+            msg = "Module `{}` shouldn't be in the order directive."
+            notify_user(msg.format(name))
+            continue
         module_name = name.split(" ")[0]
         if module_name in RETIRED_MODULES:
             notify_user(


### PR DESCRIPTION
I can't reproduce the exception. I believe this would avoid the same exception in the future.

Addresses #1705.