### PR TITLE
module for printing gpu device currently in use

### DIFF
--- a/py3status/modules/nvidia_prime.py
+++ b/py3status/modules/nvidia_prime.py
@@ -24,6 +24,9 @@ nvidia_prime {
 
 @author Jørn Sandvik Nilsson
 
+SAMPLE_OUTPUT
+{'full_text': 'GPU: intel'}
+
 """
 
 from py3status import exceptions

--- a/py3status/modules/nvidia_prime.py
+++ b/py3status/modules/nvidia_prime.py
@@ -48,11 +48,10 @@ class Py3status:
             pass
 
         return {
-            'full_text': self.py3.safe_format(
-                self.format,
-                dict(device=device)),
-            'cached_until': self.py3.time_in(self.cache_timeout)
+            "full_text": self.py3.safe_format(self.format, dict(device=device)),
+            "cached_until": self.py3.time_in(self.cache_timeout),
         }
+
 
 if __name__ == "__main__":
     """

--- a/py3status/modules/nvidia_prime.py
+++ b/py3status/modules/nvidia_prime.py
@@ -24,9 +24,8 @@ nvidia_prime {
 
 @author Jørn Sandvik Nilsson
 
-SAMPLE_OUTPUT
+SAMPLE OUTPUT
 {'full_text': 'GPU: intel'}
-
 """
 
 from py3status import exceptions

--- a/py3status/modules/nvidia_prime.py
+++ b/py3status/modules/nvidia_prime.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 """
-Display which graphics device is in use, nvidia or intel (for systems supporting prime-select)
+Display which graphics device is in use using prime-select
 
 
 Configuration parameters:
@@ -31,6 +31,7 @@ SAMPLE_OUTPUT
 
 from py3status import exceptions
 
+
 class Py3status:
     """
     """
@@ -44,12 +45,14 @@ class Py3status:
         device = "unknown"
         try:
             device = self.py3.command_output(["prime-select", "query"]).strip()
-        except exceptions.CommandError as e:
+        except exceptions.CommandError:
             pass
 
         return {
-            'full_text': self.py3.safe_format(self.format, dict(device=device)),
-            'cached_until': self.py3.time_in(self.cache_timeout) 
+            'full_text': self.py3.safe_format(
+                self.format,
+                dict(device=device)),
+            'cached_until': self.py3.time_in(self.cache_timeout)
         }
 
 if __name__ == "__main__":

--- a/py3status/modules/nvidia_prime.py
+++ b/py3status/modules/nvidia_prime.py
@@ -1,0 +1,58 @@
+# -*- coding: utf-8 -*-
+"""
+Display which graphics device is in use, nvidia or intel (for systems supporting prime-select)
+
+
+Configuration parameters:
+    cache_timeout: how often to update the bar (default 60)
+    format: (default 'GPU: {device}')
+
+Format placeholders:
+    {device} Name of device currently in use
+
+Requires:
+    nvidia-prime: nvidia's tool to switch graphics device (nvidia or intel)
+
+Example:
+```
+nvidia_prime {
+    format = "GPU: {device}"
+    cache_timeout: 600
+}
+
+```
+
+@author Jørn Sandvik Nilsson
+
+"""
+
+from py3status import exceptions
+
+class Py3status:
+    """
+    """
+
+    # available configuration parameters
+    cache_timeout = 60
+    format = "GPU: {device}"
+
+    def nvidia_prime(self):
+
+        device = "unknown"
+        try:
+            device = self.py3.command_output(["prime-selectt", "query"]).strip()
+        except exceptions.CommandError as e:
+            pass
+
+        return {
+            'full_text': self.py3.safe_format(self.format, dict(device=device)),
+            'cached_until': self.py3.time_in(self.cache_timeout) 
+        }
+
+if __name__ == "__main__":
+    """
+    Run module in test mode.
+    """
+    from py3status.module_test import module_test
+
+    module_test(Py3status)

--- a/py3status/modules/nvidia_prime.py
+++ b/py3status/modules/nvidia_prime.py
@@ -40,7 +40,7 @@ class Py3status:
 
         device = "unknown"
         try:
-            device = self.py3.command_output(["prime-selectt", "query"]).strip()
+            device = self.py3.command_output(["prime-select", "query"]).strip()
         except exceptions.CommandError as e:
             pass
 


### PR DESCRIPTION
Provides information of which graphics device is currently in use, on systems supporting nvidia-prime.

Outputs the response of the command "prime-select query"