### PR TITLE
group: calculate remaining times to cycle more accurately

### DIFF
--- a/py3status/modules/group.py
+++ b/py3status/modules/group.py
@@ -196,7 +196,7 @@ class Py3status:
             self._change_active(delta)
         self.last_active = self.active
 
-    def group(self):
+    def _get_output_and_time(self):
         # get an output. again if empty (twice).
         for x in range(3):
             output = self._get_output()
@@ -208,6 +208,11 @@ class Py3status:
         else:
             update_time = MAX_NO_CONTENT_WAIT
 
+        return output, update_time
+
+    def group(self):
+        output, update_time = self._get_output_and_time()
+
         # check for urgents
         urgent = output and output[0].get("urgent")
         self.urgent_history[self.active] = urgent
@@ -217,10 +222,12 @@ class Py3status:
         self.cycle = 0
         if self.first_run:
             self.first_run = False
+            update_time = 1
         elif self.cycle_timeout and not urgent:
             current_time = time()
             if current_time >= self.cycle_time - 0.1:
                 self._change_active(1)
+                output, update_time = self._get_output_and_time()
                 self.cycle = self.cycle_timeout
                 self.cycle_time = current_time + self.cycle
             else:

--- a/py3status/modules/group.py
+++ b/py3status/modules/group.py
@@ -188,9 +188,8 @@ class Py3status:
         return current
 
     def _change_active(self, delta):
-        # we want to ignore any empty outputs
-        # to prevent endless cycling we limit ourselves to only going through
-        # the outputs once.
+        # we want to skip empty outputs. to prevent endless cycling,
+        # we limit ourselves to only going through the outputs once.
         self.active = (self.active + delta) % len(self.items)
         if not self._get_output() and self.last_active != self.active:
             self._change_active(delta)
@@ -216,10 +215,13 @@ class Py3status:
 
         # keep cycling if defined and no urgent
         if self.cycle_timeout and not urgent:
-            self.cycle = self.cycle_timeout
-            if time() >= self.cycle_time:
+            current_time = time()
+            if current_time >= self.cycle_time - 0.1:
                 self._change_active(1)
-                self.cycle_time = time() + self.cycle
+                self.cycle = self.cycle_timeout
+                self.cycle_time = current_time + self.cycle
+            else:
+                self.cycle = self.cycle_time - current_time
 
         # time
         update_time = update_time or self.cycle or None


### PR DESCRIPTION
Different PR.
* `group: calculate remaining times to cycle more accurately` (Bugfix)
* `group: skip cycle on first run, use MAX_NO_CONTENT_WAIT` (Bugfix)
* Always get the first module on startup instead of 2nd, 3rd, etc. If first module is slow, then wait 5 seconds, then try again or move on to next module. (Enhancement) 

Addresses #1777.