### PR TITLE
group: don't cycle on zero

### DIFF
--- a/py3status/modules/group.py
+++ b/py3status/modules/group.py
@@ -214,8 +214,8 @@ class Py3status:
         self.urgent_history[self.active] = urgent
         mod_urgent = any(self.urgent_history.values())
 
-        # keep cycling if no urgent
-        if not urgent:
+        # keep cycling if defined and no urgent
+        if self.cycle_timeout and not urgent:
             self.cycle = self.cycle_timeout
             if time() >= self.cycle_time:
                 self._change_active(1)


### PR DESCRIPTION
A recent PR stops cycling on `urgent`, but omitted `cycle` so group will always cycle modules.
```diff
-            if self.cycle and time() >= self._cycle_time:
+        # keep cycling if no urgent
+        if not urgent:
+            self.cycle = self.cycle_timeout
+            if time() >= self.cycle_time:
                 self._change_active(1)
-                self._cycle_time = time() + self.cycle
```

This adds a missing check for `cycle = 0` to ensure we don't cycle against users' wishes. Sorry I always mess up something. You should come out of your rock and yell at me some more. :-)

Addresses #1756. 
