### PR TITLE
mpris module: fix KeyError exception

### DIFF
--- a/py3status/modules/mpris.py
+++ b/py3status/modules/mpris.py
@@ -394,7 +394,10 @@ class Py3status:
         if not player_id.startswith(SERVICE_BUS):
             return False
 
-        player = self._dbus.get(player_id, SERVICE_BUS_URL)
+        try:
+            player = self._dbus.get(player_id, SERVICE_BUS_URL)
+        except KeyError:
+            return False
 
         if player.Identity not in self._mpris_names:
             self._mpris_names[player.Identity] = player_id.split(".")[-1]


### PR DESCRIPTION
Use try/except to return `False` on failed player objects instead of maintaining a list (i.e. `chrome`, `chromium`, etc).  /cc @valdur55

Addresses https://github.com/ultrabug/py3status/issues/1827
