### PR TITLE
mpris: handle disconnected players gracefully on clicks

### DIFF
--- a/py3status/modules/mpris.py
+++ b/py3status/modules/mpris.py
@@ -574,9 +574,12 @@ class Py3status:
         elif button != 1:
             return
 
-        control_state = self._control_states.get(index)
-        if self._player and self._get_button_state(control_state):
-            getattr(self._player, self._control_states[index]["action"])()
+        try:
+            control_state = self._control_states.get(index)
+            if self._player and self._get_button_state(control_state):
+                getattr(self._player, self._control_states[index]["action"])()
+        except GError as err:
+            self.py3.log(str(err).split(":", 1)[-1])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This handles disconnected players gracefully on clicks.
```
2019-03-29 14:32:10 WARNING on_click event in `mpris` failed (Error) mpris.py line 579.
2019-03-29 14:32:10 INFO Traceback
Error: g-dbus-error-quark: GDBus.Error:org.freedesktop.DBus.Error.NoReply:
    Message recipient disconnected from message bus without replying (4)
  File "py3status/py3status/module.py", line 884, in click_event
    click_method(event)
  File "py3status/py3status/modules/mpris.py", line 579, in on_click
    getattr(self._player, self._control_states[index]["action"])()
  File "/usr/lib/python3.7/site-packages/pydbus/proxy_method.py", line 75, in __call__
    0, timeout_to_glib(timeout), None).unpack()

2019-03-29 14:32:10 ERROR py3status: on_click event in `mpris` failed (Error)
    mpris.py line 579. Please try to fix this and reload i3wm (Mod+Shift+R)
```