### PR TITLE
Use pathlib to manipulate paths and files

### DIFF
--- a/py3status/autodoc.py
+++ b/py3status/autodoc.py
@@ -1,7 +1,8 @@
 import ast
 import inspect
-import os.path
 import re
+
+from pathlib import Path
 
 from docutils import nodes
 from docutils.parsers.rst import Directive
@@ -139,7 +140,7 @@ def screenshots(screenshots_data, module_name):
 
     out = []
     for shot in file_sort(shots):
-        if not os.path.exists("../doc/screenshots/%s.png" % shot):
+        if not Path(f"../doc/screenshots/{shot}.png").exists():
             continue
         out.append(f"\n.. image:: screenshots/{shot}.png\n\n")
     return "".join(out)
@@ -172,8 +173,7 @@ def create_module_docs():
             )
         )
     # write include file
-    with open("../doc/modules-info.inc", "w") as f:
-        f.write("".join(out))
+    Path("../doc/modules-info.inc").write_text("".join(out))
 
 
 def get_variable_docstrings(filename):
@@ -212,9 +212,7 @@ def get_variable_docstrings(filename):
                 key = None
         return docstrings, values
 
-    with open(filename) as f:
-        source = f.read()
-    return walk_node(ast.parse(source))
+    return walk_node(ast.parse(filename.read_text()))
 
 
 def get_py3_info():
@@ -311,8 +309,7 @@ def create_py3_docs():
             output.append(".. py:{}:: {}".format(trans[k], name))
             output.append("")
             output.extend(auto_undent(desc))
-        with open("../doc/py3-%s-info.inc" % k, "w") as f:
-            f.write("\n".join(output))
+        Path(f"../doc/py3-{k}-info.inc").write_text("\n".join(output))
 
 
 def create_auto_documentation():
@@ -354,7 +351,7 @@ class ScreenshotDirective(Directive):
             }
 
         process(image_name, content, False)
-        image_path = os.path.join("screenshots", image_name + ".png")
+        image_path = Path("screenshots") / (image_name + ".png")
         screenshot_node = nodes.image(uri=image_path)
         return [targetnode, screenshot_node]
 

--- a/py3status/module.py
+++ b/py3status/module.py
@@ -1,8 +1,8 @@
-import os
 import inspect
 
 from collections import OrderedDict
 from importlib.machinery import SourceFileLoader
+from pathlib import Path
 from time import time
 from random import randint
 
@@ -110,9 +110,8 @@ class Module:
         Return user-written class object from given path.
         """
         class_inst = None
-        module_name, file_ext = os.path.splitext(os.path.split(filepath)[-1])
-        if file_ext.lower() == ".py":
-            py_mod = SourceFileLoader(module_name, filepath).load_module()
+        if filepath.suffix == ".py":
+            py_mod = SourceFileLoader(filepath.stem, filepath).load_module()
             if hasattr(py_mod, cls.EXPECTED_CLASS):
                 class_inst = py_mod.Py3status()
         return class_inst
@@ -588,7 +587,7 @@ class Module:
             # user provided modules take precedence over py3status provided modules
             if self.module_name in user_modules:
                 include_path, f_name = user_modules[self.module_name]
-                module_path = os.path.join(include_path, f_name)
+                module_path = Path(include_path) / f_name
                 self._py3_wrapper.log(f'loading module "{module}" from {module_path}')
                 self.module_class = self.load_from_file(module_path)
             # load from py3status provided modules

--- a/py3status/modules/aws_bill.py
+++ b/py3status/modules/aws_bill.py
@@ -39,6 +39,8 @@ import boto
 import csv
 import datetime
 
+from pathlib import Path
+
 from boto.s3.connection import Key
 
 
@@ -88,7 +90,7 @@ class Py3status:
 
         # Parse the file and get the InvoiceTotal amount
         try:
-            with open(self.billing_file, "rb") as f:
+            with Path(self.billing_file).open("rb") as f:
                 reader = csv.reader(f)
                 for row in reader:
                     if "".join(row).find("InvoiceTotal") == -1:

--- a/py3status/modules/battery_level.py
+++ b/py3status/modules/battery_level.py
@@ -81,11 +81,12 @@ discharging
 """
 
 from re import findall
-from glob import iglob
 
 import itertools
 import math
-import os
+
+from pathlib import Path
+
 
 BLOCKS = "_▁▂▃▄▅▆▇█"
 CHARGING_CHARACTER = "⚡"
@@ -158,7 +159,7 @@ class Py3status:
         self.last_known_status = ""
         # Guess mode if not set
         if self.measurement_mode is None:
-            if os.path.isdir(self.sys_battery_path):
+            if Path(self.sys_battery_path).is_dir():
                 self.measurement_mode = "sys"
             elif self.py3.check_commands(["acpi"]):
                 self.measurement_mode = "acpi"
