### PR TITLE
docs: make unordered list, update docs, fix typos

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -150,26 +150,26 @@ You can specify the options in module or py3status configuration section.
 
 The following options will work on ``i3``.
 
-``align``: Specify how modules should be aligned when the ``min_width``
+- ``align``: Specify how modules should be aligned when the ``min_width``
 is not reached. Either ``left`` (default), ``center``, or ``right``.
-``background``: Specify a background color for py3status modules.
-``markup``: Specify how modules should be parsed.
-``min_width``: Specify a minimum width of pixels for modules.
-``separator``: Specify a separator boolean for modules.
-``separator_block_width``: Specify a separator block width for modules.
+- ``background``: Specify a background color for py3status modules.
+- ``markup``: Specify how modules should be parsed.
+- ``min_width``: Specify a minimum width of pixels for modules.
+- ``separator``: Specify a separator boolean for modules.
+- ``separator_block_width``: Specify a separator block width for modules.
 
 The following options will work on ``i3-gaps``.
 
-``border``: Specify a border color for modules.
-``border_bottom``: Specify a border width for modules
-``border_left``: Specify a border width for modules.
-``border_right``: Specify a border width for modules.
-``border_top``: Specify a border width for modules.
+- ``border``: Specify a border color for modules.
+- ``border_bottom``: Specify a border width for modules
+- ``border_left``: Specify a border width for modules.
+- ``border_right``: Specify a border width for modules.
+- ``border_top``: Specify a border width for modules.
 
 The following options will work on ``py3status``.
 
-``min_length``: Specify a minimum length of characters for modules.
-``position``: Specify how modules should be positioned when the ``min_length``
+- ``min_length``: Specify a minimum length of characters for modules.
+- ``position``: Specify how modules should be positioned when the ``min_length``
 is not reached. Either ``left`` (default), ``center``, or ``right``.
 
 .. code-block:: py3status
@@ -198,16 +198,16 @@ is not reached. Either ``left`` (default), ``center``, or ``right``.
 
 The following options will work on ``i3bar`` and ``py3status``.
 
-``urgent_background``: Specify urgent background color for modules.
-``urgent_foreground``: Specify urgent foreground color for modules.
-``urgent_border``: Specify urgent border color for modules.
+- ``urgent_background``: Specify urgent background color for modules.
+- ``urgent_foreground``: Specify urgent foreground color for modules.
+- ``urgent_border``: Specify urgent border color for modules.
 
 The following options will work on ``i3bar-gaps`` and ``py3status``.
 
-``urgent_border_bottom``: Specify urgent border width for modules
-``urgent_border_left``: Specify urgent border width for modules.
-``urgent_border_right``: Specify urgent border width for modules.
-``urgent_border_top``: Specify urgent border width for modules.
+- ``urgent_border_bottom``: Specify urgent border width for modules
+- ``urgent_border_left``: Specify urgent border width for modules.
+- ``urgent_border_right``: Specify urgent border width for modules.
+- ``urgent_border_top``: Specify urgent border width for modules.
 
 You lose urgent functionality too that can be sometimes utilized by
 container modules, e.g., frame and group.
@@ -803,7 +803,7 @@ Inline Shell Code
 You can use the standard output of a shell script in your configuration with
 the ``shell(...)`` directive. These values are captured at startup and may be
 converted to the needed datatype (only ``str``, ``int``, ``float``, ``bool``
-and ``auto`` (the default) are currently supported).
+and ``auto`` (default) are currently supported).
 
 The shell script executed must return a single line of text on stdout and
 then terminate. If the type is explicitly declared ``bool``, the exit status
@@ -856,6 +856,7 @@ specific subsystem using the ``on_udev_<subsystem>`` configuration parameter
 and an associated action.
 
 Possible actions:
+
 - ``refresh``: immediately refresh the module and keep on updating it as usual
 - ``refresh_and_freeze``: module is ONLY refreshed when said udev subsystem emits
 an event

--- a/doc/contributing.rst
+++ b/doc/contributing.rst
@@ -181,8 +181,8 @@ i3status has cap\_net\_admin capabilities, which will make it fail with
     $ getcap `which i3status`
     /usr/sbin/i3status = cap_net_admin+ep
 
-To allow it to run without these capabilites (hence disabling some of the
-functionnalities), remove it with:
+To allow it to run without these capabilities (hence disabling some of the
+functionalities), remove it with:
 
 .. code-block:: shell
 

--- a/doc/intro.rst
+++ b/doc/intro.rst
@@ -119,9 +119,9 @@ The default packages that come with i3 (dmenu, i3status, i3lock) have to be ment
 Support
 -------
 
-Get help, share ideas or feedbacks, join community, report bugs, or others, see:
+Get help, share ideas or feedback, join community, report bugs, or others, see:
 
-Github
+GitHub
 ^^^^^^
 
 `Issues <https://github.com/ultrabug/py3status/issues>`_ /

--- a/doc/py3-cmd.rst
+++ b/doc/py3-cmd.rst
@@ -20,25 +20,6 @@ This utility allows you to run a number of commands.
 Commands available
 ------------------
 
-refresh
-^^^^^^^
-
-Cause named module(s) to have their output refreshed.
-
-.. code-block:: shell
-
-    # refresh all instances of the wifi module
-    py3-cmd refresh wifi
-
-    # refresh multiple modules
-    py3-cmd refresh coin_market github weather_yahoo
-
-    # refresh module with instance name
-    py3-cmd refresh "weather_yahoo chicago"
-
-    # refresh all modules
-    py3-cmd refresh --all
-
 
 click
 ^^^^^
@@ -69,6 +50,45 @@ You can specify the button to simulate.
     py3-cmd click --button 4 --index hours timer    # up
     py3-cmd click --button 4 --index minutes timer  # up
     py3-cmd click --button 4 --index seconds timer  # up
+
+
+list
+^^^^
+
+Print a list of modules or module docstrings.
+
+.. code-block:: shell
+
+    # list one or more modules
+    py3-cmd list clock loadavg xrandr  # full
+    py3-cmd list coin* git* window*    # fnmatch
+    py3-cmd list [a-e]*                # abcde
+
+    # list all modules
+    py3-cmd list --all
+
+    # show full (i.e. docstrings)
+    py3-cmd list vnstat uname -f
+
+
+refresh
+^^^^^^^
+
+Cause named module(s) to have their output refreshed.
+
+.. code-block:: shell
+
+    # refresh all instances of the wifi module
+    py3-cmd refresh wifi
+
+    # refresh multiple modules
+    py3-cmd refresh coin_market github weather_yahoo
+
+    # refresh module with instance name
+    py3-cmd refresh "weather_yahoo chicago"
+
+    # refresh all modules
+    py3-cmd refresh --all
 
 
 Calling commands from i3


### PR DESCRIPTION
https://py3status.readthedocs.io/en/latest/configuration.html?highlight=on_click#configuring-a-py3status-module need unordered list badly. I fix other things too. 