### PR TITLE
Mpris module: Fix AttributeError: 'MockPy3statusWrapper' object has no attribute 'is_gevent'

### DIFF
--- a/py3status/module_test.py
+++ b/py3status/module_test.py
@@ -34,6 +34,7 @@ class MockPy3statusWrapper:
         self.lock = Event()
         self.output_modules = {}
         self.running = True
+        self.is_gevent = False
 
         self.lock.set()
 


### PR DESCRIPTION
Mpris module uses is_gevent but module_test doesn''t have such attribute.

Addresses #1827