### PR TITLE
imap module: Handle OAuth TransportError

### DIFF
--- a/py3status/modules/imap.py
+++ b/py3status/modules/imap.py
@@ -67,7 +67,7 @@ import os
 from threading import Thread
 from time import sleep
 from ssl import create_default_context
-from socket import error as socket_error
+from socket import setdefaulttimeout, error as socket_error
 
 STRING_UNAVAILABLE = "N/A"
 NO_DATA_YET = -1
@@ -209,10 +209,12 @@ class Py3status:
         if self.client_secret:
             # Use OAUTH
             self._get_creds()
+        setdefaulttimeout(self.read_timeout)
         connection = imaplib.IMAP4_SSL(self.server, int(self.port))
         return connection
 
     def _connection_starttls(self):
+        setdefaulttimeout(self.read_timeout)
         connection = imaplib.IMAP4(self.server, int(self.port))
         connection.starttls(create_default_context())
         return connection


### PR DESCRIPTION
When OAuth is being used in the imap module and the network tries to redirect requests to a captive portal, google.auth.exceptions.TransportError is raised.

Unlike other errors that might be caused by authentication issues (which will throw a fatal error in the module) this specific case should probably be handled just like another recoverable network error - that is, keep trying until the network fixes itself.

To avoid all users having to install the OAuth library in order to catch this exception, a list of recoverable errors is stored as an attribute in the module, so that this exception can be dynamically added when OAuth is used.

Split out of discussion in #1883 

note: these commits need to be updated for the latest master, and probably for #1885 