@@ -275,7 +276,7 @@ class Py3status:
         a similar, yet incompatible interface in /proc
         """
 
-        if not os.listdir(self.sys_battery_path):
+        if not any(Path(self.sys_battery_path).iterdir()):
             return []
 
         def _parse_battery_info(sys_path):
@@ -284,7 +285,7 @@ class Py3status:
             int if necessary
             """
             raw_values = {}
-            with open(os.path.join(sys_path, "uevent")) as f:
+            with (sys_path / "uevent").open() as f:
                 for var in f.read().splitlines():
                     k, v = var.split("=")
                     try:
@@ -297,8 +298,9 @@ class Py3status:
 
         bglobs = ["BAT*", "*bat*"]
         path_its = itertools.chain(
-            *[iglob(os.path.join(self.sys_battery_path, bglob)) for bglob in bglobs]
+            *[Path(self.sys_battery_path).glob(bglob) for bglob in bglobs]
         )
+
         for path in path_its:
             r = _parse_battery_info(path)
 

--- a/py3status/modules/coin_balance.py
+++ b/py3status/modules/coin_balance.py
@@ -99,9 +99,9 @@ SAMPLE OUTPUT
 """
 
 from errno import ENOENT
-from os.path import expanduser
 import requests
 from string import Formatter
+from pathlib import Path
 
 
 COIN_PORTS = {"bitcoin": 8332, "dogecoin": 22555, "litecoin": 9332}
@@ -144,7 +144,7 @@ class Py3status:
 
     def _get_daemon_config_value(self, coin, key):
         try:
-            with open(expanduser("~/.{0}/{0}.conf".format(coin))) as cfg:
+            with (Path.home() / f".{coin}" / coin).open() as cfg:
                 for line in cfg.readlines():
                     line = line.strip()
                     if line.startswith("#"):

--- a/py3status/modules/conky.py
+++ b/py3status/modules/conky.py
@@ -326,7 +326,7 @@ from subprocess import Popen, PIPE, STDOUT
 from threading import Thread
 from tempfile import NamedTemporaryFile
 from json import dumps
-from os import remove as os_remove
+from pathlib import Path
 
 STRING_NOT_INSTALLED = "not installed"
 STRING_MISSING_FORMAT = "missing format"
@@ -387,7 +387,7 @@ class Py3status:
 
     def _cleanup(self):
         self.process.kill()
-        os_remove(self.tmpfile.name)
+        Path(self.tmpfile).unlink()
         self.py3.update()
 
     def _start_loop(self):

--- a/py3status/modules/diskdata.py
+++ b/py3status/modules/diskdata.py
@@ -55,6 +55,7 @@ SAMPLE OUTPUT
 {'full_text': 'all:  34.4% ( 82.0 KiB/s)'}
 """
 
+from pathlib import Path
 from time import time
 
 
@@ -130,7 +131,7 @@ class Py3status:
         if disk and disk.startswith("/dev/"):
             disk = disk[5:]
 
-        with open("/proc/diskstats") as fd:
+        with Path("/proc/diskstats").open() as fd:
             for line in fd:
                 data = line.split()
                 if disk:

--- a/py3status/modules/file_status.py
+++ b/py3status/modules/file_status.py
@@ -52,8 +52,8 @@ missing
 {'color': '#FF0000', 'full_text': u'\u25a0'}
 """
 
-from glob import glob
-from os.path import basename, expanduser
+from pathlib import Path
+
 
 STRING_NO_PATHS = "missing paths"
 
@@ -107,7 +107,7 @@ class Py3status:
         # convert str to list + expand path
         if not isinstance(self.paths, list):
             self.paths = [self.paths]
-        self.paths = list(map(expanduser, self.paths))
+        self.paths = [Path(path).expanduser() for path in self.paths]
 
         self.init = {"format_path": []}
         if self.py3.format_contains(self.format, "format_path"):
@@ -117,7 +117,9 @@ class Py3status:
 
     def file_status(self):
         # init data
-        paths = sorted([files for path in self.paths for files in glob(path)])
+        paths = sorted(
+            files for path in self.paths for files in path.parent.glob(path.name)
+        )
         count_path = len(paths)
         format_path = None
 
@@ -130,7 +132,7 @@ class Py3status:
                 path = {}
                 for key in self.init["format_path"]:
                     if key == "basename":
-                        value = basename(pathname)
+                        value = pathname.name
                     elif key == "pathname":
                         value = pathname
                     else:

--- a/py3status/modules/google_calendar.py
+++ b/py3status/modules/google_calendar.py
@@ -136,8 +136,8 @@ SAMPLE OUTPUT
 """
 
 import httplib2
-import os
 import datetime
+from pathlib import Path
 
 try:
     from googleapiclient import discovery
@@ -195,8 +195,8 @@ class Py3status:
         self.events = None
         self.no_update = False
 
-        self.client_secret = os.path.expanduser(self.client_secret)
-        self.auth_token = os.path.expanduser(self.auth_token)
+        self.client_secret = Path(self.client_secret).expanduser()
+        self.auth_token = Path(self.auth_token).expanduser()
 
         self.credentials = self._get_credentials()
         self.is_authorized = False
