### PR TITLE
Broken chromium mpris interface workaround

### DIFF
--- a/py3status/modules/mpris.py
+++ b/py3status/modules/mpris.py
@@ -137,21 +137,22 @@ class BrokenDBusMpris:
             def combined_function(*args):
                 callback(*self.filter_messages(*args))
 
-            self._subscription = self._dbus\
-                .subscribe(signal_fired=combined_function)
+            self._subscription = self._dbus.subscribe(signal_fired=combined_function)
 
         def disconnect(self):
             self._subscription.disconnect()
 
         # For some reason the dbus subscribe filtering doesn't work
         def filter_messages(self, *args):
-            dbus_params = ['/org/mpris/MediaPlayer2',
-                           'org.freedesktop.DBus.Properties',
-                           'PropertiesChanged']
+            dbus_params = [
+                "/org/mpris/MediaPlayer2",
+                "org.freedesktop.DBus.Properties",
+                "PropertiesChanged",
+            ]
 
             for i in range(1, 3):
                 if args[i] != dbus_params[i - 1]:
-                    return ('', {}, [])
+                    return ("", {}, [])
             # The 6th is a tuple, where the actual data is in the 2nd field
             msg = args[4][1]
 
@@ -161,8 +162,9 @@ class BrokenDBusMpris:
                         self._parent.PlaybackStatus = msg["PlaybackStatus"]
                     if "Metadata" in msg:
                         self._parent.Metadata = msg["Metadata"]
-                        self._parent.Metadata['xesam:artist'] = \
-                            ", ".join(msg['Metadata']["xesam:artist"])
+                        self._parent.Metadata["xesam:artist"] = ", ".join(
+                            msg["Metadata"]["xesam:artist"]
+                        )
 
                 except KeyError:
                     pass
@@ -173,16 +175,10 @@ class BrokenDBusMpris:
         self.Identity = identity
         self.PlaybackStatus = playback_status
         self.PropertiesChanged = BrokenDBusMpris.PropertiesChanged(self, dbus)
-        self.Metadata = {
-            'xesam:album': None,
-            'xesam:artist': None,
-            'xesam:title': None
-        }
+        self.Metadata = {"xesam:album": None, "xesam:artist": None, "xesam:title": None}
 
     def get(self, key):
-        data = {
-            'subscription': self.PropertiesChanged._subscription
-        }
+        data = {"subscription": self.PropertiesChanged._subscription}
         return data[key]
 
 
@@ -229,10 +225,7 @@ class Py3status:
                 "clickable": "CanPause",
                 "icon": self.icon_pause,
             },
