### PR TITLE
add hide_errors option

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -583,6 +583,31 @@ be used to allow/prevent a module from setting itself as urgent.
         allow_urgent = true
     }
 
+Hide errors
+-----------
+
+When a module error has occurred, it will be reported on the bar.
+The ``hide_errors`` configuration parameter allows users to ignore 
+module errors instead.
+
+
+.. code-block:: py3status
+    :caption: Example
+
+    # hide errors on all modules
+    py3status {
+        hide_errors = True
+    }
+
+    # hide errors on non-NVIDIA hardwares
+    nvidia_smi {
+        hide_errors = True
+    }
+
+    # hide errors on sway
+    xrandr {
+        hide_errors = True
+    }
 
 Grouping Modules
 ----------------

--- a/py3status/module.py
+++ b/py3status/module.py
@@ -36,7 +36,7 @@ class Module:
         self.disabled = False
         self.enabled = False
         self.error_messages = None
-        self.error_hide = False
+        self.error_hide = None
         self.has_post_config_hook = False
         self.has_kill = False
         self.i3status_thread = py3_wrapper.i3status_thread
@@ -788,6 +788,12 @@ class Module:
             if hasattr(param, "none_setting"):
                 param = True
             self.allow_urgent = param
+
+            # hide_errors
+            param = fn(self.module_full_name, "hide_errors")
+            if hasattr(param, "none_setting"):
+                param = False
+            self.error_hide = param
 
             # urgent background
             urgent_background = fn(self.module_full_name, "urgent_background")


### PR DESCRIPTION
This allows users to ignore module errors. 90% Untested.

You like `hide_errors`? 

Closes https://github.com/ultrabug/py3status/issues/1952. 