### PR TITLE
implement global request_retry_times and request_retry_wait options

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -937,8 +937,13 @@ an event
     by all package managers.
 
 
-Request Timeout
+Request Settings
 --------------------------------------------------------------
+
+Handling timeouts
+^^^^^^^^^^^^^^^^^
+
+Timeouts are handled thanks to the global ``request_timeout`` setting.
 
 .. note::
     New in version 3.16
@@ -956,8 +961,11 @@ module configuration. To find out if your module supports that, look for
     }
 
 
-Retrying Requests
---------------------------------------------------------------
+Handling retries
+^^^^^^^^^^^^^^^^
+
+Retries are handled thanks to the global ``request_retry_times`` and
+``request_retry_wait`` settings.
 
 .. note::
     New in version 3.21
@@ -978,7 +986,7 @@ code.
     # try to contact the OWM API 10 times every 5 seconds before displaying
     # an error on the bar for the module
     # that is equivalent to 50 seconds of retrying before an error occurs
-    weather_own {
+    weather_owm {
         request_retry_times = 10
         request_retry_wait = 5
     }

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -954,3 +954,31 @@ module configuration. To find out if your module supports that, look for
     exchange_rate {
         request_timeout = 10
     }
+
+
+Retrying Requests
+--------------------------------------------------------------
+
+.. note::
+    New in version 3.20
+
+Requests failing due to network unavailability or remote server timeouts are
+retried automatically ``request_retry_times`` times (default ``3``) at a
+``request_retry_wait`` (default ``2``) seconds interval.
+
+This allows to be more graceful to i3 startup when network is not up yet or to
+short network disruptions and not display an error on the bar in that case.
+
+To find out if your module supports that, look for ``self.py3.request`` in the
+code.
+
+.. code-block:: py3status
+    :caption: Example
+
+    # try to contact the OWM API 10 times every 5 seconds before displaying
+    # an error on the bar for the module
+    # that is equivalent to 50 seconds of retrying before an error occurs
+    weather_own {
+        request_retry_times = 10
+        request_retry_wait = 5
+    }

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -960,7 +960,7 @@ Retrying Requests
 --------------------------------------------------------------
 
 .. note::
-    New in version 3.20
+    New in version 3.21
 
 Requests failing due to network unavailability or remote server timeouts are
 retried automatically ``request_retry_times`` times (default ``3``) at a

--- a/py3status/py3.py
+++ b/py3status/py3.py
@@ -1300,16 +1300,21 @@ class Py3:
         if "User-Agent" not in headers:
             headers["User-Agent"] = "py3status/{} {}".format(version, self._uid)
 
-        for n in range(1, retry_times + 1):
+        def get_http_response(url, params, data, headers, timeout, auth, cookiejar):
+            return HttpResponse(
+                url,
+                params=params,
+                data=data,
+                headers=headers,
+                timeout=timeout,
+                auth=auth,
+                cookiejar=cookiejar,
+            )
+
+        for n in range(1, retry_times):
             try:
-                return HttpResponse(
-                    url,
-                    params=params,
-                    data=data,
-                    headers=headers,
-                    timeout=timeout,
-                    auth=auth,
-                    cookiejar=cookiejar,
+                return get_http_response(
+                    url, params, data, headers, timeout, auth, cookiejar
                 )
             except (self.RequestTimeout, self.RequestURLError):
                 self.log("HTTP request retry {}/{}".format(n, retry_times))
@@ -1318,3 +1323,5 @@ class Py3:
                 else:
                     from time import sleep
                 sleep(retry_wait)
+        self.log("HTTP request retry {}/{}".format(retry_times, retry_times))
+        return get_http_response(url, params, data, headers, timeout, auth, cookiejar)

--- a/py3status/py3.py
+++ b/py3status/py3.py
@@ -1317,11 +1317,11 @@ class Py3:
             try:
                 return get_http_response()
             except (self.RequestTimeout, self.RequestURLError):
-                self.log("HTTP request retry {}/{}".format(n, retry_times))
                 if self.is_gevent():
                     from gevent import sleep
                 else:
                     from time import sleep
+                self.log("HTTP request retry {}/{}".format(n, retry_times))
                 sleep(retry_wait)
         self.log("HTTP request retry {}/{}".format(retry_times, retry_times))
         sleep(retry_wait)

--- a/py3status/py3.py
+++ b/py3status/py3.py
@@ -1324,4 +1324,5 @@ class Py3:
                     from time import sleep
                 sleep(retry_wait)
         self.log("HTTP request retry {}/{}".format(retry_times, retry_times))
+        sleep(retry_wait)
         return get_http_response()

--- a/py3status/py3.py
+++ b/py3status/py3.py
@@ -1272,6 +1272,8 @@ class Py3:
         :param timeout: timeout for the request in seconds
         :param auth: authentication info as tuple `(username, password)`
         :param cookiejar: an object of a CookieJar subclass
+        :param retry_times: how many times to retry the request
+        :param retry_wait: how long to wait between retries in seconds
 
         :returns: HttpResponse
         """
@@ -1300,7 +1302,7 @@ class Py3:
         if "User-Agent" not in headers:
             headers["User-Agent"] = "py3status/{} {}".format(version, self._uid)
 
-        def get_http_response(url, params, data, headers, timeout, auth, cookiejar):
+        def get_http_response():
             return HttpResponse(
                 url,
                 params=params,
@@ -1313,9 +1315,7 @@ class Py3:
 
         for n in range(1, retry_times):
             try:
-                return get_http_response(
-                    url, params, data, headers, timeout, auth, cookiejar
-                )
+                return get_http_response()
             except (self.RequestTimeout, self.RequestURLError):
                 self.log("HTTP request retry {}/{}".format(n, retry_times))
                 if self.is_gevent():
@@ -1324,4 +1324,4 @@ class Py3:
                     from time import sleep
                 sleep(retry_wait)
         self.log("HTTP request retry {}/{}".format(retry_times, retry_times))
-        return get_http_response(url, params, data, headers, timeout, auth, cookiejar)
+        return get_http_response()


### PR DESCRIPTION
Requests failing due to network unavailability or remote server timeouts are
retried automatically ``request_retry_times`` times (default ``3``) at a
``request_retry_wait`` (default ``2``) seconds interval.

This allows to be more graceful to i3 startup when network is not up yet or to
short network disruptions and not display an error on the bar in that case.

This is related to the MR #1842 inspired by the work of @jose1711