### PR TITLE
diskdata: explicitly request kb from df

### DIFF
--- a/py3status/modules/diskdata.py
+++ b/py3status/modules/diskdata.py
@@ -150,7 +150,7 @@ class Py3status:
         free = 0
         devs = []
 
-        df = self.py3.command_output("df")
+        df = self.py3.command_output(["df", "-k"])
         for line in df.splitlines():
             if (disk and line.startswith(disk)) or (
                 disk is None and line.startswith("/dev/")


### PR DESCRIPTION
Plain `df` returning values in `kb` is just the default/convention.  In some environments the default units returned by `df` may be something else, eg. where one of `DF_BLOCK_SIZE`, `BLOCK_SIZE`, `BLOCKSIZE`, or `POSIXLY_CORRECT` environment variables have been set, or where `df` is a wrapper script that adjusts the default behaviour of `df` to the user's liking.

Thus the `diskdata` module's assumption (that the values it reads are always in `kb`) is not always true.  This patch adjusts the module so that it passes `-k` to `df`, to ensure that the values are always in `kb`.