### PR TITLE
imap module: implement retry logic (works around badly configured mail servers)

### DIFF
--- a/py3status/modules/imap.py
+++ b/py3status/modules/imap.py
@@ -258,7 +258,7 @@ class Py3status:
             except socket_error:
                 raise imaplib.IMAP4.abort("Server didn't respond to 'IDLE' in time")
             if not response.lower().startswith("+ idling"):
-                raise imaplib.IMAP4.abort("While initializing IDLE: " + str(response))
+                raise imaplib.IMAP4.abort("While initializing IDLE: {}".format(response))
 
             # wait for changes (EXISTS, EXPUNGE, etc.):
             socket.settimeout(self.cache_timeout)
@@ -306,7 +306,7 @@ class Py3status:
                 if self.connection.state == "NONAUTH":
                     if self.client_secret:
                         # Authenticate using OAUTH
-                        auth_string = "user=%s\1auth=Bearer %s\1\1" % (
+                        auth_string = "user={}\1auth=Bearer {}\1\1".format(
                             self.user,
                             self.creds.token,
                         )
@@ -335,7 +335,7 @@ class Py3status:
         except (socket_error, imaplib.IMAP4.abort, imaplib.IMAP4.readonly) as e:
             if self.debug:
                 self.py3.log(
-                    "Recoverable error - " + str(e), level=self.py3.LOG_WARNING
+                    "Recoverable error - {}".format(e), level=self.py3.LOG_WARNING
                 )
             self._disconnect()
 
@@ -346,7 +346,7 @@ class Py3status:
                 continue
             break
         except (imaplib.IMAP4.error, Exception) as e:
-            self.mail_error = "Fatal error - " + str(e)
+            self.mail_error = "Fatal error - {}".format(e)
             self._disconnect()
             self.mail_count = None
 


### PR DESCRIPTION
This implements some changes I've had running for over a year now, but never had the time to clean up and submit here (partly, because I've finally completed the move to a better mail host).

In essence, some mail providers (cough, cough, yahoo, cough) are just plain awful at keeping connections (automatic logout after a few minutes of not issuing a command,  randomly just refusing to log in, ...). This implements a fail-safe retry logic (retry two times, then error out).

I've opted to not expose the retry count and delay to the user, since configuring this doesn't make much of a difference, but I'm open to changes.

while I was at it, I also opted to refactor the long log messages to use String.format() instead of string concatenation. It makes sense to look at each commit on its own, since the last one adds a lot of noise due to the reformatting. Feel free to squash the commits on merging. 