### PR TITLE
mpd_status using idle (major cpu savings)

### DIFF
--- a/py3status/modules/mpd_status.py
+++ b/py3status/modules/mpd_status.py
@@ -254,14 +254,14 @@ class Py3status:
             except (ValueError, socket.error, ConnectionError, CommandError) as e:
                 # ValueError can happen when status.get(...) returns None; e.g.
                 # during reversal of playlist
-                if type(e) is ValueError:
+                if isinstance(e, ValueError):
                     text = "No song information!"
-                if type(e) is socket.error:
+                if isinstance(e, socket.error):
                     text = "Failed to connect to mpd!"
-                if type(e) is ConnectionError:
+                if isinstance(e, ConnectionError):
                     text = "Error while connecting to mpd!"
                     self._get_mpd(disconnect=True)
-                if type(e) is CommandError:
+                if isinstance(e, CommandError):
                     text = "Failed to authenticate to mpd!"
                     self._get_mpd(disconnect=True)
 

--- a/py3status/modules/mpd_status.py
+++ b/py3status/modules/mpd_status.py
@@ -10,12 +10,21 @@ Configuration parameters:
     hide_when_paused: hide the status if state is paused (default False)
     hide_when_stopped: hide the status if state is stopped (default True)
     host: mpd host (default 'localhost')
+    idle_subsystems: a space seperated string of subsystems to idle on.
+        player: changes in song information, play state
+        mixer: changes in volume
+        options: e.g. repeat mode
+        See the MPD protocol documentation for additional events.
+        (default 'player mixer options')
+    idle_timeout: force idle to reset every n seconds (default 3600)
     max_width: maximum status length (default 120)
     password: mpd password (default None)
     port: mpd port (default '6600')
     state_pause: label to display for "paused" state (default '[pause]')
     state_play: label to display for "playing" state (default '[play]')
     state_stop: label to display for "stopped" state (default '[stop]')
+    use_idle: whether to use idling instead of polling. None to autodetect
+        (default None)
 
 Format placeholders:
     {state} state (paused, playing. stopped) can be defined via `state_..`
@@ -62,6 +71,8 @@ import re
 import socket
 from py3status.composite import Composite
 from mpd import MPDClient, CommandError, ConnectionError
+from threading import Thread
+from time import sleep
 
 
 def song_attr(song, attr):
@@ -101,14 +112,20 @@ class Py3status:
     hide_when_paused = False
     hide_when_stopped = True
     host = "localhost"
+    idle_subsystems = "player mixer options"
+    idle_timeout = 3600
     max_width = 120
     password = None
     port = "6600"
     state_pause = "[pause]"
     state_play = "[play]"
     state_stop = "[stop]"
+    use_idle = None
 
     def post_config_hook(self):
+        # class variables:
+        self.current_status = None
+        self.idle_thread = Thread()
         # Convert from %placeholder% to {placeholder}
         # This is not perfect but should be good enough
         if not self.py3.get_placeholders_list(self.format) and "%" in self.format:
@@ -131,6 +148,10 @@ class Py3status:
                 self.client.connect(host=self.host, port=self.port)
                 if self.password:
                     self.client.password(self.password)
+                if self.use_idle is None:
+                    self.use_idle = "idle" in self.client.commands()
+                if self.use_idle and self.idle_timeout:
+                    self.client.idletimeout = self.idle_timeout
             return self.client
         except (socket.error, ConnectionError, CommandError) as e:
             self.client = None
@@ -146,6 +167,42 @@ class Py3status:
         return "?"
 
     def mpd_status(self):
