### PR TITLE
Remove deprectated function in modules.py

### DIFF
--- a/py3status/module.py
+++ b/py3status/module.py
@@ -567,7 +567,7 @@ class Module:
         # on_click method has extra events parameter
         if method_name == "on_click":
             arg_count = 2
-        args, vargs, kw, defaults = inspect.getargspec(method)
+        args, vargs, kw, defaults, _, _, _ = inspect.getfullargspec(method)
         if len(args) == arg_count and not vargs and not kw:
             return self.PARAMS_NEW
         else:


### PR DESCRIPTION
- `inspect.getargspec` was deprected in favor of
`inspect.getfullargspec`, which also supports return type annotations.
Fixes #1941