### PR TITLE
py3: move py3.get_color_names helper to formatter

### DIFF
--- a/py3status/constants.py
+++ b/py3status/constants.py
@@ -61,6 +61,8 @@ ERROR_CONFIG = """
 }
 """
 
+COLOR_NAMES_EXCLUDED = ["good", "bad", "degraded", "separator", "threshold", "None"]
+
 COLOR_NAMES = {
     "aliceblue": "#f0f8ff",
     "antiquewhite": "#faebd7",

--- a/py3status/formatter.py
+++ b/py3status/formatter.py
@@ -6,6 +6,7 @@ from math import ceil
 from numbers import Number
 
 from py3status.composite import Composite
+from py3status.constants import COLOR_NAMES, COLOR_NAMES_EXCLUDED
 
 try:
     from urllib.parse import parse_qsl
@@ -51,6 +52,25 @@ class Formatter:
             tokens = list(re.finditer(self.reg_ex, format_string))
             self.format_string_cache[format_string] = tokens
         return self.format_string_cache[format_string]
+
+    def get_color_names(self, format_string):
+        """
+        Parses the format_string and returns a set of color names.
+        """
+        names = set()
+        # Tokenize the format string and process them
+        for token in self.tokens(format_string):
+            if token.group("command"):
+                name = dict(parse_qsl(token.group("command"))).get("color")
+                if (
+                    not name
+                    or name in COLOR_NAMES_EXCLUDED
+                    or name in COLOR_NAMES
+                    or name[0] == "#"
+                ):
+                    continue
+                names.add(name)
+        return names
 
     def get_placeholders(self, format_string):
         """

--- a/py3status/py3.py
+++ b/py3status/py3.py
@@ -730,15 +730,7 @@ class Py3:
             format_strings = [format_strings]
         names = set()
         for string in format_strings:
-            for color in string.replace("&", " ").split("color=")[1::1]:
-                color = color.split()[0]
-                if "#" in color:
-                    continue
-                if color in ["good", "bad", "degraded", "None", "threshold"]:
-                    continue
-                if color in COLOR_NAMES:
-                    continue
-                names.add(color)
+            names.update(self._formatter.get_color_names(string))
         return list(names)
 
     def get_placeholders_list(self, format_string, match=None):

--- a/tests/test_formatter.py
+++ b/tests/test_formatter.py
@@ -165,6 +165,20 @@ def update_placeholders(test_dict):
         pytest.fail("Results not as expected")
 
 
+def get_color_names(test_dict):
+    __tracebackhide__ = True
+
+    result = f.get_color_names(test_dict["format"])
+    expected = test_dict.get("expected")
+
+    if result != expected:
+        print("Format\n{}\n".format(test_dict["format"]))
+        print("Expected\n{}".format(pformat(expected)))
+        print("Got\n{}".format(pformat(result)))
+    if result != expected:
+        pytest.fail("Results not as expected")
+
+
 def test_1():
     run_formatter({"format": u"hello ☂", "expected": u"hello ☂"})
 
@@ -1355,6 +1369,42 @@ def test_update_placeholders_5():
             "format": r"\{placeholder\}{placeholder}[\?if=placeholder&color=red something]",
             "updates": {"placeholder": "new_placeholder"},
             "expected": r"\{placeholder\}{new_placeholder}[\?if=new_placeholder&color=red something]",
+        }
+    )
+
+
+def test_get_color_names_1():
+    get_color_names(
+        {
+            "format": r"\?color=red \?color=#0f0 green \?color=#0000ff blue",
+            "expected": set(),
+        }
+    )
+
+
+def test_get_color_names_2():
+    get_color_names(
+        {
+            "format": r"[\?color=tobias funke|\?color=bluemangroup troupe]",
+            "expected": {"tobias", "bluemangroup"},
+        }
+    )
+
+
+def test_get_color_names_3():
+    get_color_names(
+        {
+            "format": r"[\?color=good bonsai tree][\?color=None Saibot]",
+            "expected": set(),
+        }
+    )
+
+
+def test_get_color_names_4():
+    get_color_names(
+        {
+            "format": r"\?color=rebeccapurple \?color=rebecca \?color=purple",
+            "expected": {"rebecca"},
         }
     )
 


### PR DESCRIPTION
This moves `py3.get_color_names` helper from self-contained parsing to formatter parsing.

>@tobes This function should be fixed so it give accurate results. Currently it uses a poor method
to find the colors.

It did give us what we need with 100% accuracy targeting a specific type of colors, which is placeholder color names to be used with thresholds. This excludes other colors (i.e. css color names, hex color codes, and special color names).

>>@lasers self.py3.get_color_placeholders_list might be more accurate... similar to
>
>@tobes colours are not placeholders

Yes sir. That's why I went with `get_color_names`. Alternative names could be... 
* `get_threshold_color_names`
* `get_threshold_names`
* `get_color_placeholders`
* `get_threshold_placeholders`

I dunno. They're all wonderful.


>for me the issues are is this just for thresholds?

Yes sir. It's just for thresholds.

>@tobes It needs to be done by the formatter parser

Yes sir.

>@lasers This PR is trying too hard... and many things are not necessary.

Because this is just for thresholds, I don't need `fix_colors` function so I'm not going to include it in this PR. That `fix_colors` function should be done separately too anyway. Cheers.

Addresses #1469. 
Addresses #1472.
