### PR TITLE
volume_status module: Add support for custom_command

### DIFF
--- a/py3status/modules/volume_status.py
+++ b/py3status/modules/volume_status.py
@@ -4,6 +4,7 @@ Volume control.
 Configuration parameters:
     blocks: a string, where each character represents a volume level
             (default "_▁▂▃▄▅▆▇█")
+    button_custom: button to run "custom_command" (default 3)
     button_down: button to decrease volume (default 5)
     button_mute: button to toggle mute (default 1)
     button_up: button to increase volume (default 4)
@@ -15,6 +16,7 @@ Configuration parameters:
     command: Choose between "amixer", "pamixer" or "pactl".
         If None, try to guess based on available commands.
         (default None)
+    custom_command: Command to run on "button_custom" (default None)
     device: Device to use. Defaults value is backend dependent
         (default None)
     format: Format of the output.
@@ -298,6 +300,7 @@ class Py3status:
 
     # available configuration parameters
     blocks = "_▁▂▃▄▅▆▇█"
+    button_custom = 3
     button_down = 5
     button_mute = 1
     button_up = 4
@@ -305,6 +308,7 @@ class Py3status:
     card = None
     channel = None
     command = None
+    custom_command = None
     device = None
     format = r"[\?if=is_input 😮|♪]: {percentage}%"
     format_muted = r"[\?if=is_input 😶|♪]: muted"
@@ -400,6 +404,12 @@ class Py3status:
             self.backend.volume_down(self.volume_delta)
         elif button == self.button_mute:
             self.backend.toggle_mute()
+        elif button == self.button_custom:
+            self._run_custom_command()
+
+    def _run_custom_command(self):
+        if self.custom_command is not None:
+            self.py3.command_run(self.custom_command)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
I find myself opening `pavucontrol` to refine some audio settings. This PR allows for the user to configure a button (by default 3) to execute given command (in my case that would be `pavucontrol`).

It could be configured specifically for each backend, like the `command` is. But in this case it should not be hardcoded, since each user may have different needs on which command to run. It's also simpler to leave it in the main module :grin:.

**Comments**:

`py3.command_run` will throw an Error if anything fails. We could add some safety by changing:

```python
self.py3.command_run(self.custom_command)
```

to:

```python
import subprocess
subprocess.run([self.custom_command], shell=True, capture_output=True, check=False)
```

But then it would fail silently. 
We could add some visibility to that by doing something like:

```python
import syslog
try:
    self.py3.command_run(self.custom_command)
except Exception as ex:
    syslog.syslog(f'custom_command failed: {ex}')
```
What do you think?