@@ -210,14 +210,11 @@ class Py3status:
 
         Returns: Credentials, the obtained credential.
         """
-        client_secret_path = os.path.dirname(self.client_secret)
-        auth_token_path = os.path.dirname(self.auth_token)
+        client_secret_path = self.client_secret.parent
+        auth_token_path = self.auth_token.parent
 
-        if not os.path.exists(auth_token_path):
-            os.makedirs(auth_token_path)
-
-        if not os.path.exists(client_secret_path):
-            os.makedirs(client_secret_path)
+        auth_token_path.mkdir(parents=True, exists_ok=True)
+        client_secret_path.mkdir(parents=True, exists_ok=True)
 
         flags = tools.argparser.parse_args(args=[])
         store = Storage(self.auth_token)

--- a/py3status/modules/i3pystatus.py
+++ b/py3status/modules/i3pystatus.py
@@ -46,9 +46,8 @@ SAMPLE OUTPUT
 {'full_text': 'i3pystatus module'}
 """
 
-import os
-
 from importlib import import_module
+from pathlib import Path
 from threading import Timer
 
 try:
@@ -93,21 +92,16 @@ def get_backends():
     global backends
     if backends is None:
         backends = {}
-        i3pystatus_dir = os.path.dirname(i3pystatus.__file__)
-        subdirs = [
-            x
-            for x in next(os.walk(i3pystatus_dir))[1]
-            if not x.startswith("_") and x not in IGNORE_DIRS
-        ]
-        for subdir in subdirs:
-            dirs = next(os.walk(os.path.join(i3pystatus_dir, subdir)))[2]
-            backends.update(
-                {
-                    x[:-3]: "i3pystatus.{}.{}".format(subdir, x[:-3])
-                    for x in dirs
-                    if not x.startswith("_") and x.endswith(".py")
-                }
-            )
+        i3pystatus_dir = Path(i3pystatus.__file__).parent
+        for subdir in i3pystatus_dir.iterdir():
+            if (
+                subdir.is_dir()
+                and not subdir.name.startswith("_")
+                and subdir.name not in IGNORE_DIRS
+            ):
+                for path in subdir.glob("*.py"):
+                    if not path.stem.startswith("_"):
+                        backends[path.stem] = f"i3pystatus.{subdir.name}.{path.stem}"
     return backends
 
 
@@ -225,8 +219,7 @@ SKIP_ATTRS = [
 
 
 class Py3status:
-    """
-    """
+    """"""
 
     # available configuration parameters
     module = None

--- a/py3status/modules/imap.py
+++ b/py3status/modules/imap.py
@@ -62,11 +62,11 @@ SAMPLE OUTPUT
 {'full_text': 'Mail: 36', 'color': '#00FF00'}
 """
 import imaplib
-import os
 from threading import Thread
 from time import sleep
 from ssl import create_default_context
 from socket import setdefaulttimeout, error as socket_error
+from pathlib import Path
 
 STRING_UNAVAILABLE = "N/A"
 NO_DATA_YET = -1
@@ -123,8 +123,8 @@ class Py3status:
         self.idle_thread = Thread()
 
         if self.client_secret:
-            self.client_secret = os.path.expanduser(self.client_secret)
-        self.auth_token = os.path.expanduser(self.auth_token)
+            self.client_secret = Path(self.client_secret).expanduser()
+        self.auth_token = Path(self.auth_token).expanduser()
 
         if self.security not in ["ssl", "starttls"]:
             raise ValueError("Unknown security protocol")
@@ -186,8 +186,8 @@ class Py3status:
         self.creds = None
 
         # Open pickle file with access and refresh tokens if it exists
-        if os.path.exists(self.auth_token):
-            with open(self.auth_token, "rb") as token:
+        if self.auth_token.exists():
+            with self.auth_token.open("rb") as token:
                 self.creds = pickle.load(token)
 
         if not self.creds or not self.creds.valid:
@@ -202,7 +202,7 @@ class Py3status:
                     )
                     self.creds = flow.run_local_server(port=0)
                 # Save the credentials for the next run
-                with open(self.auth_token, "wb") as token:
+                with self.auth_token.open("wb") as token:
                     pickle.dump(self.creds, token)
             except TransportError as e:
                 # Treat the same as a socket_error

--- a/py3status/modules/mail.py
+++ b/py3status/modules/mail.py
@@ -156,9 +156,10 @@ no_mail
 """
 
 import mailbox
+import os
 from csv import reader
 from imaplib import IMAP4_SSL, IMAP4
-from os.path import exists, expanduser, expandvars
+from pathlib import Path
 
 STRING_MISSING = "missing {} {}"
 STRING_INVALID_NAME = "invalid name `{}`"
@@ -167,8 +168,7 @@ STRING_INVALID_FILTER = "invalid imap filters `{}`"
 
 
 class Py3status:
-    """
-    """
+    """"""
 
     # available configuration parameters
     accounts = {}
@@ -215,8 +215,10 @@ class Py3status:
                         if mail == box.lower():
                             if "path" not in account:
                                 raise Exception(STRING_MISSING.format(mail, "path"))
-                            path = expandvars(expanduser(account["path"]))
-                            if not exists(path):
+                            path = os.path.expandvars(
+                                Path(account["path"]).expanduser()
+                            )
+                            if not path.exists():
                                 path = f"path: {path}"
                                 raise Exception(STRING_MISSING.format(mail, path))
                             account["box"] = box

--- a/py3status/modules/netdata.py
+++ b/py3status/modules/netdata.py
@@ -32,6 +32,7 @@ SAMPLE OUTPUT
 ]
 """
 
+from pathlib import Path
 from time import time
 
 
@@ -111,7 +112,7 @@ class Py3status:
         self.last_time = time()
         # Get default gateway from /proc.
         if self.nic is None:
-            with open("/proc/net/route") as fh:
+            with Path("/proc/net/route").open() as fh:
                 for line in fh:
                     fields = line.strip().split()
                     if fields[1] == "00000000" and int(fields[3], 16) & 2:
@@ -124,7 +125,7 @@ class Py3status:
         self.thresholds_init = self.py3.get_color_names_list(self.format)
 
     def _get_bytes(self):
-        with open("/proc/net/dev") as fh:
+        with Path("/proc/net/dev").open() as fh:
             net_data = fh.read().split()
         interface_index = net_data.index(self.nic + ":")
         received_bytes = int(net_data[interface_index + 1])

--- a/py3status/modules/player_control.py
+++ b/py3status/modules/player_control.py
@@ -36,7 +36,7 @@ pause
 # Any contributor to this module should add his/her name to the @author
 # line, comma separated.
 
-import os
+from pathlib import Path
 
 try:
     import dbus
@@ -145,14 +145,11 @@ class Py3status:
         """
         supported_players = self.supported_players.split(",")
         running_players = []
