### PR TITLE
backlight module: a small fix to avoid 1% too low values

### DIFF
--- a/py3status/modules/backlight.py
+++ b/py3status/modules/backlight.py
@@ -154,7 +154,7 @@ class Py3status:
             brightness = int(brightness_line)
         for brightness_max_line in open("%s/max_brightness" % self.device, "rb"):
             brightness_max = int(brightness_max_line)
-        return brightness * 100 / brightness_max
+        return round(brightness * 100 / brightness_max)
 
     # Returns the string array for the command to get the current backlight level
     def _command_get(self):


### PR DESCRIPTION
When light is being used instead of xbacklight, it returns float values, like e.g. 19.99 instead of 20. It results in slightly strange and misleading output. As a newborn Sway user, I'd be grateful if you could merge this PR, or consider fixing the issue in some other way.

Best regards,
Piotr