### PR TITLE
Fix logo url in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,4 +1,4 @@
-.. image:: https://github.com/Tobaloidee/py3status/blob/master/logo/logotype-horizontal.png
+.. image:: https://github.com/ultrabug/py3status/blob/master/logo/logotype-horizontal.png
 *********
 py3status
 *********


### PR DESCRIPTION
Changed the logo URL in the README to point to the main repo and not Tobaloidee's fork, in case the fork gets deleted in the future.