### PR TITLE
sysdata : Prevent a divide by zero on empty swap

### DIFF
--- a/py3status/modules/sysdata.py
+++ b/py3status/modules/sysdata.py
@@ -330,7 +330,10 @@ class Py3status:
             total_mem_kib = meminfo["SwapTotal:"]
             used_mem_kib = total_mem_kib - meminfo["SwapFree:"]
 
-        used_percent = 100 * used_mem_kib / total_mem_kib
+        if total_mem_kib == 0:
+            used_percent = 0
+        else:
+            used_percent = 100 * used_mem_kib / total_mem_kib
 
         unit = "B" if unit == "dynamic" else unit
         (total, total_unit) = self.py3.format_units(total_mem_kib * 1024, unit)


### PR DESCRIPTION
In some case the swap memory on a machine is available at a time and not available at another (for example if you plug your swap on a removable device...).
So I've notice that in that case, the sysdata module fail with a "divide by zero" exception.

This PR propose a fix to this.

Feel free to make any feedbacks