### PR TITLE
core: document adding i3status modules in the log

### DIFF
--- a/py3status/core.py
+++ b/py3status/core.py
@@ -551,6 +551,8 @@ class Py3statusWrapper:
             self.i3status_thread.mock()
             i3s_mode = "mocked"
         else:
+            for module in i3s_modules:
+                self.log("adding module {}".format(module))
             i3s_mode = "started"
             self.i3status_thread.start()
             while not self.i3status_thread.ready:


### PR DESCRIPTION
Whilst troubleshooting an issue, I noticed we log starting and exiting i3status, but not i3status modules. 

Before.
```
2019-04-08 00:12:37 INFO i3status spawned using config file /tmp/py3status_vglx24_e
```
After.
```
2019-04-08 00:12:37 INFO adding module cpu_usage
2019-04-08 00:12:37 INFO adding module disk /
2019-04-08 00:12:37 INFO adding module ethernet _first_
2019-04-08 00:12:37 INFO adding module tztime local
2019-04-08 00:12:37 INFO i3status spawned using config file /tmp/py3status_vglx24_e
```