### PR TITLE
wifi module: fix bug introduced in PR #1834

### DIFF
--- a/py3status/modules/wifi.py
+++ b/py3status/modules/wifi.py
@@ -109,6 +109,8 @@ class Py3status:
             raise Exception(ce.error.strip())
         last_device = None
         for line in data.splitlines()[1:]:
+            if not line.startswith("\t\t"):
+                last_device = None
             if "Interface" in line or ("addr" in line and last_device is not None):
                 intf_or_addr = line.split()[-1]
                 if "Interface" in line:


### PR DESCRIPTION
@X-dark mentioned he saw a regression with automatic device detection due to #1834. Seems to be due to slightly unusual output from `iw dev`:

```
phy#0
	Unnamed/non-netdev interface
		wdev 0x4
		addr e4:xx:xx
		type P2P-device
		txpower 0.00 dBm
	Interface wlan0
		ifindex 3
		wdev 0x1
		addr e4:xx:xx
		ssid xxxx
		type managed
		channel 48 (5240 MHz), width: 20 MHz, center1: 5240 MHz
		txpower 17.00 dBm
		multicast TXQ:
			qsz-byt	qsz-pkt	flows	drops	marks	overlmt	hashcol	tx-bytes	tx-packets
			0	0	0	0	0	0	0	0		0
```
Ignoring non `Interface` devices should fix it.