### PR TITLE
formatter: revision 1

### DIFF
--- a/py3status/formatter.py
+++ b/py3status/formatter.py
@@ -17,22 +17,25 @@ except ImportError:
 python2 = sys.version_info < (3, 0)
 
 
-def expand_color(color, default=None, passthrough=False):
+def expand_color(color, default=None, passthrough=False, block=None):
     """
     Expand various colors to #RRGGBB.
     """
-    if color and color[0] == "#":
-        color = color[1:]
-        try:
-            int(color, 16)
-        except ValueError:
-            return
-        length = len(color)
-        if length in [3, 4]:
-            color = "".join(color[x] * 2 for x in range(length))
-        elif length not in [6, 8]:
-            return
-        return "#" + color.upper()
+    if color:
+        if color[0] == "#":
+            color = color[1:]
+            try:
+                int(color, 16)
+            except ValueError:
+                return block
+            length = len(color)
+            if length in [3, 4]:
+                color = "".join(color[x] * 2 for x in range(length))
+            elif length not in [6, 8]:
+                return block
+            return "#" + color.upper()
+    elif block:
+        return block
     return COLOR_NAMES.get(color, color if passthrough else default)
 
 
@@ -509,7 +512,9 @@ class BlockConfig:
             self._if = Condition(_if)
         self._set_int(commands, "max_length")
         self._set_int(commands, "min_length")
-        self.color = expand_color(commands.get("color"), passthrough=True)
+        self.color = expand_color(
+            commands.get("color"), passthrough=True, block=self.color
+        )
 
         self.not_zero = "not_zero" in commands or self.not_zero
         self.show = "show" in commands or self.show

--- a/tests/test_formatter.py
+++ b/tests/test_formatter.py
@@ -861,11 +861,22 @@ def test_color_11():
     run_formatter(
         {
             "format": r"[\?color=ORANGE&show orange] [\?color=bLuE&show blue]",
-            "expected": "orange blue",
+            "expected": "orange blue",  # wrong imho
             # "expected": [
             #     {"full_text": "orange", "color": "#FFA500"},
             #     {"full_text": "blue", "color": "#0000FF"},
             # ],
+        }
+    )
+
+
+def test_color_12():
+    run_formatter(
+        {
+            "color_test": "#FFA500",
+            "format": r"\?color=test test",
+            "expected": "test",  # wrong
+            # "expected": [{"full_text": "test", "color": "#FFA500"}]
         }
     )
 


### PR DESCRIPTION
This adds `self.color` to `expand_color` used in the `formatter`. Originally not included because I thought it was redundant. You can see conky example below already working okay on `master`, but not in @ultrabug's `color_time` for `google_calendar`. Huh...

```python
order += "conky info"
conky info {
    format = '[\?color=title&show OS] [\?color=output {distribution}] '
    format += '[\?color=title&show CPU] [\?color=output {cpu cpu0}%] '
    format += '[\?color=title&show MEM] '
    format += '[\?color=output {mem}/{memmax} ({memperc}%)] '
    format += '[\?color=title&show HDD] [\?color=output {fs_used_perc}%] '
    format += '[\?color=title&show Kernel] [\?color=output {kernel}] '
    format += '[\?color=title&show Loadavg] [\?color=output {loadavg 1}] '
    format += '[\?color=title&show Uptime] [\?color=output {uptime}] '
    format += '[\?color=title&show Freq GHZ] [\?color=output {freq_g}]'
    color_title = '#ffffff'
    color_output = '#00bfff'
}
```

Addresses https://github.com/ultrabug/py3status/commit/86b62726303ec7accbdd1cf86d389c16c80ed757#comments