### PR TITLE
tox.ini: unpin flake8 3.6.0

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -4,8 +4,6 @@ skip_missing_interpreters = True
 [testenv]
 skip_install = True
 deps =
-# remove flake8 later, see https://github.com/tholo/pytest-flake8/issues/56
-    flake8==3.6.0
     pytest
     pytest-flake8
 commands =
@@ -14,8 +12,6 @@ commands =
 [testenv:py36]
 skip_install = True
 deps =
-# remove flake8 later, see https://github.com/tholo/pytest-flake8/issues/56
-    flake8==3.6.0
     black
     pytest
     pytest-flake8


### PR DESCRIPTION
`flake8 3.7` failed all Python tests so we pinned `flake8 3.6.0`. It got fixed not long after. Can unpin.