### PR TITLE
spaceapi: fix offline attributeerror exception

### DIFF
--- a/py3status/modules/spaceapi.py
+++ b/py3status/modules/spaceapi.py
@@ -86,6 +86,7 @@ class Py3status:
         self.button_refresh = 2
         self.color_open = self.py3.COLOR_OPEN or self.py3.COLOR_GOOD
         self.color_closed = self.py3.COLOR_CLOSED or self.py3.COLOR_BAD
+        self.hackerspace_url = None
 
     def spaceapi(self):
         color = self.color_closed
@@ -94,7 +95,6 @@ class Py3status:
 
         try:
             data = self.py3.request(self.url).json()
-            self._url = data.get("url")
 
             if data["state"]["open"]:
                 color = self.color_open
@@ -113,6 +113,9 @@ class Py3status:
 
         except (self.py3.RequestException, KeyError):
             full_text = STRING_UNAVAILABLE
+            data = {}
+
+        self.hackerspace_url = data.get("url")
 
         return {
             "cached_until": self.py3.time_in(self.cache_timeout),
@@ -122,10 +125,10 @@ class Py3status:
 
     def on_click(self, event):
         button = event["button"]
-        if self._url and self.button_url == button:
-            self.py3.command_run("xdg-open {}".format(self._url))
-            self.py3.prevent_refresh()
-        elif button != self.button_refresh:
+        if button == self.button_url:
+            if self.hackerspace_url:
+                self.py3.command_run("xdg-open {}".format(self.hackerspace_url))
+        if button != self.button_refresh:
             self.py3.prevent_refresh()
 
 


### PR DESCRIPTION
If you are offline, clicking `spaceapi: N/A` produces this because of missing `_url`.

```python
2019-12-12 INFO trying to dispatch event to module "spaceapi"
2019-12-12 WARNING on_click event in `spaceapi` failed (AttributeError) spaceapi.py line 125.
2019-12-12 INFO Traceback
AttributeError: 'Py3status' object has no attribute '_url'
  File "py3status/module.py", line 901, in click_event
    click_method(event)
  File "py3status/modules/spaceapi.py", line 125, in on_click
    if self._url and self.button_url == button:
```

EDIT: And.... if you got an `_url` and go offline later, it should not open url again.
EDIT 2: It'd be nice to kill try/exception, `STRING_UNAVAILABLE`, etc in favor of exposing real error.