### PR TITLE
formatter: add expand_color()

### DIFF
--- a/py3status/core.py
+++ b/py3status/core.py
@@ -15,8 +15,8 @@ from syslog import syslog, LOG_ERR, LOG_INFO, LOG_WARNING
 from traceback import extract_tb, format_tb, format_stack
 
 from py3status.command import CommandServer
-from py3status.constants import COLOR_NAMES
 from py3status.events import Events
+from py3status.formatter import expand_color
 from py3status.helpers import print_stderr
 from py3status.i3status import I3status
 from py3status.parse_config import process_config
@@ -160,20 +160,8 @@ class Common:
             # check py3status general section
             param = config["general"].get(attribute, self.none_setting)
         if param and (attribute == "color" or attribute.startswith("color_")):
-            if param[0] != "#":
-                # named color
-                param = COLOR_NAMES.get(param.lower(), self.none_setting)
-            elif len(param) == 4:
-                # This is a color like #123 convert it to #112233
-                param = (
-                    "#"
-                    + param[1]
-                    + param[1]
-                    + param[2]
-                    + param[2]
-                    + param[3]
-                    + param[3]
-                )
+            # check color value
+            param = expand_color(param.lower(), self.none_setting)
         return param
 
     def report_exception(self, msg, notify_user=True, level="error", error_frame=None):

--- a/py3status/py3.py
+++ b/py3status/py3.py
@@ -14,8 +14,7 @@ from time import time
 from uuid import uuid4
 
 from py3status import exceptions
-from py3status.constants import COLOR_NAMES
-from py3status.formatter import Formatter, Composite
+from py3status.formatter import Formatter, Composite, expand_color
 from py3status.request import HttpResponse
 from py3status.storage import Storage
 from py3status.util import Gradients
@@ -157,9 +156,13 @@ class Py3:
                 # use color "hidden" to hide blocks
                 if _name == "hidden":
                     param = "hidden"
+                # TODO: removing this statement does not fail "test_color_10()" but would fail
+                # easily in the bar. the test is there to raise awareness about this.
+                # TODO: "test_color_11()" shows how the tests can be incorrect as it does not print
+                # everything correctly (i.e. orange vs ORaNgE) due to non composite/formatter code.
                 elif hasattr(param, "none_setting"):
                     # see if named color and use if it is
-                    param = COLOR_NAMES.get(_name)
+                    param = expand_color(_name)
                 elif param is None:
                     param = self._none_color
             # if a non-color parameter and was not set then set to default
@@ -169,25 +172,10 @@ class Py3:
         return self._config_setting[name]
 
     def _get_color(self, color):
-        if not color:
-            return
-        # fix any hex colors so they are #RRGGBB
-        if color.startswith("#"):
-            color = color.upper()
-            if len(color) == 4:
-                color = (
-                    "#"
-                    + color[1]
-                    + color[1]
-                    + color[2]
-                    + color[2]
-                    + color[3]
-                    + color[3]
-                )
-            return color
-
-        name = "color_%s" % color
-        return self._get_config_setting(name)
+        if color:
+            if color[0] == "#":
+                return expand_color(color)
+            return self._get_config_setting("color_" + color)
 
     def _thresholds_init(self):
         """

--- a/tests/test_formatter.py
+++ b/tests/test_formatter.py
@@ -66,7 +66,7 @@ class Module:
 
     class py3:
         COLOR_BAD = "#FF0000"
-        COLOR_DEGRADED = "#FF00"
+        COLOR_DEGRADED = "#FFFF00"
         COLOR_GOOD = "#00FF00"
 
     def module_method(self):
@@ -839,6 +839,33 @@ def test_color_9a():
                 {"color": "#FF0000", "full_text": "LA 09:34"},
                 {"color": "#00FF00", "full_text": "NY 12:34"},
             ],
+        }
+    )
+
+
+def test_color_10():
+    # correct, but code is py3 instead of composite/formatter. same w/ color=hidden.
+    run_formatter(
+        {
+            "format": r"[\?color=None&show None][\?color=degraded&show degraded]",
+            "expected": [
+                {"full_text": "None"},
+                {"full_text": "degraded", "color": "#FFFF00"},
+            ],
+        }
+    )
+
+
+def test_color_11():
+    # one would say it's right, but maybe one would say it's wrong too.
+    run_formatter(
+        {
+            "format": r"[\?color=ORANGE&show orange] [\?color=bLuE&show blue]",
+            "expected": "orange blue",
+            # "expected": [
+            #     {"full_text": "orange", "color": "#FFA500"},
+            #     {"full_text": "blue", "color": "#0000FF"},
+            # ],
         }
     )
 


### PR DESCRIPTION
This aims to replace unrelated `fix_color` code in #1472. I found more things to use `expand_color` on too. This passed all the tests, but I see two instances where the tests can be wrong.

If you want to close this and #1472 instead, then that's fine too. Black star just in case.

Addresses #1472 unrelatedly.

EDIT: Do you like `expand_color` or something else? `get_color`? 