### PR TITLE
keyboard_layout: xkblayout-state should prefer variant if available

### DIFF
--- a/py3status/modules/keyboard_layout.py
+++ b/py3status/modules/keyboard_layout.py
@@ -167,7 +167,7 @@ class Py3status:
     def _set_xkblayout(self):
         layout = self._layouts[self._active]
         layout_pos = (
-            self.py3.command_output(["xkblayout-state", "print", "%S"])
+            self.py3.command_output(["xkblayout-state", "print", "%E"])
             .split()
             .index(layout)
         )


### PR DESCRIPTION
Fixes #1794 

**Changes:**

- changes "xkblayout-state print %S" to "xkblayout-state print %E". This way the keyboard variant is returned if there is one set.