+        # I - get current mpd status (or wait until it changes)
+        # this writes into self.current_status
+        if self.use_idle is not False:
+            if not self.idle_thread.is_alive():
+                sleep(self.cache_timeout)  # rate limit thread restarting
+                self.idle_thread = Thread(target=self._get_status)
+                self.idle_thread.daemon = True
+                self.idle_thread.start()
+        else:
+            self._get_status()
+
+        # II - format response
+        (text, state) = ("", "")
+        if self.current_status is not None:
+            (text, state) = self.current_status
+
+        if len(text) > self.max_width:
+            text = u"{}...".format(text[: self.max_width - 3])
+
+        response = {
+            "cached_until": self.py3.time_in(self.cache_timeout),
+            "full_text": text if state or not self.hide_on_error else "",
+        }
+
+        if state:
+            if state == "play":
+                response["color"] = self.py3.COLOR_PLAY or self.py3.COLOR_GOOD
+            elif state == "pause":
+                response["color"] = self.py3.COLOR_PAUSE or self.py3.COLOR_DEGRADED
+            elif state == "stop":
+                response["color"] = self.py3.COLOR_STOP or self.py3.COLOR_BAD
+
+        return response
+
+    def _get_status(self):
+      while True:
         try:
             status = self._get_mpd().status()
             song = int(status.get("song", 0))
@@ -180,39 +237,39 @@ class Py3status:
                 if isinstance(text, Composite):
                     text = text.text()
 
-        except ValueError:
-            # when status.get(...) returns None; e.g. during reversal of playlist
-            text = "No song information!"
-            state = None
-        except socket.error:
-            text = "Failed to connect to mpd!"
-            state = None
-        except ConnectionError:
-            text = "Error while connecting to mpd!"
-            state = None
-            self._get_mpd(disconnect=True)
-        except CommandError:
-            text = "Failed to authenticate to mpd!"
-            state = None
-            self._get_mpd(disconnect=True)
+            self.current_status = (text, status)
 
-        if len(text) > self.max_width:
-            text = u"{}...".format(text[: self.max_width - 3])
+            if self.use_idle:
+                self.py3.update()
+                # Note: mpd2 does not support more than 1 idle subsystem. so if
+                # the user wants to listen on more than one, we listen on all
+                # and loop until one we're interested in changed.
+                # https://github.com/Mic92/python-mpd2/issues/107
+                changed = self._get_mpd().idle()
+                while not any([c in self.idle_subsystems for c in changed]):
+                    changed = self._get_mpd().idle()
+            else:
+                return
 
-        response = {
-            "cached_until": self.py3.time_in(self.cache_timeout),
-            "full_text": text if state or not self.hide_on_error else "",
-        }
+        except (ValueError, socket.error, ConnectionError, CommandError) as e:
+            # ValueError can happen when status.get(...) returns None; e.g.
+            # during reversal of playlist
+            if type(e) is ValueError:
+                text = "No song information!"
+            if type(e) is socket.error:
+                text = "Failed to connect to mpd!"
+            if type(e) is ConnectionError:
+                text = "Error while connecting to mpd!"
+                self._get_mpd(disconnect=True)
+            if type(e) is CommandError:
+                text = "Failed to authenticate to mpd!"
+                self._get_mpd(disconnect=True)
 
-        if state:
-            if state == "play":
-                response["color"] = self.py3.COLOR_PLAY or self.py3.COLOR_GOOD
-            elif state == "pause":
-                response["color"] = self.py3.COLOR_PAUSE or self.py3.COLOR_DEGRADED
-            elif state == "stop":
-                response["color"] = self.py3.COLOR_STOP or self.py3.COLOR_BAD
-
-        return response
+            state = None
+            self.current_status = (text, status)
+            return
+        finally:
+            self.py3.update()  # to propagate error message
 
     def kill(self):
         self._get_mpd(disconnect=True)


### PR DESCRIPTION
Issuing commands every two seconds, even if nothing changes causes high
CPU load with Mopidy-MPD, and possibly other MPD servers. With polling
every 2 seconds (the default), mopidy (while paused) was consuming
between 10% and 15%, with occational spikes even up to 20% cpu; using
idling, this number dropped to 0.0%.

This patch is similar to IDLE in imap.py, where we listen for changes on
subsystems we're interested in (99% that's just 'player', but we'll
default to 'mixer' (changes in volume) and 'options' (e.g. repeat mode)
too, just in case a user has those states displayed in her status bar).