### PR TITLE
Fix collections.abc imports for Python 3.9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
-sudo: false
 language: python
 python:
   - "2.7"
@@ -6,11 +5,7 @@ python:
   - "3.5"
   - "3.6"
   - "3.7"
-matrix:
-  include:
-    - python: "3.8"
-      dist: xenial
-      sudo: true
+  - "3.8"
 install:
   - travis_retry pip install tox-travis
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ python:
   - "3.6"
   - "3.7"
   - "3.8"
+  - "3.9-dev"
 install:
   - travis_retry pip install tox-travis
 script:

--- a/py3status/py3.py
+++ b/py3status/py3.py
@@ -1,9 +1,14 @@
 from __future__ import division
 
-import collections
 import os
 import sys
 import shlex
+
+try:
+    # Python 3.3+
+    from collections.abc import Mapping
+except ImportError:
+    from collections import Mapping
 
 from copy import deepcopy
 from fnmatch import fnmatch
@@ -315,7 +320,7 @@ class Py3:
                 items.append((k, v))
             if isinstance(v, list):
                 v = dict(enumerate(v))
-            if isinstance(v, collections.Mapping):
+            if isinstance(v, Mapping):
                 items.extend(
                     self.flatten_dict(v, delimiter, intermediates, str(k)).items()
                 )

--- a/py3status/storage.py
+++ b/py3status/storage.py
@@ -2,7 +2,12 @@ from __future__ import with_statement
 
 import os
 
-from collections import Iterable, Mapping
+try:
+    # Python 3.3+
+    from collections.abc import Iterable, Mapping
+except ImportError:
+    from collections import Iterable, Mapping
+
 from pickle import dump, load
 from tempfile import NamedTemporaryFile
 from time import time


### PR DESCRIPTION
Fedora bug report: https://bugzilla.redhat.com/show_bug.cgi?id=1791939

On Python 3.9:

```
Traceback (most recent call last):
  File "/usr/lib/python3.9/site-packages/sphinx/config.py", line 361, in eval_config_file
    execfile_(filename, namespace)
  File "/usr/lib/python3.9/site-packages/sphinx/util/pycompat.py", line 81, in execfile_
    exec(code, _globals)
  File "/builddir/build/BUILD/py3status-3.24/doc/conf.py", line 5, in <module>
    from py3status.autodoc import (
  File "/builddir/build/BUILD/py3status-3.24/py3status/autodoc.py", line 15, in <module>
    from py3status.py3 import Py3
  File "/builddir/build/BUILD/py3status-3.24/py3status/py3.py", line 19, in <module>
    from py3status.storage import Storage
  File "/builddir/build/BUILD/py3status-3.24/py3status/storage.py", line 5, in <module>
    from collections import Iterable, Mapping
ImportError: cannot import name 'Iterable' from 'collections' (/usr/lib64/python3.9/collections/__init__.py)
```

This also adds `3.9-dev` to show it red on the CI before the fix:
* https://travis-ci.org/hugovk/py3status/builds/639465541

And green after:
* https://travis-ci.org/hugovk/py3status/builds/639469129

---

This also simplifies the CI config: sudo no longer has any effect (https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration) and Xenial is now the default.