### PR TITLE
Fix imap idle for courier

### DIFF
--- a/py3status/modules/imap.py
+++ b/py3status/modules/imap.py
@@ -257,6 +257,8 @@ class Py3status:
                 response = socket.read(4096).decode("ascii")
             except socket_error:
                 raise imaplib.IMAP4.abort("Server didn't respond to 'IDLE' in time")
+            # Dovecot will responde with "+ idling", courier will return "+ entering idle mode"
+            # RFC 2177 (https://tools.ietf.org/html/rfc2177) only requires the "+" character.
             if not response.lower().startswith("+"):
                 raise imaplib.IMAP4.abort(
                     "While initializing IDLE: {}".format(response)

--- a/py3status/modules/imap.py
+++ b/py3status/modules/imap.py
@@ -257,7 +257,7 @@ class Py3status:
                 response = socket.read(4096).decode("ascii")
             except socket_error:
                 raise imaplib.IMAP4.abort("Server didn't respond to 'IDLE' in time")
-            if not response.lower().startswith("+ idling"):
+            if not response.lower().startswith("+"):
                 raise imaplib.IMAP4.abort(
                     "While initializing IDLE: {}".format(response)
                 )


### PR DESCRIPTION
As stated in RFC 2177 (https://tools.ietf.org/html/rfc2177)  
> The server requests a response to the IDLE command using the continuation ("+") [...]

For example curier responds with "+ entering idle mode" instead of "+ idling".