### PR TITLE
mpris: make new default changes

### DIFF
--- a/py3status/modules/mpris.py
+++ b/py3status/modules/mpris.py
@@ -12,7 +12,8 @@ Configuration parameters:
     button_stop: mouse button to stop the player (default None)
     button_toggle: mouse button to toggle between play and pause mode (default 1)
     format: see placeholders below
-        (default '{previous}{toggle}{next} {state} [{artist} - ][{title}]')
+    format: display format for this module
+        (default '[{artist} - ][{title}] {previous} {toggle} {next}')
     format_none: define output if no player is running
         (default 'no player running')
     icon_next: specify icon for next button (default u'\u25b9')
@@ -24,7 +25,7 @@ Configuration parameters:
         Keep in mind that the state has a higher priority than
         player_priority. So when player_priority is "[mpd, bomi]" and mpd is
         paused and bomi is playing than bomi wins. (default [])
-    state_pause: specify icon for pause state (default '\u25eb')
+    state_pause: specify icon for pause state (default u'\u25eb')
     state_play: specify icon for play state (default u'\u25b7')
     state_stop: specify icon for stop state (default u'\u25a1')
 
@@ -135,7 +136,7 @@ class Py3status:
     button_previous = None
     button_stop = None
     button_toggle = 1
-    format = "{previous}{toggle}{next} {state} [{artist} - ][{title}]"
+    format = "[{artist} - ][{title}] {previous} {toggle} {next}"
     format_none = "no player running"
     icon_next = u"\u25b9"
     icon_pause = u"\u25eb"

--- a/py3status/modules/mpris.py
+++ b/py3status/modules/mpris.py
@@ -15,18 +15,18 @@ Configuration parameters:
         (default '{previous}{toggle}{next} {state} [{artist} - ][{title}]')
     format_none: define output if no player is running
         (default 'no player running')
-    icon_next: specify icon for next button (default ' » ')
-    icon_pause: specify icon for pause button (default ' ▮ ')
-    icon_play: specify icon for play button (default ' ▶ ')
-    icon_previous: specify icon for previous button (default ' « ')
-    icon_stop: specify icon for stop button (default ' ◾ ')
+    icon_next: specify icon for next button (default u'\u25b9')
+    icon_pause: specify icon for pause button (default u'\u25eb')
+    icon_play: specify icon for play button (default u'\u25b7')
+    icon_previous: specify icon for previous button (default u'\u25c3')
+    icon_stop: specify icon for stop button (default u'\u25a1')
     player_priority: priority of the players.
         Keep in mind that the state has a higher priority than
         player_priority. So when player_priority is "[mpd, bomi]" and mpd is
         paused and bomi is playing than bomi wins. (default [])
-    state_pause: text for placeholder {state} when song is paused (default '▮')
-    state_play: text for placeholder {state} when song is playing (default '▶')
-    state_stop: text for placeholder {state} when song is stopped (default '◾')
+    state_pause: specify icon for pause state (default '\u25eb')
+    state_play: specify icon for play state (default u'\u25b7')
+    state_stop: specify icon for stop state (default u'\u25a1')
 
 Format placeholders:
     {album} album name
@@ -137,15 +137,15 @@ class Py3status:
     button_toggle = 1
     format = "{previous}{toggle}{next} {state} [{artist} - ][{title}]"
     format_none = "no player running"
-    icon_next = u" » "
-    icon_pause = u" ▮ "
-    icon_play = u" ▶ "
-    icon_previous = u" « "
-    icon_stop = u" ◾ "
+    icon_next = u"\u25b9"
+    icon_pause = u"\u25eb"
+    icon_play = u"\u25b7"
+    icon_previous = u"\u25c3"
+    icon_stop = u"\u25a1"
     player_priority = []
-    state_pause = u"▮"
-    state_play = u"▶"
-    state_stop = u"◾"
+    state_pause = u"\u25eb"
+    state_play = u"\u25b7"
+    state_stop = u"\u25a1"
 
     def post_config_hook(self):
         if self.py3.is_gevent():

--- a/py3status/modules/mpris.py
+++ b/py3status/modules/mpris.py
@@ -7,8 +7,8 @@ button in the text information or by using buttons. For former you have
 to define the button parameters in your config.
 
 Configuration parameters:
-    button_next: mouse button to play the next entry (default 4)
-    button_previous: mouse button to play the previous entry (default 5)
+    button_next: mouse button to play the next entry (default None)
+    button_previous: mouse button to play the previous entry (default None)
     button_stop: mouse button to stop the player (default None)
     button_toggle: mouse button to toggle between play and pause mode (default 1)
     format: see placeholders below
@@ -131,8 +131,8 @@ class Py3status:
     """
 
     # available configuration parameters
-    button_next = 4
-    button_previous = 5
+    button_next = None
+    button_previous = None
     button_stop = None
     button_toggle = 1
     format = "{previous}{toggle}{next} {state} [{artist} - ][{title}]"


### PR DESCRIPTION
1) Minimal fix is commit `mpris: disable next/previous buttons`.

    >There are two ways to control the media player. Either by clicking with a mouse
button in the text information or by using buttons. For former you have
to define the button parameters in your config.

    Because we have two ways to control, we shouldn't have both enabled at same time. I also do not think it is ideal to default next/previous with scrolling buttons. If anything, users should set this themselves. The stop button is already disabled by default... leaving us with only (enabled) toggling button. It also helps that default `format` already next/previous placeholders for users to use instead.. or make changes. Overall, it is a better default behavior (imo).

    i) Alternative: Tell users to disable `button` 4 or 5 when using `on_click` 4 or 5. 

2) Various fonts can have missing or non-ideal gylphs (aka emojis mixed in with symbols). I think I replaced this with all symbols hopefully to make it more consistent for users with various fonts. There are no identical filled symbols so I think the new symbols would fare okay.

3) Use a bit more friendly `format` since modules are often on right side and users often are right-handed. It feels more natural to adjust things on right side... and because song artist/titles change often resulting in new positions for button placeholders. With this, the button placeholders are likely to remain in mostly same place. You can test this easily with next/previous buttons or placeholders.

Addresses #1739. If need, I can split them up into separate PRs. 