### PR TITLE
Improvements to handling and indication of recoverable errors

### DIFF
--- a/py3status/modules/imap.py
+++ b/py3status/modules/imap.py
@@ -120,6 +120,11 @@ class Py3status:
             0  # IMAPcommands are tagged, so responses can be matched up to requests
         )
         self.idle_thread = Thread()
+        self.recoverable_errors = [
+            socket_error,
+            imaplib.IMAP4.abort,
+            imaplib.IMAP4.readonly,
+        ]
 
         if self.client_secret:
             self.client_secret = os.path.expanduser(self.client_secret)
@@ -329,7 +334,7 @@ class Py3status:
                     self._idle()
                 else:
                     return
-        except (socket_error, imaplib.IMAP4.abort, imaplib.IMAP4.readonly) as e:
+        except tuple(self.recoverable_errors) as e:
             if self.debug:
                 self.py3.log(
                     "Recoverable error - " + str(e), level=self.py3.LOG_WARNING

--- a/py3status/modules/imap.py
+++ b/py3status/modules/imap.py
@@ -182,7 +182,11 @@ class Py3status:
     def _get_creds(self):
         from google_auth_oauthlib.flow import InstalledAppFlow
         from google.auth.transport.requests import Request
+        from google.auth.exceptions import TransportError
         import pickle
+
+        # Add recoverable errors that could be thrown by auth module
+        self.recoverable_errors += [TransportError]
 
         self.creds = None
 


### PR DESCRIPTION
These commits make three separate changes relating to the handling of recoverable exceptions.

### Background
The imap module treats some errors as recoverable rather than fatal. When these errors occur, the module will keep trying to check mail. Currently there is no indication that there has been a problem retrieving the mail count, and the module continues showing the last count.

### Changes in this PR
1) Maintain a list of recoverable exceptions so that it can be adjusted according to how the module is configured
2) Add a recoverable exception that is only thrown when using OAuth
3) Color the module output as *degraded* when a recoverable error means that the mail count is no longer necessarily up to date