### PR TITLE
fix flake8 code linting and black code formatting to pass tests

### DIFF
--- a/py3status/module.py
+++ b/py3status/module.py
@@ -1,8 +1,8 @@
 import os
-import imp
 import inspect
 
 from collections import OrderedDict
+from importlib.machinery import SourceFileLoader
 from time import time
 from random import randint
 
@@ -104,7 +104,7 @@ class Module:
         class_inst = None
         module_name, file_ext = os.path.splitext(os.path.split(filepath)[-1])
         if file_ext.lower() == ".py":
-            py_mod = imp.load_source(module_name, filepath)
+            py_mod = SourceFileLoader(module_name, filepath).load_module()
             if hasattr(py_mod, cls.EXPECTED_CLASS):
                 class_inst = py_mod.Py3status()
         return class_inst

--- a/py3status/modules/do_not_disturb.py
+++ b/py3status/modules/do_not_disturb.py
@@ -8,7 +8,7 @@ Configuration parameters:
         (default '{name} [\?color=state&show DND]')
     pause: specify whether to pause or kill processes; for dunst
         see `Dunst Miscellaneous` section for more information
-        (default False)
+        (default True)
     server: specify server to use, eg mako, dunst or xfce4-notifyd, otherwise auto
         (default None)
     state: specify state to use on startup, otherwise last

--- a/py3status/modules/frame.py
+++ b/py3status/modules/frame.py
@@ -124,7 +124,7 @@ class Py3status:
         for item in self.items:
             out = self.py3.get_output(item)[:]
             for o in out:
-                composites[f'output_{o["name"]}'] = o["full_text"]
+                composites["output_" + o["name"]] = o["full_text"]
             if self.format_separator is None:
                 if out and "separator" not in out[-1]:
                     # we copy the item as we do not want to change the

--- a/py3status/modules/networkmanager.py
+++ b/py3status/modules/networkmanager.py
@@ -157,7 +157,7 @@ class Py3status:
                 device[key] = value
 
             # Add specific extra entries for the AP currently used by the device.
-            if used_ap != None:
+            if used_ap is not None:
                 current_ap = {}
                 for key in device:
                     if key.startswith(used_ap + "_"):

--- a/py3status/modules/pingdom.py
+++ b/py3status/modules/pingdom.py
@@ -81,9 +81,7 @@ class Py3status:
                         response["color"] = self.py3.COLOR_DEGRADED
                 else:
                     response["color"] = self.py3.COLOR_BAD
-                    pingdom += "{}: DOWN".format(
-                        check["name"], check["lastresponsetime"]
-                    )
+                    pingdom += "{}: DOWN".format(check["name"])
             pingdom = pingdom.strip(", ")
             response["full_text"] = self.py3.safe_format(
                 self.format, {"pingdom": pingdom}

--- a/py3status/modules/sysdata.py
+++ b/py3status/modules/sysdata.py
@@ -355,7 +355,16 @@ class Py3status:
         (total, total_unit) = self.py3.format_units(total_mem_kib * 1024, unit)
         (used, used_unit) = self.py3.format_units(used_mem_kib * 1024, unit)
         (free, free_unit) = self.py3.format_units(free_mem_kib * 1024, unit)
-        return total, total_unit, used, used_unit, used_percent, free, free_unit, free_percent
+        return (
+            total,
+            total_unit,
+            used,
+            used_unit,
+            used_percent,
+            free,
+            free_unit,
+            free_percent,
+        )
 
     def _get_meminfo(self, head=24):
         with open("/proc/meminfo") as f:

--- a/py3status/parse_config.py
+++ b/py3status/parse_config.py
@@ -1,9 +1,9 @@
 import codecs
-import imp
 import os
 import re
 
 from collections import OrderedDict
+from importlib import util
 from string import Template
 from subprocess import check_output, CalledProcessError
 
@@ -185,22 +185,10 @@ class ConfigParser:
             return
         root = os.path.dirname(os.path.realpath(__file__))
         module_path = os.path.join(root, "modules")
-        try:
-            info = imp.find_module(name, [module_path])
-        except ImportError:
-            return
+        info = util.find_spec(name, [module_path])
         if not info:
             return
-        (file, pathname, description) = info
-        try:
-            py_mod = imp.load_module(name, file, pathname, description)
-        except Exception:
-            # We cannot load the module!  We could error out here but then the
-            # user gets informed that the problem is with their config.  This
-            # is not correct.  Better to say that all is well and then the
-            # config can get parsed and py3status loads.  The error about the
-            # failing module load is better handled at that point, and will be.
-            return
+        py_mod = util.exec_module(info)
         try:
             container = py_mod.Py3status.Meta.container
         except AttributeError:

--- a/tox.ini
+++ b/tox.ini
@@ -26,7 +26,9 @@ commands =
 # https://github.com/ambv/black/blob/master/.flake8
 flake8-ignore =
     C901
-    E
+    E203
+    E266
+    E501
     W503
     py3status/modules/*.py W605 W504
 flake8-select = F


### PR DESCRIPTION
This fixes things and whatnot to pass tests. I failed to get rid of this one though. Seems ok to me.
>========== warnings summary ==========
tests/test_module_doc.py: 66 tests with warnings
  <string>:1: DeprecationWarning: invalid escape sequence \?
...