### PR TITLE
i3status: support read_file module

### DIFF
--- a/py3status/constants.py
+++ b/py3status/constants.py
@@ -25,6 +25,7 @@ I3S_INSTANCE_MODULES = [
     "ethernet",
     "memory",
     "path_exists",
+    "read_file",
     "run_watch",
     "tztime",
     "volume",


### PR DESCRIPTION
This support i3status `read_file` module. Untested.

Closes https://github.com/ultrabug/py3status/issues/1908. 