### PR TITLE
window: get nodes or empty lists

### DIFF
--- a/py3status/modules/window.py
+++ b/py3status/modules/window.py
@@ -157,7 +157,7 @@ class Msg(Ipc):
                 if res:
                     return res
         elif isinstance(tree, dict):
-            nodes = tree["nodes"] + tree["floating_nodes"]
+            nodes = tree.get("nodes", []) + tree.get("floating_nodes", [])
             if focused:
                 for node in nodes:
                     if node["id"] == focused["id"]:

--- a/py3status/modules/window.py
+++ b/py3status/modules/window.py
@@ -97,12 +97,12 @@ class I3ipc(Ipc):
                     and len(focused.parent.nodes) > 1
                 )
             ):
-                focused.window_title = None
+                focused.name = None
         self.update(focused)
 
     def update(self, window_properties):
         window_properties = {
-            "title": window_properties.window_title,
+            "title": window_properties.name,
             "class": window_properties.window_class,
             "instance": window_properties.window_instance,
         }


### PR DESCRIPTION
This fixes second output issue in https://github.com/ultrabug/py3status/pull/1854#issuecomment-549896144

When making `window`, I tested with `swaymsg -t get_tree` on i3. I take it `swaymsg -t get_tree` does not output 100% same on sway due to missing `nodes` key and maybe others.

This PR is tested okay on default sway. `hide_title` works okay too.

The first output issue (missing/no title) looks unrelated imho.