### PR TITLE
I3pystatus: support universal/py3status module options

### DIFF
--- a/py3status/modules/i3pystatus.py
+++ b/py3status/modules/i3pystatus.py
@@ -197,7 +197,32 @@ class ClickTimer:
 STRING_NOT_SUPPORTED = "python2 not supported"
 STRING_NOT_INSTALLED = "not installed"
 STRING_MISSING_MODULE = "missing module"
-SKIP_ATTRS = ["on_click", "run", "post_config_hook", "module", "py3"]
+SKIP_ATTRS = [
+    "align",
+    "allow_urgent",
+    "background",
+    "border",
+    "border_bottom",
+    "border_left",
+    "border_right",
+    "border_top",
+    "markup",
+    "min_length",
+    "min_width",
+    "module",
+    "on_click",
+    "position",
+    "post_config_hook",
+    "py3",
+    "run",
+    "separator",
+    "separator_block_width",
+    "urgent_border",
+    "urgent_border_bottom",
+    "urgent_border_left",
+    "urgent_border_right",
+    "urgent_border_top",
+]
 
 
 class Py3status:
@@ -293,6 +318,11 @@ class Py3status:
 
     def run(self):
         output = self.module.output or {"full_text": ""}
+        full_text = output.get("full_text", "")
+
+        # which modules return tuples?
+        if isinstance(full_text, tuple):
+            full_text = full_text[0]
 
         if self._last_content != output:
             self._last_content = output
@@ -302,16 +332,14 @@ class Py3status:
             if self._timeout > MAX_AUTO_TIMEOUT:
                 self._timeout = MAX_AUTO_TIMEOUT
 
-        # some modules return tuples
-        if isinstance(output["full_text"], tuple):
-            output["full_text"] = output["full_text"][0]
-
         if self.is_interval_module:
-            output["cached_until"] = self.py3.time_in(
-                sync_to=min(self._cache_timeout, self._timeout)
-            )
+            interval = min(self._cache_timeout, self._timeout)
         else:
-            output["cached_until"] = self.py3.time_in(sync_to=self._timeout)
+            interval = self._timeout
+
+        if full_text:
+            output["full_text"] = self.py3.safe_format(full_text)
+        output["cached_until"] = self.py3.time_in(sync_to=interval)
 
         return output
 


### PR DESCRIPTION
1) ENHANCEMENT. This should support (all?) universal/py3status module options:
1a) BUGFIX: Universal/py3status module options does not work on i3pystatus. 
```python
SKIP_OPTS = [
    "align",
    "allow_urgent",
    "background",
    "border",
    "border_bottom",
    "border_left",
    "border_right",
    "border_top",
    "markup",
    "min_length",
    "min_width",
    "position",
    "separator",
    "separator_block_width",
    "urgent_border",
    "urgent_border_bottom",
    "urgent_border_left",
    "urgent_border_right",
    "urgent_border_top",
]
```
2) BUGFIX. Fixes an `interval` bug where author last-minute removed `safeformat()` in the code before it gets merged... resulting in occuring unequal contents... triggering modules to nearly always check the content every second instead of `interval`/15/30. 

~~3) BUGFIX. Check Python version first before we tell Python2 users to install i3py3status.~~