-        for pid in os.listdir("/proc"):
-            if not pid.isdigit():
+        for pid in Path("/proc").iterdir():
+            if not pid.name.isdigit():
                 continue
-
-            fn = os.path.join("/proc", pid, "comm")
             try:
-                with open(fn, "rb") as f:
-                    player_name = f.read().decode().rstrip()
+                player_name = (pid / "comm").read_bytes().decode().rstrip()
             except:  # noqa e722
                 # (IOError, FileNotFoundError):  # (assumed py2, assumed py3)
                 continue

--- a/py3status/modules/rate_counter.py
+++ b/py3status/modules/rate_counter.py
@@ -38,8 +38,8 @@ SAMPLE OUTPUT
 """
 
 
-import os
 import time
+from pathlib import Path
 
 
 # No "magic numbers"
@@ -61,13 +61,13 @@ class Py3status:
     tax = 1.02
 
     def post_config_hook(self):
-        self.config_file = os.path.expanduser(self.config_file)
+        self.config_file = Path(self.config_file).expanduser()
         self.running = False
         self.saved_time = 0
         self.start_time = self.current_time
         try:
             # Use file to refer to the file object
-            with open(self.config_file) as file:
+            with self.config_file.open() as file:
                 self.saved_time = float(file.read())
         except:  # noqa e722 // (IOError, FileNotFoundError):  # py2/py3
             pass
@@ -113,7 +113,7 @@ class Py3status:
 
     def kill(self):
         self._stop_timer()
-        with open(self.config_file, "w") as f:
+        with self.config_file.open("w") as f:
             f.write(str(self.saved_time))
 
     def on_click(self, event):
@@ -125,7 +125,7 @@ class Py3status:
     def _reset(self):
         if not self.running:
             self.saved_time = 0.0
-            with open(self.config_file, "w") as f:
+            with self.config_file.open("w") as f:
                 f.write("0")
 
     def rate_counter(self):

--- a/py3status/modules/screenshot.py
+++ b/py3status/modules/screenshot.py
@@ -37,9 +37,10 @@ basename
 {'color': '#00FF00', 'full_text': 'qs60.jpg'}
 """
 
-import os
 import random
 import string
+
+from pathlib import Path
 
 
 class Py3status:
@@ -65,7 +66,7 @@ class Py3status:
 
     def post_config_hook(self):
         self.shot_data = {}
-        self.save_path = os.path.expanduser(self.save_path)
+        self.save_path = Path(self.save_path).expanduser()
         self.chars = string.ascii_lowercase + string.digits
 
     def _generator(self, size=6):
@@ -79,7 +80,7 @@ class Py3status:
 
     def on_click(self, event):
         basename = self._generator(self.file_length) + ".jpg"
