### PR TITLE
py3: add multiple get_placeholders_list

### DIFF
--- a/py3status/py3.py
+++ b/py3status/py3.py
@@ -741,12 +741,13 @@ class Py3:
                 names.add(color)
         return list(names)
 
-    def get_placeholders_list(self, format_string, match=None):
+    def get_placeholders_list(self, format_string, matches=None):
         """
         Returns a list of placeholders in ``format_string``.
 
-        If ``match`` is provided then it is used to filter the result using
-        fnmatch so the following patterns can be used:
+        If ``matches`` is provided then it is used to filter the result
+        using fnmatch so the following patterns can be used:
+
 
         .. code-block:: none
 
@@ -765,14 +766,17 @@ class Py3:
         else:
             placeholders = self._format_placeholders[format_string]
 
-        if not match:
+        if not matches:
             return list(placeholders)
+        elif isinstance(matches, basestring):
+            matches = [matches]
         # filter matches
-        found = []
-        for placeholder in placeholders:
-            if fnmatch(placeholder, match):
-                found.append(placeholder)
-        return found
+        found = set()
+        for match in matches:
+            for placeholder in placeholders:
+                if fnmatch(placeholder, match):
+                    found.add(placeholder)
+        return list(found)
 
     def get_placeholder_formats_list(self, format_string):
         """


### PR DESCRIPTION
We can match more than once to better specify different list of placeholders for different functions.

```diff
diff --git a/py3status/modules/static_string.py b/py3status/modules/static_string.py
index 1cfbfed..1c0059f 100644
--- a/py3status/modules/static_string.py
+++ b/py3status/modules/static_string.py
@@ -17,9 +17,13 @@ class Py3status:
     """

     # available configuration parameters
-    format = "Hello, world!"
+    format = "{hello_world} {hell} {word2} {help} {zebra} {test}"
+    # format = "{hello_name} {help_girl} {word} {test_me}"

     def static_string(self):
+        matches = ["hell*", "test", "word"]
+        placeholders = self.py3.get_placeholders_list(self.format, matches)
+        self.py3.log(placeholders)
         return {
             "cached_until": self.py3.CACHE_FOREVER,
             "full_text": self.py3.safe_format(self.format),
```