### PR TITLE
py3: support converting bytes to bits on format_units()

### DIFF
--- a/py3status/py3.py
+++ b/py3status/py3.py
@@ -375,6 +375,8 @@ class Py3:
                 si = len(unit) > 1 and unit[1] != "i"
                 if si:
                     post = post[1:]
+                    if unit[1] == "b":
+                        value *= 8
                 auto = False
             else:
                 index = 0


### PR DESCRIPTION
I tested this with:
```diff
diff --git a/py3status/modules/static_string.py b/py3status/modules/static_string.py
index 1cfbfed..aeca0fe 100644
--- a/py3status/modules/static_string.py
+++ b/py3status/modules/static_string.py
@@ -20,6 +20,7 @@ class Py3status:
     format = "Hello, world!"
 
     def static_string(self):
+        self.py3.log(self.py3.format_units(100, "Mb"))
         return {
             "cached_until": self.py3.CACHE_FOREVER,
             "full_text": self.py3.safe_format(self.format),

```
Before.
```
➜ python3 static_string.py 
Module `test_module`: (0.0001, 'Mb')
Module `test_module`: (0.0001, 'Mb')
```
After.
```                                                                                  
➜ python3 static_string.py
Module `test_module`: (0.0008, 'Mb')
Module `test_module`: (0.0008, 'Mb')
```
Conversion.
```
100 bytes to Mb... is... 100 Byte = 0.0008 Megabit
```

I didn't look into whole `format_units` code. This might be enough to solve an issue. Please review.

Addresses #1775.