-        pathname = os.path.join(self.save_path, basename)
+        pathname = self.save_path / basename
         self.shot_data["basename"] = basename
 
         self.py3.command_run(" ".join([self.screenshot_command, pathname]))

--- a/py3status/modules/sql.py
+++ b/py3status/modules/sql.py
@@ -92,7 +92,7 @@ SAMPLE OUTPUT
 """
 
 from importlib import import_module
-from os.path import expanduser
+from pathlib import Path
 
 
 class Py3status:
@@ -124,7 +124,7 @@ class Py3status:
         )
         self.is_parameters_a_dict = isinstance(self.parameters, dict)
         if not self.is_parameters_a_dict:
-            self.parameters = expanduser(self.parameters)
+            self.parameters = Path(self.parameters).expanduser()
 
         self.thresholds_init = {}
         for name in ("format", "format_row"):

--- a/py3status/modules/sysdata.py
+++ b/py3status/modules/sysdata.py
@@ -106,6 +106,7 @@ SAMPLE OUTPUT
 
 from fnmatch import fnmatch
 from os import getloadavg
+from pathlib import Path
 
 import re
 
@@ -284,7 +285,7 @@ class Py3status:
                         break
 
     def _get_cpuinfo(self):
-        with open("/proc/cpuinfo") as f:
+        with Path("/proc/cpuinfo").open() as f:
             return [float(line.split()[-1]) for line in f if "cpu MHz" in line]
 
     def _calc_cpu_freqs(self, cpu_freqs, unit, keys):
@@ -301,7 +302,7 @@ class Py3status:
     def _get_stat(self):
         # kernel/system statistics. man -P 'less +//proc/stat' procfs
         stat = []
-        with open("/proc/stat") as f:
+        with Path("/proc/stat").open() as f:
             for line in f:
                 if "cpu" in line:
                     stat.append(line)
@@ -376,7 +377,7 @@ class Py3status:
         )
 
     def _get_meminfo(self, head=28):
-        with open("/proc/meminfo") as f:
+        with Path("/proc/meminfo").open() as f:
             info = [line.split() for line in (next(f) for x in range(head))]
             return {fields[0]: float(fields[1]) for fields in info}
 
@@ -422,7 +423,7 @@ class Py3status:
     def _get_cputemp(self, zone, unit):
         if zone is not None:
             try:
-                with open(zone) as f:
+                with Path(zone).open() as f:
                     cpu_temp = f.readline()
                     cpu_temp = float(cpu_temp) / 1000  # convert from mdegC to degC
             except (OSError, ValueError):

--- a/py3status/modules/thunderbird_todos.py
+++ b/py3status/modules/thunderbird_todos.py
@@ -138,9 +138,9 @@ SAMPLE OUTPUT
 {'full_text': 'New Task 1, New Task 2'}
 """
 
-from os import path
 from sqlite3 import connect
 from datetime import datetime
+from pathlib import Path
 
 STRING_NO_PROFILE = "missing profile"
 STRING_NOT_INSTALLED = "not installed"
@@ -166,20 +166,21 @@ class Py3status:
 
         # first profile, please.
         if not self.profile:
-            directory = "~/.thunderbird"
-            profile_ini = path.expanduser(directory + "/profiles.ini")
+            directory = Path("~/.thunderbird").expanduser()
+            profile_ini = directory / "profiles.ini"
             profile = []
-            for line in open(profile_ini):
-                if line.startswith("Path="):
-                    profile.append(
-                        "{}/{}".format(directory, line.split("Path=")[-1].strip())
-                    )
+            with profile_ini.open() as f:
+                for line in f:
+                    if line.startswith("Path="):
+                        profile.append(
+                            "{}/{}".format(directory, line.split("Path=")[-1].strip())
+                        )
             if not len(profile):
                 raise Exception(STRING_NO_PROFILE)
             self.profile = profile[0]
 
-        self.profile = path.expanduser(self.profile)
-        self.path = self.profile + "/calendar-data/local.sqlite"
+        self.profile = Path(self.profile).expanduser()
+        self.path = self.profile / "calendar-data/local.sqlite"
 
         self.init_datetimes = []
         for word in self.format_datetime:

--- a/py3status/modules/uptime.py
+++ b/py3status/modules/uptime.py
@@ -63,6 +63,7 @@ SAMPLE OUTPUT
 from time import time
 from datetime import datetime
 from collections import OrderedDict
+from pathlib import Path
 
 
 class Py3status:
@@ -91,7 +92,7 @@ class Py3status:
                 self.seconds, self.interval = None, second
 
     def uptime(self):
-        with open("/proc/uptime") as f:
+        with Path("/proc/uptime").open() as f:
             up = int(float(f.readline().split()[0]))
             offset = time() - up
 

--- a/py3status/modules/vpn_status.py
+++ b/py3status/modules/vpn_status.py
@@ -36,8 +36,8 @@ off
 from pydbus import SystemBus
 from gi.repository import GObject
 from threading import Thread
-from os import path
 from time import sleep