-            "play": {
-                "action": "Play",
-                "clickable": "CanPlay",
-                "icon": self.icon_play},
+            "play": {"action": "Play", "clickable": "CanPlay", "icon": self.icon_play},
             "stop": {
                 "action": "Stop",
                 "clickable": "True",  # The MPRIS API lacks 'CanStop' function.
@@ -414,8 +407,7 @@ class Py3status:
                 if priority is not None:
                     p["_priority"] = priority
             if p.get("_priority") is not None:
-                players.append((p["_state_priority"], p["_priority"],
-                                p["index"], name))
+                players.append((p["_state_priority"], p["_priority"], p["index"], name))
         if players:
             top_player = self._mpris_players.get(sorted(players)[0][3])
         else:
@@ -466,8 +458,8 @@ class Py3status:
         try:
             player = self._dbus.get(player_id, SERVICE_BUS_URL)
         except KeyError:
-            if 'chromium' in player_id:
-                player = BrokenDBusMpris(self._dbus, 'Chromium', 'Stopped')
+            if "chromium" in player_id:
+                player = BrokenDBusMpris(self._dbus, "Chromium", "Stopped")
             else:
                 return False
 
@@ -580,8 +572,7 @@ class Py3status:
 
         if is_stream and self._data.get("title"):
             # delete the file extension
-            self._data["title"] = re.sub(r"\....$", "",
-                                         self._data.get("title"))
+            self._data["title"] = re.sub(r"\....$", "", self._data.get("title"))
             self._data["nowplaying"] = metadata.get("vlc:nowplaying")
 
     def kill(self):
@@ -607,8 +598,7 @@ class Py3status:
             (text, color, cached_until) = self._get_text()
             self._control_states = self._get_control_states()
             buttons = self._get_response_buttons()
-            composite = self.py3.safe_format(self.format,
-                                             dict(text, **buttons))
+            composite = self.py3.safe_format(self.format, dict(text, **buttons))
 
         if self._data.get(
             "error_occurred"
@@ -622,8 +612,7 @@ class Py3status:
                 return self.mpris()
             # Max retries hit we need to output something
             composite = [
-                {"full_text": "Something went wrong",
-                 "color": self.py3.COLOR_BAD}
+                {"full_text": "Something went wrong", "color": self.py3.COLOR_BAD}
             ]
             cached_until = self.py3.time_in(1)
 

--- a/py3status/modules/mpris.py
+++ b/py3status/modules/mpris.py
@@ -127,6 +127,65 @@ def _get_time_str(microseconds):
     return time
 
 
+class BrokenDBusMpris:
+    class PropertiesChanged:
+        def __init__(self, parent, dbus):
+            self._dbus = dbus
+            self._parent = parent
+
+        def connect(self, callback):
+            def combined_function(*args):
+                callback(*self.filter_messages(*args))
+
+            self._subscription = self._dbus\
+                .subscribe(signal_fired=combined_function)
+
+        def disconnect(self):
+            self._subscription.disconnect()
+
+        # For some reason the dbus subscribe filtering doesn't work
+        def filter_messages(self, *args):
+            dbus_params = ['/org/mpris/MediaPlayer2',
+                           'org.freedesktop.DBus.Properties',
+                           'PropertiesChanged']
+
+            for i in range(1, 3):
+                if args[i] != dbus_params[i - 1]:
+                    return ('', {}, [])
+            # The 6th is a tuple, where the actual data is in the 2nd field
+            msg = args[4][1]
+
+            if msg:
+                try:
+                    if "PlaybackStatus" in msg:
+                        self._parent.PlaybackStatus = msg["PlaybackStatus"]
+                    if "Metadata" in msg:
+                        self._parent.Metadata = msg["Metadata"]
+                        self._parent.Metadata['xesam:artist'] = \
+                            ", ".join(msg['Metadata']["xesam:artist"])
+
+                except KeyError:
+                    pass
+            return args[4]
+
+    def __init__(self, dbus, identity, playback_status):
+        self._dbus = dbus
+        self.Identity = identity
+        self.PlaybackStatus = playback_status
+        self.PropertiesChanged = BrokenDBusMpris.PropertiesChanged(self, dbus)
+        self.Metadata = {
+            'xesam:album': None,
+            'xesam:artist': None,
+            'xesam:title': None
+        }
+
+    def get(self, key):
+        data = {
+            'subscription': self.PropertiesChanged._subscription
+        }
+        return data[key]
+
+
 class Py3status:
     """
     """
@@ -170,7 +229,10 @@ class Py3status:
                 "clickable": "CanPause",
                 "icon": self.icon_pause,
             },
-            "play": {"action": "Play", "clickable": "CanPlay", "icon": self.icon_play},
+            "play": {
+                "action": "Play",
+                "clickable": "CanPlay",
+                "icon": self.icon_play},
             "stop": {
                 "action": "Stop",
                 "clickable": "True",  # The MPRIS API lacks 'CanStop' function.
@@ -279,7 +341,8 @@ class Py3status:
             "time": ptime,
             "title": self._data.get("title") or "No Track",
             "nowplaying": self._data.get("nowplaying"),
-            "full_name": self._player_details.get("full_name"),  # for debugging ;p
+            # for debugging ;p
+            "full_name": self._player_details.get("full_name"),
         }
 
         return (placeholders, color, update)
@@ -330,8 +393,8 @@ class Py3status:
     def _set_player(self):
         """
         Sort the current players into priority order and set self._player
-        Players are ordered by working state, then by preference supplied by user
-        and finally by instance if a player has more than one running.
+        Players are ordered by working state, then by preference supplied by
+        user and finally by instance if a player has more than one running.
         """
         players = []
         for name, p in self._mpris_players.items():
@@ -351,7 +414,8 @@ class Py3status:
                 if priority is not None:
                     p["_priority"] = priority
             if p.get("_priority") is not None:
-                players.append((p["_state_priority"], p["_priority"], p["index"], name))
+                players.append((p["_state_priority"], p["_priority"],
+                                p["index"], name))
         if players:
             top_player = self._mpris_players.get(sorted(players)[0][3])
         else:
@@ -372,12 +436,14 @@ class Py3status:
             if status:
                 player = self._mpris_players[player_id]
 
-                # Note: Workaround. Since all players get noted if playback status
-                #       has been changed we have to check if we are the chosen one
+                # Note: Workaround. Since all players get noted if playback
+                #       status has been changed we have to check if we are the
+                #       chosen one
                 try:
                     dbus_status = player["_dbus_player"].PlaybackStatus
                 except GError:
-                    # Prevent errors when calling methods of deleted dbus objects
+                    # Prevent errors when calling methods of deleted dbus
+                    # objects
                     return
                 if status != dbus_status:
                     # FIXME: WE DON'T RECOGNIZE ANY TITLE CHANGE
@@ -396,10 +462,14 @@ class Py3status:
         if not player_id.startswith(SERVICE_BUS):
             return False
 
+        # Fixes chromium mpris
         try:
             player = self._dbus.get(player_id, SERVICE_BUS_URL)
         except KeyError:
-            return False
+            if 'chromium' in player_id:
+                player = BrokenDBusMpris(self._dbus, 'Chromium', 'Stopped')
+            else:
+                return False
 
         if player.Identity not in self._mpris_names:
             self._mpris_names[player.Identity] = player_id.split(".")[-1]
@@ -492,7 +562,7 @@ class Py3status:
                 self._data["title"] = metadata.get("xesam:title")
                 self._data["album"] = metadata.get("xesam:album")
 
-                if metadata.get("xesam:artist") is not None:
+                if metadata.get("xesam:artist"):
                     self._data["artist"] = metadata.get("xesam:artist")[0]
                 else:
                     # we assume here that we playing a video and these types of
@@ -510,8 +580,8 @@ class Py3status:
 
         if is_stream and self._data.get("title"):
             # delete the file extension
-            self._data["title"] = re.sub(r"\....$", "", self._data.get("title"))
-
+            self._data["title"] = re.sub(r"\....$", "",
+                                         self._data.get("title"))
             self._data["nowplaying"] = metadata.get("vlc:nowplaying")
 
     def kill(self):
@@ -523,6 +593,7 @@ class Py3status:
         """
         if self._kill:
             raise KeyboardInterrupt
+
         current_player_id = self._player_details.get("id")
         cached_until = self.py3.CACHE_FOREVER
 
@@ -536,7 +607,8 @@ class Py3status:
             (text, color, cached_until) = self._get_text()
             self._control_states = self._get_control_states()
             buttons = self._get_response_buttons()
-            composite = self.py3.safe_format(self.format, dict(text, **buttons))
+            composite = self.py3.safe_format(self.format,
+                                             dict(text, **buttons))
 
         if self._data.get(
             "error_occurred"
@@ -550,7 +622,8 @@ class Py3status:
                 return self.mpris()
             # Max retries hit we need to output something
             composite = [
-                {"full_text": "Something went wrong", "color": self.py3.COLOR_BAD}
+                {"full_text": "Something went wrong",
+                 "color": self.py3.COLOR_BAD}
             ]
             cached_until = self.py3.time_in(1)
 


### PR DESCRIPTION
This pull request is basically a workaround that bypasses chromium broken mpris interface thus allowing py3status to show which media is currently being played in the browser.

**Bugs**:
- Control buttons don't work as chromium doesn't expose any interface in dbus, maybe can be fixed with some IPC
- If a player with higher priority was running the title of the old media will remain until you switch to a tab with a new media
- If playback is started before py3status the status bar won't be synchronized until a new media is played

At the moment i'm not planning on fixing those bugs because the most sensible way to do it would be to fix chromium's MPRIS.