### PR TITLE
Fix compatibility to checkupates update

### DIFF
--- a/py3status/modules/arch_updates.py
+++ b/py3status/modules/arch_updates.py
@@ -78,8 +78,8 @@ class Py3status:
         try:
             updates = self.py3.command_output(["checkupdates"])
             return len(updates.splitlines())
-        except self.py3.CommandError:
-            return None
+        except self.py3.CommandError as ce:
+            return None if ce.error else 0
 
     def _get_auracle_updates(self):
         try:


### PR DESCRIPTION
After the most recent update to the checkupdates script, the _get_checkupdates_updates method requires a change, similar to the _get_auracle_updates.

Without this, is simply return 'None' instead of 0 when there are no updates.