### PR TITLE
module_test: support config cli arguments

### DIFF
--- a/py3status/module_test.py
+++ b/py3status/module_test.py
@@ -1,3 +1,4 @@
+from ast import literal_eval
 from sys import argv
 from threading import Event
 from time import sleep, time
@@ -61,6 +62,20 @@ def module_test(module_class, config=None):
     if not config:
         config = {}
 
+    # config cli arguments
+    arguments, term = argv[1:], False
+    for index, arg in enumerate(arguments):
+        if "--term" in arg:
+            term = True
+        elif arg[0:2] == "--":
+            key = arguments[index][2:]
+            value = arguments[index + 1]
+            try:
+                value = literal_eval(value)
+            except (SyntaxError, ValueError):
+                pass
+            config[key] = value
+
     py3_config = {
         "general": {
             "color_bad": "#FF0000",
@@ -91,7 +106,7 @@ def module_test(module_class, config=None):
                 if "name" in item:
                     del item["name"]
 
-            if "--term" in argv:
+            if term:
                 line = "\033[0m"
                 for item in output:
                     if item.get("urgent"):

--- a/py3status/modules/scratchpad.py
+++ b/py3status/modules/scratchpad.py
@@ -195,5 +195,4 @@ if __name__ == "__main__":
     from py3status.module_test import module_test
 
     config = {"format": "\[{ipc}\] [\?color=scratchpad {scratchpad}]"}
-
     module_test(Py3status, config=config)

--- a/py3status/modules/window.py
+++ b/py3status/modules/window.py
@@ -209,17 +209,9 @@ class Py3status:
 
 if __name__ == "__main__":
     """
-    Specify --ipc [i3ipc|i3msg|swaymsg].
-    """
-    from sys import argv
-
-    config = {"format": "\[{ipc}\] [\?color=pink {title}]"}
-    for index, arg in enumerate(argv):
-        if "--ipc" in arg:
-            config["ipc"] = argv[index + 1]
-    """
     Run module in test mode.
     """
     from py3status.module_test import module_test
 
+    config = {"format": "\[{ipc}\] [\?color=pink {title}]"}
     module_test(Py3status, config=config)


### PR DESCRIPTION
This permits us to use cli arguments to test different configs for easier testing in terminal.

```bash
# Test different ipcs.
$ python scratchpad.py --term --ipc [i3ipc|i3msg|swaymsg] 
$ python window.py --term --ipc [i3ipc|i3msg|swaymsg]

# Test different placeholders.
$ python loadavg.py --term --format "Testing format... [\?color=1avg {1min}], {5min}, {15min}"

# Test a random config without touching a module or config.
$ python xrandr.py --term --icon_extend "|"

# Test a module requiring a key without touching or exporting anything.
$ python weather_owm.py --term --api_key LONG_API_KEY
```

This replaces a small testing code in ~~`scratchpad`~~ `window` too. 