### PR TITLE
usbguard: update for versioned dbus in 0.7.5

### DIFF
--- a/py3status/modules/usbguard.py
+++ b/py3status/modules/usbguard.py
@@ -90,15 +90,15 @@ class Py3status:
             self.bus,
             Gio.DBusProxyFlags.NONE,
             None,
-            "org.usbguard",
-            "/org/usbguard/Devices",
-            "org.usbguard.Devices",
+            "org.usbguard1",
+            "/org/usbguard1/Devices",
+            "org.usbguard.Devices1",
             None,
         )
         for signal in ["DevicePolicyChanged", "DevicePresenceChanged"]:
             self.bus.signal_subscribe(
                 None,
-                "org.usbguard.Devices",
+                "org.usbguard.Devices1",
                 signal,
                 None,
                 None,


### PR DESCRIPTION
usbguard v0.7.5 made a breaking change and switched to [versioned dbus](https://github.com/USBGuard/usbguard/pull/302), this PR adapts our module for these changes.