+from pathlib import Path
 
 
 class Py3status:
@@ -101,7 +101,7 @@ class Py3status:
 
     def _check_pid(self):
         """Returns True if pidfile exists, False otherwise."""
-        return path.isfile(self.pidfile)
+        return Path(self.pidfile).is_file()
 
     # Method run by py3status
     def vpn_status(self):

--- a/py3status/modules/watson.py
+++ b/py3status/modules/watson.py
@@ -24,8 +24,8 @@ SAMPLE OUTPUT
 """
 
 import json
-import os
 
+from pathlib import Path
 from typing import Dict, List, Union
 
 
@@ -39,10 +39,10 @@ class Py3status:
     state_file = "~/.config/watson/state"
 
     def post_config_hook(self):
-        self.state_file = os.path.expanduser(self.state_file)
+        self.state_file = Path(self.state_file).expanduser()
 
     def watson(self) -> Dict[str, str]:
-        if not os.path.isfile(self.state_file):
+        if not self.state_file.is_file():
             return {
                 "full_text": "State file not found",
                 "color": self.py3.COLOR_BAD,
@@ -50,7 +50,7 @@ class Py3status:
             }
 
         try:
-            with open(self.state_file) as f:
+            with self.state_file.open("r") as f:
                 session_data = json.load(f)
                 output = self._format_output(session_data=session_data)
                 output["cached_until"] = self.py3.time_in(seconds=self.cache_timeout)

--- a/py3status/modules/wwan_status.py
+++ b/py3status/modules/wwan_status.py
@@ -55,9 +55,9 @@ off
 """
 
 import netifaces as ni
-import os
 import stat
 import serial
+from pathlib import Path
 from time import sleep
 
 
@@ -92,7 +92,8 @@ class Py3status:
         response["cached_until"] = self.py3.time_in(self.cache_timeout)
 
         # Check if path exists and is a character device
-        if os.path.exists(self.modem) and stat.S_ISCHR(os.stat(self.modem).st_mode):
+        modem_path = Path(self.modem)
+        if modem_path.exists() and stat.S_ISCHR(modem_path.stat().st_mode):
             print("Found modem " + self.modem)
             try:
                 ser = serial.Serial(

--- a/py3status/modules/xkb_input.py
+++ b/py3status/modules/xkb_input.py
@@ -112,6 +112,8 @@ au
 {"color": "#F0E68C", "full_text": "au"}
 """
 
+from pathlib import Path
+
 STRING_ERROR = "invalid command `{}`"
 STRING_NOT_AVAILABLE = "no available binary"
 STRING_NOT_INSTALLED = "command `{}` not installed"
@@ -198,7 +200,7 @@ class Xkb:
         self.variant_mapping = []
 
         try:
-            with open("/usr/share/X11/xkb/rules/base.lst") as f:
+            with Path("/usr/share/X11/xkb/rules/base.lst").open() as f:
                 for chunk in f.read().split("\n\n"):
                     if "! layout" in chunk:
                         for line in chunk.splitlines()[1:]:

--- a/py3status/modules/xsel.py
+++ b/py3status/modules/xsel.py
@@ -35,7 +35,7 @@ SAMPLE OUTPUT
 
 
 import time
-import os.path
+from pathlib import Path
 
 
 class Py3status:
@@ -52,14 +52,13 @@ class Py3status:
 
     def post_config_hook(self):
         self.selection_cache = None
-        if self.log_file:
-            self.log_file = os.path.expanduser(self.log_file)
+        self.log_file = Path(self.log_file).expanduser()
 
     def xsel(self):
         selection = self.py3.command_output(self.command).strip()
 
         if self.log_file and selection and selection != self.selection_cache:
-            with open(self.log_file, "a") as f:
+            with self.log_file.open("a") as f:
                 datetime = time.strftime("%Y-%m-%d %H:%M:%S")
                 f.write(f"{datetime}\n{selection}\n")
             self.selection_cache = selection

--- a/py3status/modules/yubikey.py
+++ b/py3status/modules/yubikey.py
@@ -26,6 +26,8 @@ import os
 import socket
 import threading
 
+from pathlib import Path
+
 
 class YubiKeyTouchDetectorListener(threading.Thread):
     """
@@ -82,7 +84,7 @@ class Py3status:
     socket_path = "$XDG_RUNTIME_DIR/yubikey-touch-detector.socket"
 
     def post_config_hook(self):
-        self.socket_path = os.path.expanduser(self.socket_path)
+        self.socket_path = Path(self.socket_path).expanduser()
         self.socket_path = os.path.expandvars(self.socket_path)
 
         self.status = {"is_gpg": False, "is_u2f": False}

--- a/py3status/py3.py
+++ b/py3status/py3.py
@@ -6,6 +6,7 @@ from collections.abc import Mapping
 from copy import deepcopy
 from fnmatch import fnmatch
 from math import log10
+from pathlib import Path
 from pprint import pformat
 from subprocess import Popen, PIPE, STDOUT
 from time import time
@@ -1103,7 +1104,7 @@ class Py3:
             if cmd:
                 if cmd == "ffplay":
                     cmd = "ffplay -autoexit -nodisp -loglevel 0"
-                sound_file = os.path.expanduser(sound_file)
+                sound_file = Path(sound_file).expanduser()
                 c = shlex.split(f"{cmd} {sound_file}")
                 self._audio = Popen(c)
 

--- a/setup.py
+++ b/setup.py
@@ -4,11 +4,11 @@ py3status
 
 from setuptools import find_packages, setup
 import fastentrypoints  # noqa f401
-import os
 import sys
+from pathlib import Path
 
-module_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), "py3status")
-sys.path.insert(0, module_path)
+module_path = Path(__file__).resolve().parent / "py3status"
+sys.path.insert(0, str(module_path))
 from version import version  # noqa e402
 
 sys.path.remove(module_path)
