### PR TITLE
Fix tests for python 3.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,10 @@ python:
   - "3.4"
   - "3.5"
   - "3.6"
+  - "3.7"
 matrix:
   include:
-    - python: "3.7"
+    - python: "3.8"
       dist: xenial
       sudo: true
 install:

--- a/setup.py
+++ b/setup.py
@@ -62,6 +62,7 @@ setup(
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
         "Topic :: Software Development :: Libraries :: Python Modules",
     ],
 )

--- a/tests/test_module_doc.py
+++ b/tests/test_module_doc.py
@@ -33,7 +33,12 @@ OBSOLETE_PARAM = []
 
 RE_PARAM = re.compile(r"^  - `(?P<name>[^`]*)`.*?(\*\(default (?P<value>(.*))\)\*)?$")
 
-AST_LITERAL_TYPES = {"Num": "n", "Str": "s", "NameConstant": "value", "Constant": "value"}
+AST_LITERAL_TYPES = {
+    "Num": "n",
+    "Str": "s",
+    "NameConstant": "value",
+    "Constant": "value",
+}
 
 MODULE_PATH = os.path.join(
     os.path.dirname(os.path.abspath(__file__)), "..", "py3status", "modules"

--- a/tests/test_module_doc.py
+++ b/tests/test_module_doc.py
@@ -33,7 +33,7 @@ OBSOLETE_PARAM = []
 
 RE_PARAM = re.compile(r"^  - `(?P<name>[^`]*)`.*?(\*\(default (?P<value>(.*))\)\*)?$")
 
-AST_LITERAL_TYPES = {"Num": "n", "Str": "s", "NameConstant": "value"}
+AST_LITERAL_TYPES = {"Num": "n", "Str": "s", "NameConstant": "value", "Constant": "value"}
 
 MODULE_PATH = os.path.join(
     os.path.dirname(os.path.abspath(__file__)), "..", "py3status", "modules"


### PR DESCRIPTION
Finally had time to figure out why unit tests have been failing for me on Arch since the last release, but Travis was green.

https://docs.python.org/3/library/ast.html

> Deprecated since version 3.8: Class ast.Constant is now used for all constants.
Old classes ast.Num, ast.Str, ast.Bytes, ast.NameConstant and ast.Ellipsis are still available, but they will be removed in future Python releases.

Adding python 3.8 to testing matrix