### PR TITLE
arch_updates module: auracle throws exit code on zero updates

### DIFF
--- a/py3status/modules/arch_updates.py
+++ b/py3status/modules/arch_updates.py
@@ -84,8 +84,8 @@ class Py3status:
         try:
             updates = self.py3.command_output(["auracle", "sync"])
             return len(updates.splitlines())
-        except self.py3.CommandError:
-            return 0
+        except self.py3.CommandError as ce:
+            return None if ce.error else 0
 
     def _get_cower_updates(self):
         try:

--- a/py3status/modules/arch_updates.py
+++ b/py3status/modules/arch_updates.py
@@ -85,7 +85,7 @@ class Py3status:
             updates = self.py3.command_output(["auracle", "sync"])
             return len(updates.splitlines())
         except self.py3.CommandError:
-            return None
+            return 0
 
     def _get_cower_updates(self):
         try:


### PR DESCRIPTION
The bug manifests in the arch_updates module when no AUR updates found. The `auracle sync` command in such case returns exit status 1:

```
Command `auracle sync` returned non-zero exit status 1
```
Instead of returning 0 as the result of `len(updates.splitlines())`, the exception code is being executed, that results in strange display like "UPD: 0/None" for default format.

![image](https://user-images.githubusercontent.com/20579136/58138875-78e81800-7c38-11e9-8ecf-5a49f26780ae.png)

As a simple workaround, I propose returning 0 instead of None.