### PR TITLE
add the filter ability of the mail module to the imap module

### DIFF
--- a/py3status/modules/imap.py
+++ b/py3status/modules/imap.py
@@ -383,17 +383,13 @@ class Py3status:
                                 STRING_INVALID_FILTER.format(filters),
                                 self.py3.CACHE_FOREVER,
                             )
-                        for line in lines:
-                            self.py3.log(line)
+                        if self.debug:
+                            for line in lines:
+                                self.py3.log(line)
 
                 for directory in directories:
-                    if (
-                        self.connection.select(directory, readonly=True)[0]
-                        == "OK"
-                    ):
-                        unseen_response = self.connection.search(
-                            None, self.criterion
-                        )
+                    if self.connection.select(directory, readonly=True)[0] == "OK":
+                        unseen_response = self.connection.search(None, self.criterion)
                         mails = unseen_response[1][0].split()
                         tmp_mail_count += len(mails)
                     else:


### PR DESCRIPTION
adds a new parameter `filter` which can be a list of regular expressions. If the `mailbox` parameter is not set to an empty string the old behavior will be used.

fix #1902