### PR TITLE
NetworkManager: allow using the currently active AP in formats

### DIFF
--- a/py3status/modules/networkmanager.py
+++ b/py3status/modules/networkmanager.py
@@ -165,7 +165,6 @@ class Py3status:
                         current_ap[key.replace(used_ap + "_", "ap_")] = device[key]
                 device.update(current_ap)
 
-
             for x in self.thresholds_init:
                 if x in device:
                     self.py3.threshold_get_color(device[x], x)

--- a/py3status/modules/networkmanager.py
+++ b/py3status/modules/networkmanager.py
@@ -21,13 +21,13 @@ Format_device placeholders:
     {general_connection} eg Py3status, Wired Connection 1
     {general_device}     eg wlp3s0b1, enp2s0
     {general_type}       eg wifi, ethernet
-    {ap1_bars}           signal strength in bars, eg ▂▄▆_
-    {ap1_chan}           wifi channel, eg 6
-    {ap1_mode}           network mode, eg Adhoc or Infra
-    {ap1_rate}           bitrate, eg 54 Mbit/s
-    {ap1_security}       signal security, eg WPA2
-    {ap1_signal}         signal strength in percentage, eg 63
-    {ap1_ssid}           ssid name, eg Py3status
+    {ap_bars}            signal strength in bars, eg ▂▄▆_
+    {ap_chan}            wifi channel, eg 6
+    {ap_mode}            network mode, eg Adhoc or Infra
+    {ap_rate}            bitrate, eg 54 Mbit/s
+    {ap_security}        signal security, eg WPA2
+    {ap_signal}          signal strength in percentage, eg 63
+    {ap_ssid}            ssid name, eg Py3status
     {ip4_address1}       eg 192.168.1.108
     {ip6_address1}       eg 0000::0000:0000:0000:0000
 
@@ -80,7 +80,7 @@ class Py3status:
     format = "{format_device}"
     format_device = (
         "[\?if=general_connection {general_device}[\?soft  ]"
-        "[\?color=ap1_signal {ap1_ssid} {ap1_bars} {ap1_signal}%][\?soft  ]"
+        "[\?color=ap1_signal {ap_ssid} {ap_bars} {ap_signal}%][\?soft  ]"
         "[\?color=good {ip4_address1}]]"
     )
     format_device_separator = " "
@@ -105,7 +105,6 @@ class Py3status:
         ).split()
         self.caches = {"lines": {}, "devices": {}}
         self.devices = {"list": [], "devices": self.devices}
-
         self.thresholds_init = self.py3.get_color_names_list(self.format_device)
 
     def _update_key(self, key):
@@ -116,6 +115,7 @@ class Py3status:
     def networkmanager(self):
         nm_data = self.py3.command_output(self.nmcli_command, localized=True)
         new_device = []
+        used_ap = None
 
         for chunk in nm_data.split("\n\n"):
             lines = chunk.splitlines()
@@ -137,7 +137,6 @@ class Py3status:
                 key = self.caches["devices"][key]
 
             device = {key: value}
-
             for line in lines[1:]:
                 try:
                     key, value = self.caches["lines"][line]
@@ -154,7 +153,18 @@ class Py3status:
 
                     self.caches["lines"][line] = (key, value)
 
+                if "ap" in key and "in_use" in key and value == "*":
+                    used_ap = key.split("_")[0]
                 device[key] = value
+
+            # Add specific extra entries for the AP currently used by the device.
+            if used_ap != None:
+                current_ap = {}
+                for key in device:
+                    if key.startswith(used_ap + "_"):
+                        current_ap[key.replace(used_ap + "_", "ap_")] = device[key]
+                device.update(current_ap)
+
 
             for x in self.thresholds_init:
                 if x in device:

--- a/py3status/modules/networkmanager.py
+++ b/py3status/modules/networkmanager.py
@@ -8,7 +8,7 @@ Configuration parameters:
     format: display format for this module (default '{format_device}')
     format_device: format for devices
         *(default "[\?if=general_connection {general_device}[\?soft  ]"
-        "[\?color=ap1_signal {ap1_ssid} {ap1_bars} {ap1_signal}%][\?soft  ]"
+        "[\?color=ap_signal {ap_ssid} {ap_bars} {ap_signal}%][\?soft  ]"
         "[\?color=good {ip4_address1}]]")*
     format_device_separator: show separator if more than one (default ' ')
     thresholds: specify color thresholds to use
@@ -80,7 +80,7 @@ class Py3status:
     format = "{format_device}"
     format_device = (
         "[\?if=general_connection {general_device}[\?soft  ]"
-        "[\?color=ap1_signal {ap_ssid} {ap_bars} {ap_signal}%][\?soft  ]"
+        "[\?color=ap_signal {ap_ssid} {ap_bars} {ap_signal}%][\?soft  ]"
         "[\?color=good {ip4_address1}]]"
     )
     format_device_separator = " "


### PR DESCRIPTION
Currently, you can only configure your format with access points numbers, e.g.  `ap1_ssid`, `ap2_bars`, ...

This works fine most of the time because `nmcli` only returns one AP, the currently active one. So most of the time the `ap1_xxx` placeholders make sense. However, occasionally, `nmcli` may return additional APs (for instance when a scan has been performed). In that case, AP1 may not always be the currently active AP, and if your format contains `ap1_ssid` py3status will show you as being connected to an incorrect SSID. 

This change allows to use `ap_ssid`, `ap_rate` instead of `ap1_ssid` etc. so that py3status always shows the information related to the currently used AP, and not just a specific AP number.