### PR TITLE
Add `paused` control placeholder to spotify module

### DIFF
--- a/py3status/modules/spotify.py
+++ b/py3status/modules/spotify.py
@@ -166,7 +166,13 @@ class Py3status:
             return (
                 self.py3.safe_format(
                     self.format,
-                    dict(title=title, artist=artist, album=album, time=rtime, paused=paused),
+                    dict(
+                        title=title,
+                        artist=artist,
+                        album=album,
+                        time=rtime,
+                        paused=paused,
+                    ),
                 ),
                 color,
             )

--- a/py3status/modules/spotify.py
+++ b/py3status/modules/spotify.py
@@ -18,6 +18,9 @@ Configuration parameters:
         *(default ['bonus', 'demo', 'edit', 'explicit', 'extended',
             'feat', 'mono', 'remaster', 'stereo', 'version'])*
 
+Control placeholders:
+    {paused} true when Spotify is paused
+
 Format placeholders:
     {album} album name
     {artist} artiste name (first one)
@@ -55,11 +58,11 @@ stopped
 {'color': '#FF0000', 'full_text': 'Spotify stopped'}
 """
 
-import dbus
 import re
-
 from datetime import timedelta
 from time import sleep
+
+import dbus
 
 SPOTIFY_CMD = """dbus-send --print-reply --dest=org.mpris.MediaPlayer2.spotify
                  /org/mpris/MediaPlayer2 org.mpris.MediaPlayer2.Player.{cmd}"""
@@ -150,8 +153,10 @@ class Py3status:
                 )
                 if playback_status.strip() == "Playing":
                     color = self.py3.COLOR_PLAYING or self.py3.COLOR_GOOD
+                    paused = False
                 else:
                     color = self.py3.COLOR_PAUSED or self.py3.COLOR_DEGRADED
+                    paused = True
             except Exception:
                 return (
                     self.format_stopped,
@@ -161,7 +166,7 @@ class Py3status:
             return (
                 self.py3.safe_format(
                     self.format,
-                    dict(title=title, artist=artist, album=album, time=rtime),
+                    dict(title=title, artist=artist, album=album, time=rtime, paused=paused),
                 ),
                 color,
             )

--- a/py3status/modules/spotify.py
+++ b/py3status/modules/spotify.py
@@ -18,12 +18,10 @@ Configuration parameters:
         *(default ['bonus', 'demo', 'edit', 'explicit', 'extended',
             'feat', 'mono', 'remaster', 'stereo', 'version'])*
 
-Control placeholders:
-    {paused} true when Spotify is paused
-
 Format placeholders:
     {album} album name
     {artist} artiste name (first one)
+    {state} state of the player: playing, paused, stopped
     {time} time duration of the song
     {title} name of the song
 
@@ -153,13 +151,13 @@ class Py3status:
                 )
                 if playback_status.strip() == "Playing":
                     color = self.py3.COLOR_PLAYING or self.py3.COLOR_GOOD
-                    paused = False
+                    state = "playing"
                 else:
                     color = self.py3.COLOR_PAUSED or self.py3.COLOR_DEGRADED
-                    paused = True
+                    state = "paused"
             except Exception:
                 return (
-                    self.format_stopped,
+                    self.py3.safe_format(self.format_stopped, dict(state="stopped")),
                     self.py3.COLOR_PAUSED or self.py3.COLOR_DEGRADED,
                 )
 
@@ -167,11 +165,7 @@ class Py3status:
                 self.py3.safe_format(
                     self.format,
                     dict(
-                        title=title,
-                        artist=artist,
-                        album=album,
-                        time=rtime,
-                        paused=paused,
+                        title=title, artist=artist, album=album, time=rtime, state=state
                     ),
                 ),
                 color,

--- a/py3status/modules/spotify.py
+++ b/py3status/modules/spotify.py
@@ -21,7 +21,7 @@ Configuration parameters:
 Format placeholders:
     {album} album name
     {artist} artiste name (first one)
-    {state} state of the player: playing, paused, stopped
+    {playback} state of the playback: Playing, Paused
     {time} time duration of the song
     {title} name of the song
 
@@ -149,15 +149,13 @@ class Py3status:
                 playback_status = self.player.Get(
                     "org.mpris.MediaPlayer2.Player", "PlaybackStatus"
                 )
-                if playback_status.strip() == "Playing":
+                if playback_status == "Playing":
                     color = self.py3.COLOR_PLAYING or self.py3.COLOR_GOOD
-                    state = "playing"
                 else:
                     color = self.py3.COLOR_PAUSED or self.py3.COLOR_DEGRADED
-                    state = "paused"
             except Exception:
                 return (
-                    self.py3.safe_format(self.format_stopped, dict(state="stopped")),
+                    self.format_stopped,
                     self.py3.COLOR_PAUSED or self.py3.COLOR_DEGRADED,
                 )
 
@@ -165,7 +163,11 @@ class Py3status:
                 self.py3.safe_format(
                     self.format,
                     dict(
-                        title=title, artist=artist, album=album, time=rtime, state=state
+                        title=title,
+                        artist=artist,
+                        album=album,
+                        time=rtime,
+                        playback=playback_status,
                     ),
                 ),
                 color,


### PR DESCRIPTION
I've been bothered for a pretty long time now that module for music player doesn't have an option to show whether the music is actually playing. I hope someone will find this little change as useful as I do.