### PR TITLE
events: remove unused if statement for \$OUTPUT{,_PART}

### DIFF
--- a/py3status/events.py
+++ b/py3status/events.py
@@ -111,23 +111,22 @@ class Events(Thread):
         """
         index = event.get("index")
         module_info = self.py3_wrapper.output_modules.get(module_name)
-        if module_info:
-            output = module_info["module"].get_latest()
-            full_text = u"".join([out["full_text"] for out in output])
+        output = module_info["module"].get_latest()
+        full_text = u"".join([out["full_text"] for out in output])
 
-            partial = None
-            if index is not None:
-                if isinstance(index, int):
-                    partial = output[index]
-                else:
-                    for item in output:
-                        if item.get("index") == index:
-                            partial = item
-                            break
-            if partial:
-                partial_text = partial["full_text"]
+        partial = None
+        if index is not None:
+            if isinstance(index, int):
+                partial = output[index]
             else:
-                partial_text = full_text
+                for item in output:
+                    if item.get("index") == index:
+                        partial = item
+                        break
+        if partial:
+            partial_text = partial["full_text"]
+        else:
+            partial_text = full_text
         return full_text, partial_text
 
     def on_click_dispatcher(self, module_name, event, command):


### PR DESCRIPTION
Not exactly a bugfix. `if module_info` is always True, otherwise, we would see this exception already because `full_text` and `partial_text` is not defined anywhere other than inside `if module_info`. 
```bash
UnboundLocalError: local variable 'full_text' referenced before assignment
  File "py3status/py3status/core.py", line 58, in run
    self.module.run()
  File "py3status/py3status/events.py", line 83, in run
    self.module_name, self.event, self.command
  File "py3status/py3status/events.py", line 149, in on_click_dispatcher
    full_text, partial_text = self.get_module_text(module_name, event)
  File "py3status/py3status/events.py", line 131, in get_module_text
    return full_text, partial_text
```