@@ -19,7 +19,7 @@ sys.path.remove(module_path)
 # README file and 2) it's easier to type in the README file than to put a raw
 # string in below ...
 def read(fname):
-    return open(os.path.join(os.path.dirname(__file__), fname)).read()
+    return (Path(__file__).resolve().parent / fname).read_text()
 
 
 # extra requirements

--- a/tests/test_consistency.py
+++ b/tests/test_consistency.py
@@ -1,8 +1,6 @@
-import os
+from pathlib import Path
 
-MODULE_PATH = os.path.join(
-    os.path.dirname(os.path.abspath(__file__)), "..", "py3status", "modules"
-)
+MODULE_PATH = Path(__file__).resolve().parent.parent / "py3status" / "modules"
 
 
 def test_method_mismatch():
@@ -10,12 +8,11 @@ def test_method_mismatch():
     skip_files = ["__init__.py", "i3pystatus.py"]
     errors = []
 
-    for _file in sorted(os.listdir(MODULE_PATH)):
-        if _file.endswith(".py") and _file not in skip_files:
-            with open(os.path.join(MODULE_PATH, _file)) as f:
-                name = _file[:-3]
-                if f"def {name}(self" not in f.read():
-                    errors.append((name, _file))
+    for _file in sorted(MODULE_PATH.iterdir()):
+        if _file.suffix == ".py" and _file.name not in skip_files:
+            with _file.open() as f:
+                if f"def {_file.stem}(self" not in f.read():
+                    errors.append((_file.stem, _file))
     if errors:
         line = "Method mismatched error(s) detected!\n\n"
         for error in errors:
@@ -29,9 +26,9 @@ def test_authors():
     skip_files = ["__init__.py"]
     errors = []
 
-    for _file in sorted(os.listdir(MODULE_PATH)):
-        if _file.endswith(".py") and _file not in skip_files:
-            with open(os.path.join(MODULE_PATH, _file)) as f:
+    for _file in sorted(MODULE_PATH.iterdir()):
+        if _file.suffix == ".py" and _file.name not in skip_files:
+            with _file.open() as f:
                 if comment not in f.read():
                     errors.append((comment, _file))
     if errors:
@@ -47,9 +44,9 @@ def test_sample_output():
     skip_files = ["__init__.py"]
     errors = []
 
-    for _file in sorted(os.listdir(MODULE_PATH)):
-        if _file.endswith(".py") and _file not in skip_files:
-            with open(os.path.join(MODULE_PATH, _file)) as f:
+    for _file in sorted(MODULE_PATH.iterdir()):
+        if _file.suffix == ".py" and _file.name not in skip_files:
+            with _file.open() as f:
                 if comment not in f.read():
                     errors.append((comment, _file))
     if errors:
@@ -65,9 +62,9 @@ def test_sample_output():
 #     skip_files = ["__init__.py"]
 #     errors = []
 #
-#     for _file in sorted(os.listdir(MODULE_PATH)):
-#         if _file.endswith(".py") and _file not in skip_files:
-#             with open(os.path.join(MODULE_PATH, _file)) as f:
+#     for _file in sorted(MODULE_PATH.iterdir()):
+#         if _file.suffix == ".py" and _file.name not in skip_files:
+#             with _file.open() as f:
 #                 if comment not in f.read():
 #                     errors.append((comment, _file))
 #     if errors:
@@ -83,9 +80,9 @@ def test_available_configuration_parameters():
     skip_files = ["__init__.py"]
     errors = []
 
-    for _file in sorted(os.listdir(MODULE_PATH)):
-        if _file.endswith(".py") and _file not in skip_files:
-            with open(os.path.join(MODULE_PATH, _file)) as f:
+    for _file in sorted(MODULE_PATH.iterdir()):
+        if _file.suffix == ".py" and _file.name not in skip_files:
+            with _file.open() as f:
                 if comment not in f.read():
                     errors.append((comment, _file))
     if errors:
@@ -102,9 +99,9 @@ def test_class_meta_before_parameters():
     errors = []
     skip_files = ["__init__.py"]
 
