### PR TITLE
module: fix indexerror exception

### DIFF
--- a/py3status/module.py
+++ b/py3status/module.py
@@ -278,7 +278,7 @@ class Module:
         for method in self.methods.values():
             data = method["last_output"]
             if isinstance(data, list):
-                if self.testing:
+                if self.testing and data:
                     data[0]["cached_until"] = method.get("cached_until")
                 output.extend(data)
             else:


### PR DESCRIPTION
Consistent behavior for `[]` and `None` in testing modules. Most modules uses composites anyway.

Addresses https://github.com/ultrabug/py3status/pull/1735#issue-258578484.

> ... ran into `SPEC VIOLATION: full_text is NULL!` because I supplied `None` for everything...
> 
> ... discrepancy between real modules and test modules...

