### PR TITLE
Support more battery in battery_level module

### DIFF
--- a/py3status/modules/battery_level.py
+++ b/py3status/modules/battery_level.py
@@ -83,6 +83,7 @@ discharging
 from re import findall
 from glob import iglob
 
+import itertools
 import math
 import os
 
@@ -293,7 +294,11 @@ class Py3status:
             return raw_values
 
         battery_list = []
-        for path in iglob(os.path.join(self.sys_battery_path, "BAT*")):
+
+        bglobs = ["BAT*", "*bat*"]
+        path_its = itertools.chain(*[iglob(os.path.join(self.sys_battery_path,
+                                                        bglob)) for bglob in bglobs])
+        for path in path_its:
             r = _parse_battery_info(path)
 
             capacity = r.get(


### PR DESCRIPTION
Previous code only matches with "BAT*" names in the /sys/class/power_supply.
There does not seem to be any naming convention in the documentation:
https://www.kernel.org/doc/html/latest/power/power_supply_class.html
For example, the battery on the GPD Pocket is exposed as "max170xx_battery".

This patch allows for easier addition of glob patterns to use to match for
battery nodes and adds "*bat*" in the list.