-    for _file in sorted(os.listdir(MODULE_PATH)):
-        if _file.endswith(".py") and _file not in skip_files:
-            with open(os.path.join(MODULE_PATH, _file)) as f:
+    for _file in sorted(MODULE_PATH.iterdir()):
+        if _file.suffix == ".py" and _file.name not in skip_files:
+            with _file.open() as f:
                 for x in f.readlines():
                     if line in x:
                         errors.append((line, _file))
@@ -125,9 +122,9 @@ def test_examples_before_requires():
     errors = []
     skip_files = ["__init__.py"]
 
-    for _file in sorted(os.listdir(MODULE_PATH)):
-        if _file.endswith(".py") and _file not in skip_files:
-            with open(os.path.join(MODULE_PATH, _file)) as f:
+    for _file in sorted(MODULE_PATH.iterdir()):
+        if _file.suffix == ".py" and _file.name not in skip_files:
+            with _file.open() as f:
                 output = f.read()
                 if line not in output or comment not in output:
                     continue
@@ -151,9 +148,9 @@ def test_authors_before_examples():
     errors = []
     skip_files = ["__init__.py"]
 
-    for _file in sorted(os.listdir(MODULE_PATH)):
-        if _file.endswith(".py") and _file not in skip_files:
-            with open(os.path.join(MODULE_PATH, _file)) as f:
+    for _file in sorted(MODULE_PATH.iterdir()):
+        if _file.suffix == ".py" and _file.name not in skip_files:
+            with _file.open() as f:
                 output = f.read()
                 if line not in output or comment not in output:
                     continue
@@ -185,9 +182,9 @@ def test_format_placeholders():
     ]
     errors = []
 
-    for _file in sorted(os.listdir(MODULE_PATH)):
-        if _file.endswith(".py") and _file not in skip_files:
-            with open(os.path.join(MODULE_PATH, _file)) as f:
+    for _file in sorted(MODULE_PATH.iterdir()):
+        if _file.suffix == ".py" and _file.name not in skip_files:
+            with _file.open() as f:
                 output = f.read()
                 if comment not in output:
                     if comment2 not in output:

--- a/tests/test_module_doc.py
+++ b/tests/test_module_doc.py
@@ -11,10 +11,10 @@ Specific modules/config parameters are excluded but this should be discouraged.
 """
 
 import ast
-import os.path
 import re
 
 from collections import OrderedDict
+from pathlib import Path
 
 from py3status.docstrings import core_module_docstrings
 
@@ -40,9 +40,7 @@ AST_LITERAL_TYPES = {
     "Constant": "value",
 }
 
-MODULE_PATH = os.path.join(
-    os.path.dirname(os.path.abspath(__file__)), "..", "py3status", "modules"
-)
+MODULE_PATH = Path(__file__).resolve().parent.parent / "py3status" / "modules"
 
 
 def docstring_params(docstring):
@@ -173,7 +171,7 @@ def get_module_attributes(path):
                     value = line.value
                     dest[attr] = get_value(value)
 
-    with open(path) as f:
+    with path.open() as f:
         tree = ast.parse(f.read(), "")
         # some modules have constants defined we need to find these
         get_values(tree.body, names)
@@ -239,7 +237,7 @@ def check_docstrings():
         if module_name in IGNORE_MODULE:
             continue
 
-        path = os.path.join(MODULE_PATH, "%s.py" % module_name)
+        path = MODULE_PATH / f"{module_name}.py"
         mod_config = get_module_attributes(path)
 
         params, obsolete = docstring_params(docstrings[module_name])

--- a/tests/test_user_modules.py
+++ b/tests/test_user_modules.py
@@ -1,5 +1,5 @@
 import argparse
-import os
+from pathlib import Path
 
 import pkg_resources
 import pytest
@@ -17,11 +17,11 @@ def make_status_wrapper():
 
 def test__get_path_based_modules(status_wrapper):
     """Use the list of inbuilt modules as reference to check against."""
-    included_modules_path = os.path.join(os.path.dirname(py3status.__file__), "modules")
+    included_modules_path = Path(py3status.__file__).resolve().parent / "modules"
     status_wrapper.options.__dict__["include_paths"] = [included_modules_path]
-    assert os.path.exists(included_modules_path)
+    assert included_modules_path.exists()
     expected_keys = [
-        n[:-3] for n in os.listdir(included_modules_path) if n.endswith(".py")
+        n.stem for n in included_modules_path.iterdir() if n.suffix == ".py"
     ]
     modules = status_wrapper._get_path_based_modules()
     assert sorted(modules.keys()) == sorted(expected_keys)


### PR DESCRIPTION
The project uses different ways to manipulate paths and files. This is an attempt to replace all `os.path.*`, `glob.*`, and `open` calls with `pathlib.Path` objects and methods that make the directory tree structure clearer and that allow better manipulation of disk-related operations.