### PR TITLE
i3status: add markup support for time,tztime modules

### DIFF
--- a/py3status/i3status.py
+++ b/py3status/i3status.py
@@ -78,6 +78,10 @@ class I3statusModule:
         self.i3status = i3status
         py3_wrapper = i3status.py3_wrapper
 
+        markup = py3_wrapper.config["py3_config"]["general"].get("markup")
+        if markup:
+            self.item["markup"] = markup
+
         # color map for if color good/bad etc are set for the module
         color_map = {}
         py3_config = py3_wrapper.config["py3_config"]


### PR DESCRIPTION
This allows users to use markup on tztime,time modules too.  Untested (as usual).

Closes #1976. 