### PR TITLE
Use f-strings

### DIFF
--- a/py3status/autodoc.py
+++ b/py3status/autodoc.py
@@ -101,7 +101,7 @@ def markdown_2_rst(lines):
             code = not code
             space = " " * (len(line.rstrip()) - 3)
             if code:
-                out.append("\n\n%s.. code-block:: none\n\n" % space)
+                out.append(f"\n\n{space}.. code-block:: none\n\n")
             else:
                 out.append("\n")
         else:
@@ -163,7 +163,7 @@ def create_module_docs():
     out = []
     # details
     for module in sorted(data.keys()):
-        out.append("\n.. _module_%s:\n" % module)  # reference for linking
+        out.append(f"\n.. _module_{module}:\n")  # reference for linking
         out.append(
             "\n{name}\n{underline}\n\n{screenshots}{details}\n".format(
                 name=module,
@@ -304,9 +304,9 @@ def create_py3_docs():
         output = []
         for name, desc in v:
             output.append("")
-            output.append(".. _%s:" % name)  # reference for linking
+            output.append(f".. _{name}:")  # reference for linking
             output.append("")
-            output.append(".. py:{}:: {}".format(trans[k], name))
+            output.append(f".. py:{trans[k]}:: {name}")
             output.append("")
             output.extend(auto_undent(desc))
         Path(f"../doc/py3-{k}-info.inc").write_text("\n".join(output))
@@ -337,10 +337,10 @@ class ScreenshotDirective(Directive):
     def run(self):
         env = self.state.document.settings.env
 
-        targetid = "screenshot-%d" % env.new_serialno("screenshot")
+        targetid = f"screenshot-{env.new_serialno('screenshot')}"
         targetnode = nodes.target("", "", ids=[targetid])
 
-        image_name = "_%s" % targetid
+        image_name = f"_{targetid}"
         try:
             content = ast.literal_eval("\n".join(self.content))
         except:  # noqa e722

--- a/py3status/command.py
+++ b/py3status/command.py
@@ -159,7 +159,7 @@ class CommandRunner:
                         found_modules.add(module_name)
 
         if self.debug:
-            self.py3_wrapper.log("found %s" % found_modules)
+            self.py3_wrapper.log(f"found {found_modules}")
         return found_modules
 
     def refresh(self, data):
@@ -172,7 +172,7 @@ class CommandRunner:
         for module_name in self.find_modules(modules):
             module = self.py3_wrapper.output_modules[module_name]
             if self.debug:
-                self.py3_wrapper.log("refresh %s" % module)
+                self.py3_wrapper.log(f"refresh {module}")
             if module["type"] == "py3status":
                 module["module"].force_update()
             else:
@@ -209,7 +209,7 @@ class CommandRunner:
         """
         command = data.get("command")
         if self.debug:
-            self.py3_wrapper.log("Running remote command %s" % command)
+            self.py3_wrapper.log(f"Running remote command {command}")
         if command == "refresh":
             self.refresh(data)
         elif command == "refresh_all":
@@ -246,7 +246,7 @@ class CommandServer(threading.Thread):
         sock.bind(server_address.as_posix())
 
         if self.debug:
-            self.py3_wrapper.log("Unix domain socket at %s" % server_address)
+            self.py3_wrapper.log(f"Unix domain socket at {server_address}")
 
         # Listen for incoming connections
         sock.listen(1)
@@ -283,7 +283,7 @@ class CommandServer(threading.Thread):
                     if data:
                         data = json.loads(data.decode("utf-8"))
                         if self.debug:
-                            self.py3_wrapper.log("received %s" % data)
+                            self.py3_wrapper.log(f"received {data}")
                         self.command_runner.run_command(data)
                 finally:
                     # Clean up the connection
@@ -317,9 +317,7 @@ def command_parser():
 
     # parser: add verbose, version
     for short, name, msg in INFORMATION:
-        short = "-%s" % short
-        arg = "--%s" % name
-        parser.add_argument(short, arg, action="store_true", help=msg)
+        parser.add_argument(f"-{short}", f"--{name}", action="store_true", help=msg)
 
     # make subparsers // ALIAS_DEPRECATION: remove metavar later
     metavar = "{click,list,refresh}"
@@ -527,18 +525,18 @@ def send_command():
     options = command_parser()
     msg = json.dumps(vars(options)).encode("utf-8")
     if len(msg) > MAX_SIZE:
-        verbose("Message length too long, max length (%s)" % MAX_SIZE)
+        verbose(f"Message length too long, max length ({MAX_SIZE})")
 
     # find all likely socket addresses
     uds_list = Path(".").glob(f"{SERVER_ADDRESS}.[0-9]*")
 
-    verbose('message "%s"' % msg)
+    verbose(f"message {msg!r}")
     for uds in uds_list:
         # Create a UDS socket
         sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
 
         # Connect the socket to the port where the server is listening
-        verbose("connecting to %s" % uds)
+        verbose(f"connecting to {uds}")
         try:
             sock.connect(uds)
         except OSError:

--- a/py3status/core.py
+++ b/py3status/core.py
@@ -730,7 +730,7 @@ class Py3statusWrapper:
                 stderr=Path("/dev/null").open("w"),
             )
         except Exception as err:
-            self.log("notify_user error: %s" % err)
+            self.log(f"notify_user error: {err}")
 
     def stop(self):
         """

--- a/py3status/formatter.py
+++ b/py3status/formatter.py
@@ -179,8 +179,7 @@ class Formatter:
                 and token.group("key") in placeholder_formats
             ):
                 output.append(
-                    "{%s%s}"
-                    % (token.group("key"), placeholder_formats[token.group("key")])
+                    f"{{{token.group('key')}{placeholder_formats[token.group('key')]}}}"
                 )
                 continue
             value = token.group(0)
@@ -312,7 +311,7 @@ class Placeholder:
         """
         return the correct value for the placeholder
         """
-        value = "{%s}" % self.key
+        value = f"{{{self.key}}}"
         try:
             value = value_ = get_params(self.key)
             if self.format.startswith(":"):
@@ -357,14 +356,14 @@ class Placeholder:
         return valid, value, enough
 
     def __repr__(self):
-        return "<Placeholder {%s}>" % self.repr()
+        return f"<Placeholder {{{self.repr()}}}>"
 
     def repr(self):
         if self.format:
             value = f"{self.key}{self.format}"
         else:
             value = self.key
-        return "{%s}" % value
+        return f"{{{value}}}"
 
 
 class Literal:
@@ -376,7 +375,7 @@ class Literal:
         self.text = text
 
     def __repr__(self):
-        return "<Literal %s>" % self.text
+        return f"<Literal {self.text}>"
 
     def repr(self):
         return self.text
@@ -562,7 +561,7 @@ class Block:
         return self.next_block
 
     def __repr__(self):
-        return "<Block %s>" % self.repr()
+        return f"<Block {self.repr()}>"
 
     def repr(self):
         my_repr = [x.repr() for x in self.content]
@@ -624,8 +623,8 @@ class Block:
         # clean
         color = self.commands.color
         if color and color[0] != "#":
-            color_name = "color_%s" % color
-            threshold_color_name = "color_threshold_%s" % color
+            color_name = f"color_{color}"
+            threshold_color_name = f"color_threshold_{color}"
             # substitute color
             color = (
                 getattr(module, color_name, None)

--- a/py3status/i3status.py
+++ b/py3status/i3status.py
@@ -335,12 +335,12 @@ class I3status(Thread):
         """
         # order += ...
         for module in self.py3_config["i3s_modules"]:
-            self.write_in_tmpfile('order += "%s"\n' % module, tmpfile)
+            self.write_in_tmpfile(f'order += "{module}"\n', tmpfile)
         self.write_in_tmpfile("\n", tmpfile)
         # config params for general section and each module
         for section_name in ["general"] + self.py3_config["i3s_modules"]:
             section = self.py3_config[section_name]
-            self.write_in_tmpfile("%s {\n" % section_name, tmpfile)
+            self.write_in_tmpfile(f"{section_name} {{\n", tmpfile)
             for key, value in section.items():
                 # don't include color values except in the general section
                 if key.startswith("color"):

--- a/py3status/module.py
+++ b/py3status/module.py
@@ -154,9 +154,9 @@ class Module:
                     ),
                 ]
                 self.runtime_error(self.error_messages[0], "post_config_hook")
-                msg = "Exception in `%s` post_config_hook()" % self.module_full_name
+                msg = f"Exception in `{self.module_full_name}` post_config_hook()"
                 self._py3_wrapper.report_exception(msg, notify_user=False)
-                self._py3_wrapper.log("terminating module %s" % self.module_full_name)
+                self._py3_wrapper.log(f"terminating module {self.module_full_name}")
         self.enabled = True
 
     def runtime_error(self, msg, method):
@@ -227,7 +227,7 @@ class Module:
         self.prepare_module()
         if not (self.disabled or self.terminated):
             # Start the module and call its output method(s)
-            self._py3_wrapper.log("starting module %s" % self.module_full_name)
+            self._py3_wrapper.log(f"starting module {self.module_full_name}")
             self._py3_wrapper.timeout_queue_add(self)
 
     def force_update(self):
@@ -253,7 +253,7 @@ class Module:
         # purge from any container modules
         self._py3_wrapper.purge_module(self.module_full_name)
         self.error_output("")
-        self._py3_wrapper.log("disabling module `%s`" % self.module_full_name)
+        self._py3_wrapper.log(f"disabling module `{self.module_full_name}`")
 
     def wake(self):
         self.sleeping = False
@@ -682,7 +682,7 @@ class Module:
                         placeholder = item["placeholder"]
                         if "{}" in mod_config.get(param, ""):
                             mod_config[param] = mod_config[param].replace(
-                                "{}", "{%s}" % placeholder
+                                "{}", f"{{{placeholder}}}"
                             )
                             deprecation_log(item)
                 if "rename_placeholder" in deprecated:

--- a/py3status/modules/air_quality.py
+++ b/py3status/modules/air_quality.py
@@ -135,7 +135,7 @@ class Py3status:
 
     def post_config_hook(self):
         self.auth_token = {"token": self.auth_token}
-        self.url = "https://api.waqi.info/feed/%s/" % self.location
+        self.url = f"https://api.waqi.info/feed/{self.location}/"
         self.init_datetimes = []
         for word in self.format_datetime:
             if (self.py3.format_contains(self.format, word)) and (

--- a/py3status/modules/backlight.py
+++ b/py3status/modules/backlight.py
@@ -114,7 +114,7 @@ class Py3status:
         if not self.device:
             self.device = get_device()
         elif "/" not in self.device:
-            self.device = "/sys/class/backlight/%s" % self.device
+            self.device = f"/sys/class/backlight/{self.device}"
         if self.device is None:
             if self.hide_when_unavailable:
                 return

--- a/py3status/modules/battery_level.py
+++ b/py3status/modules/battery_level.py
@@ -358,7 +358,7 @@ class Py3status:
     def _seconds_to_hms(self, secs):
         m, s = divmod(secs, 60)
         h, m = divmod(m, 60)
-        return "%d:%02d:%02d" % (h, m, s)
+        return f"{h}:{m:02d}:{s:02d}"
 
     def _refresh_battery_info(self, battery_list):
         if type(self.battery_id) == int:

--- a/py3status/modules/cmus.py
+++ b/py3status/modules/cmus.py
@@ -115,7 +115,7 @@ class Py3status:
     def _seconds_to_time(self, value):
         m, s = divmod(int(value), 60)
         h, m = divmod(m, 60)
-        time = "%d:%02d:%02d" % (h, m, s)
+        time = f"{h}:{m:02d}:{s:02d}"
         return time.lstrip("0").lstrip(":")
 
     def _get_cmus_data(self):
@@ -196,7 +196,7 @@ class Py3status:
                     is_playing=is_playing,
                     is_started=is_started,
                     is_stopped=is_stopped,
-                    **data
+                    **data,
                 ),
             ),
         }

--- a/py3status/modules/conky.py
+++ b/py3status/modules/conky.py
@@ -366,7 +366,7 @@ class Py3status:
 
         # make an output.
         config = dumps(self.config, separators=(",", "=")).replace('"', "")
-        text = self.separator.join("${%s}" % x for x in conky_placeholders)
+        text = self.separator.join([f"${{{x}}}" for x in conky_placeholders])
         tmp = f"conky.config = {config}\nconky.text = [[{text}]]"
 
         # write tmp output to '/tmp/py3status-conky_*', make a command

--- a/py3status/modules/gitlab.py
+++ b/py3status/modules/gitlab.py
@@ -154,7 +154,7 @@ class Py3status:
     def on_click(self, event):
         button = event["button"]
         if button == self.button_open:
-            self.py3.command_run("xdg-open %s" % self.project)
+            self.py3.command_run(f"xdg-open {self.project}")
         if button != self.button_refresh:
             self.py3.prevent_refresh()
 

--- a/py3status/modules/hueshift.py
+++ b/py3status/modules/hueshift.py
@@ -67,8 +67,8 @@ cool
 [{'full_text': 'Blueshift '}, {'full_text': '10000K', 'color': '#33ccff'}]
 """
 
-STRING_BAD_COMMAND = "invalid command `%s`"
-STRING_NOT_INSTALLED = "command `%s` not installed"
+STRING_BAD_COMMAND = "invalid command `{}`"
+STRING_NOT_INSTALLED = "command `{}` not installed"
 STRING_NOT_AVAILABLE = "no available command"
 
 
@@ -96,9 +96,9 @@ class Py3status:
         if not self.command:
             self.command = self.py3.check_commands(hueshift_commands)
         elif self.command not in hueshift_commands:
-            raise Exception(STRING_BAD_COMMAND % self.command)
+            raise Exception(STRING_BAD_COMMAND.format(self.command))
         elif not self.py3.check_commands(self.command):
-            raise Exception(STRING_NOT_INSTALLED % self.command)
+            raise Exception(STRING_NOT_INSTALLED.format(self.command))
         if not self.command:
             raise Exception(STRING_NOT_AVAILABLE)
 

--- a/py3status/modules/kdeconnector.py
+++ b/py3status/modules/kdeconnector.py
@@ -113,7 +113,7 @@ class Py3status:
                 return False
 
         try:
-            self._dev = _bus.get(SERVICE_BUS, DEVICE_PATH + "/%s" % self.device_id)
+            self._dev = _bus.get(SERVICE_BUS, DEVICE_PATH + f"/{self.device_id}")
         except Exception:
             return False
 
@@ -130,7 +130,7 @@ class Py3status:
             return devices[0]
 
         for id in devices:
-            self._dev = bus.get(SERVICE_BUS, DEVICE_PATH + "/%s" % id)
+            self._dev = bus.get(SERVICE_BUS, DEVICE_PATH + f"/{id}")
             if self.device == self._dev.name:
                 return id
 

--- a/py3status/modules/keyboard_layout.py
+++ b/py3status/modules/keyboard_layout.py
@@ -123,7 +123,7 @@ class Py3status:
             if character in language:
                 language = language.replace(character, "_")
 
-        lang_color = getattr(self.py3, "COLOR_%s" % language)
+        lang_color = getattr(self.py3, f"COLOR_{language}")
         if not lang_color:
             lang_color = self.colors_dict.get(lang)
         if not lang_color:  # old compatibility: try default value

--- a/py3status/modules/keyboard_locks.py
+++ b/py3status/modules/keyboard_locks.py
@@ -68,7 +68,7 @@ class Py3status:
     def keyboard_locks(self):
         xset_data = self.py3.command_output("xset q")
         for k, v in self.keyring.items():
-            self.locks[k] = "on" in xset_data.split("%s Lock:" % v)[1][0:6]
+            self.locks[k] = "on" in xset_data.split(f"{v} Lock:")[1][0:6]
 
         return {
             "cached_until": self.py3.time_in(self.cache_timeout),

--- a/py3status/modules/net_rate.py
+++ b/py3status/modules/net_rate.py
@@ -98,7 +98,7 @@ class Py3status:
         if not isinstance(self.interfaces_blacklist, list):
             self.interfaces_blacklist = self.interfaces_blacklist.split(",")
         placeholders = self.py3.get_placeholder_formats_list(self.format_value)
-        values = ["{%s}" % x[1] for x in placeholders if x[0] == "value"]
+        values = [f"{{{x[1]}}}" for x in placeholders if x[0] == "value"]
         self._value_formats = values
         # last
         self.last_interface = None

--- a/py3status/modules/netdata.py
+++ b/py3status/modules/netdata.py
@@ -120,7 +120,7 @@ class Py3status:
                         break
             if self.nic is None:
                 self.nic = "lo"
-            self.py3.log("selected nic: %s" % self.nic)
+            self.py3.log(f"selected nic: {self.nic}")
 
         self.thresholds_init = self.py3.get_color_names_list(self.format)
 

--- a/py3status/modules/online_status.py
+++ b/py3status/modules/online_status.py
@@ -61,7 +61,7 @@ class Py3status:
     def post_config_hook(self):
         self.color_on = self.py3.COLOR_ON or self.py3.COLOR_GOOD
         self.color_off = self.py3.COLOR_OFF or self.py3.COLOR_BAD
-        self.ping_command = ["ping", "-c", "1", "-W", "%s" % self.timeout, self.url]
+        self.ping_command = ["ping", "-c", "1", "-W", f"{self.timeout}", self.url]
 
     def _connection_present(self):
         if "://" in self.url:

--- a/py3status/modules/player_control.py
+++ b/py3status/modules/player_control.py
@@ -97,7 +97,7 @@ class Py3status:
 
     def _run(self, command):
         if self.debug:
-            self.py3.log("running %s" % command)
+            self.py3.log(f"running {command}")
         self.py3.command_run(command)
 
     def _play(self):
@@ -137,7 +137,7 @@ class Py3status:
         """Change volume using amixer
         """
         sign = "+" if increase else "-"
-        delta = "%d%%%s" % (self.volume_tick, sign)
+        delta = f"{self.volume_tick}%{sign}"
         self._run(["amixer", "-q", "sset", "Master", delta])
 
     def _detect_running_player(self):
@@ -161,11 +161,11 @@ class Py3status:
         for player_name in supported_players:
             if player_name in running_players:
                 if self.debug:
-                    self.py3.log("found player: %s" % player_name)
+                    self.py3.log(f"found player: {player_name}")
 
                 # those players need the dbus module
                 if player_name in ("vlc") and not dbus_available:
-                    self.py3.log("%s requires the dbus python module" % player_name)
+                    self.py3.log(f"{player_name} requires the dbus python module")
                     return None
 
                 return player_name

--- a/py3status/modules/pomodoro.py
+++ b/py3status/modules/pomodoro.py
@@ -222,15 +222,12 @@ class Py3status:
             mins, seconds = divmod(rest, 60)
 
             if hours:
-                vals["mmss"] = "%d%s%02d%s%02d" % (
-                    hours,
-                    self.format_separator,
-                    mins,
-                    self.format_separator,
-                    seconds,
+                vals["mmss"] = (
+                    f"{hours}{self.format_separator}"
+                    f"{mins:02d}{self.format_separator}{seconds:02d}"
                 )
             else:
-                vals["mmss"] = "%d%s%02d" % (mins, self.format_separator, seconds)
+                vals["mmss"] = f"{mins}{self.format_separator}{seconds:02d}"
 
         if self.py3.format_contains(self.format, "bar"):
             vals["bar"] = self._setup_bar()

--- a/py3status/modules/rate_counter.py
+++ b/py3status/modules/rate_counter.py
@@ -141,11 +141,11 @@ class Py3status:
         subtotal = float(self.hour_price) * (running_time / SECS_IN_HOUR)
         total = subtotal * float(self.tax)
         subtotal_cost = self.py3.safe_format(
-            self.format_money, {"price": "%.2f" % subtotal}
+            self.format_money, {"price": f"{subtotal:.2f}"}
         )
-        total_cost = self.py3.safe_format(self.format_money, {"price": "%.2f" % total})
+        total_cost = self.py3.safe_format(self.format_money, {"price": f"{total:.2f}"})
         tax_cost = self.py3.safe_format(
-            self.format_money, {"price": "%.2f" % (total - subtotal)}
+            self.format_money, {"price": f"{total - subtotal:.2f}"}
         )
         response = {
             "cached_until": self.py3.time_in(self.cache_timeout),

--- a/py3status/modules/rss_aggregator.py
+++ b/py3status/modules/rss_aggregator.py
@@ -70,7 +70,7 @@ class Py3status:
     def post_config_hook(self):
         self._cached = "?"
         if self.aggregator not in ["owncloud", "ttrss"]:  # more options coming
-            raise ValueError("%s is not a supported feed aggregator" % self.aggregator)
+            raise ValueError(f"{self.aggregator} is not a supported feed aggregator")
         if self.user is None or self.password is None:
             raise ValueError("user and password must be provided")
 
@@ -97,7 +97,7 @@ class Py3status:
     def _get_count_owncloud(self):
         try:
             rss_count = 0
-            api_url = "%s/index.php/apps/news/api/v1-2/" % self.server
+            api_url = f"{self.server}/index.php/apps/news/api/v1-2/"
             r = requests.get(
                 api_url + "feeds", auth=(self.user, self.password), timeout=10
             )
@@ -117,7 +117,7 @@ class Py3status:
     def _get_count_ttrss(self):
         try:
             rss_count = 0
-            api_url = "%s/api/" % self.server
+            api_url = f"{self.server}/api/"
             r = requests.post(
                 api_url,
                 data=json.dumps(

--- a/py3status/modules/sql.py
+++ b/py3status/modules/sql.py
@@ -116,7 +116,7 @@ class Py3status:
                 if not self.py3.format_contains(self.format, config_name):
                     continue
             if not getattr(self, config_name, None):
-                raise Exception("missing %s" % config_name)
+                raise Exception(f"missing {config_name}")
 
         self.connect = getattr(import_module(self.database), "connect")
         self.operational_error = getattr(

--- a/py3status/modules/taskwarrior.py
+++ b/py3status/modules/taskwarrior.py
@@ -50,7 +50,7 @@ class Py3status:
             raise Exception(STRING_NOT_INSTALLED)
         self.placeholders = self.py3.get_placeholders_list(self.format)
         if self.filter:
-            self.taskwarrior_command = "task %s export" % self.filter
+            self.taskwarrior_command = f"task {self.filter} export"
         else:
             self.taskwarrior_command = "task export"
 

--- a/py3status/modules/volume_status.py
+++ b/py3status/modules/volume_status.py
@@ -84,9 +84,9 @@ import re
 import math
 from py3status.exceptions import CommandError
 
-STRING_ERROR = "invalid command `%s`"
+STRING_ERROR = "invalid command `{}`"
 STRING_NOT_AVAILABLE = "no available binary"
-COMMAND_NOT_INSTALLED = "command `%s` not installed"
+COMMAND_NOT_INSTALLED = "command `{}` not installed"
 
 
 class Audio:
@@ -356,9 +356,9 @@ class Py3status:
                 commands = ["amixer"]
             self.command = self.py3.check_commands(commands)
         elif self.command not in ["amixer", "pamixer", "pactl"]:
-            raise Exception(STRING_ERROR % self.command)
+            raise Exception(STRING_ERROR.format(self.command))
         elif not self.py3.check_commands(self.command):
-            raise Exception(COMMAND_NOT_INSTALLED % self.command)
+            raise Exception(COMMAND_NOT_INSTALLED.format(self.command))
         if not self.command:
             raise Exception(STRING_NOT_AVAILABLE)
 

--- a/py3status/modules/wanda_the_fish.py
+++ b/py3status/modules/wanda_the_fish.py
@@ -94,9 +94,9 @@ class Py3status:
             r"[\?color=orange&show <"
             r"[\?color=lightblue&show º]"
             r"[\?color=darkorange&show ,]))"
-            r"[\?color=darkorange&show ))>%s]]"
+            r"[\?color=darkorange&show ))>{}]]"
         )
-        wanda = [body % fin for fin in ("<", ">", "<", "3")]
+        wanda = [body.format(fin) for fin in ("<", ">", "<", "3")]
         self.wanda = [self.py3.safe_format(x) for x in wanda]
         self.wanda_length = len(self.wanda)
         self.index = 0

--- a/py3status/modules/weather_owm.py
+++ b/py3status/modules/weather_owm.py
@@ -385,11 +385,11 @@ class Py3status:
         for source in (defaults, self.icons):
             for key in source:
                 if not key.replace("_", "").isdigit():
-                    raise Exception("Invalid icon id: (%s)" % key)
+                    raise Exception(f"Invalid icon id: ({key})")
 
                 if "_" in key:
                     if key.count("_") != 1:
-                        raise Exception("Invalid icon range: %s" % key)
+                        raise Exception("fInvalid icon range: {key}")
 
                     # Populate each code
                     start, _, end = key.partition("_")

--- a/py3status/modules/xrandr.py
+++ b/py3status/modules/xrandr.py
@@ -319,8 +319,7 @@ class Py3status:
         """
         Center the given string on the detected max width.
         """
-        fmt = "{:^%d}" % self.max_width
-        return fmt.format(s)
+        return f"{s:^{self.max_width}}"
 
     def _apply(self, force=False):
         """

--- a/py3status/parse_config.py
+++ b/py3status/parse_config.py
@@ -378,7 +378,7 @@ class ConfigParser:
         """
         value = os.getenv(param)
         if value is None:
-            self.notify_user("Environment variable `%s` undefined" % param)
+            self.notify_user(f"Environment variable `{param}` undefined" % param)
         return self.value_convert(value, value_type)
 
     def make_value_from_shell(self, param, value_type, function):
@@ -394,7 +394,7 @@ class ConfigParser:
             else:
                 if self.py3_wrapper:
                     self.py3_wrapper.report_exception(
-                        msg="shell: called with command `%s`" % param
+                        msg=f"shell: called with command `{param}`"
                     )
                 self.notify_user("shell script exited with an error")
                 value = None
@@ -425,18 +425,17 @@ class ConfigParser:
 
                 value = base64.b64decode(value).decode("utf-8")
             except TypeError as e:
-                self.notify_user("base64(..) error %s" % str(e))
+                self.notify_user(f"base64(..) error {e}")
 
         # check we are in a module definition etc
         if not self.current_module:
-            self.notify_user("%s(..) used outside of module or section" % function)
+            self.notify_user(f"{function}(..) used outside of module or section")
             return None
 
         module = self.current_module[-1].split()[0]
         if module in CONFIG_FILE_SPECIAL_SECTIONS + I3S_MODULE_NAMES:
             self.notify_user(
-                "%s(..) cannot be used outside of py3status module "
-                "configuration" % function
+                f"{function}(..) cannot be used outside of py3status module configuration"
             )
             return None
 
@@ -887,5 +886,5 @@ if __name__ == "__main__":
         file_name = sys.argv[1]
     else:
         file_name = Path.home() / ".i3/i3status.conf"
-    print("\nPARSING CONFIG FILE %s\n\n" % file_name)
+    print(f"\nPARSING CONFIG FILE {file_name}\n\n")
     pprint.pprint(process_config(file_name))

--- a/py3status/profiling.py
+++ b/py3status/profiling.py
@@ -16,6 +16,6 @@ def profile(thread_run_fn):
             return profiler.runcall(thread_run_fn, self)
         finally:
             thread_id = getattr(self, "ident", "core")
-            profiler.dump_stats("py3status-%s.profile" % thread_id)
+            profiler.dump_stats(f"py3status-{thread_id}.profile")
 
     return wrapper_run

--- a/py3status/py3.py
+++ b/py3status/py3.py
@@ -125,7 +125,7 @@ class Py3:
         if it exists
         """
         if not name.startswith("COLOR_"):
-            raise AttributeError("Attribute `%s` not in Py3" % name)
+            raise AttributeError(f"Attribute `{name}` not in Py3")
         return self._get_config_setting(name.lower())
 
     def _get_config_setting(self, name, default=None):
@@ -1209,7 +1209,7 @@ class Py3:
 
         # save color so it can be accessed via safe_format()
         if name:
-            color_name = "color_threshold_%s" % name
+            color_name = f"color_threshold_{name}"
         else:
             color_name = "color_threshold"
         setattr(self._py3status_module, color_name, color)

--- a/py3status/request.py
+++ b/py3status/request.py
@@ -39,6 +39,7 @@ class HttpResponse:
             url = urlunsplit(parts)
         if auth:
             # we need to do the encode/decode to keep python 3 happy
+            # TODO: make this straight for python 3
             auth_str = base64.b64encode(("%s:%s" % (auth)).encode("utf-8"))
             headers["Authorization"] = "Basic %s" % auth_str.decode("utf-8")
         if data:

--- a/py3status/screenshots.py
+++ b/py3status/screenshots.py
@@ -86,7 +86,7 @@ def get_color_for_name(module_name):
         )
         * 3
     )[5 ** int(hue) // 3 % 3 :: int(hue) % 2 + 1][:3]
-    return "#" + "%02x" * 3 % (int(r), int(g), int(b))
+    return f"#{int(r):02x}{int(g):02x}{int(b):02x}"
 
 
 def contains_bad_glyph(glyph_data, data):

--- a/py3status/udev_monitor.py
+++ b/py3status/udev_monitor.py
@@ -55,20 +55,19 @@ class UdevMonitor:
                 self._setup_pyudev_monitoring()
             if trigger_action not in ON_TRIGGER_ACTIONS:
                 self.py3_wrapper.log(
-                    "module %s: invalid action %s on udev events subscription"
-                    % (py3_module.module_full_name, trigger_action)
+                    f"module {py3_module.module_full_name}: invalid action "
+                    f"{trigger_action} on udev events subscription"
                 )
                 return False
             self.udev_consumers[subsystem].append((py3_module, trigger_action))
             self.py3_wrapper.log(
-                "module %s subscribed to udev events on %s"
-                % (py3_module.module_full_name, subsystem)
+                f"module {py3_module.module_full_name} subscribed to udev events on {subsystem}"
             )
             return True
         else:
             self.py3_wrapper.log(
-                "pyudev module not installed: module %s not subscribed to events on %s"
-                % (py3_module.module_full_name, subsystem)
+                f"pyudev module not installed: module {py3_module.module_full_name} "
+                f"not subscribed to events on {subsystem}"
             )
             return False
 
@@ -79,8 +78,7 @@ class UdevMonitor:
         for py3_module, trigger_action in self.udev_consumers[subsystem]:
             if trigger_action in ON_TRIGGER_ACTIONS:
                 self.py3_wrapper.log(
-                    "%s udev event, refresh consumer %s"
-                    % (subsystem, py3_module.module_full_name)
+                    f"%{subsystem} udev event, refresh consumer {py3_module.module_full_name}"
                 )
                 sleep(0.1)
                 py3_module.force_update()

--- a/tests/test_module_doc.py
+++ b/tests/test_module_doc.py
@@ -154,9 +154,9 @@ def get_module_attributes(path):
                         else:
                             attr_value = f"UNKNOWN {class_name} BinOp {op}"
                     except Exception:
-                        attr_value = "UNKNOWN %s BinOp error" % class_name
+                        attr_value = f"UNKNOWN {class_name} BinOp error"
                 else:
-                    attr_value = "UNKNOWN %s" % class_name
+                    attr_value = f"UNKNOWN {class_name}"
             return attr_value
 
         if extra is None:
@@ -192,12 +192,12 @@ def _gen_diff(source, target, source_label="Source", target_label="Target"):
     # Determine the length of the longest item in the list
     max_elem_len = max(len(str(elem)) for elem in source)
     padding = "    "
-    format_str = padding + ("%%%ds %%s %%s" % max_elem_len)
+    format_str = padding + f"{{:{max_elem_len}}} {{}} {{}}"
 
     # Set up initial output contents
     middle_orig = "  "
     out = [
-        format_str % (source_label, middle_orig, target_label),
+        format_str.format(source_label, middle_orig, target_label),
         # Length of dashes is enough for the longest element on both sides,
         # plus the size of the middle symbol(s), plus two spaces for separation
         padding + ("-" * (2 * max_elem_len + len(middle_orig) + 2)),
@@ -222,7 +222,7 @@ def _gen_diff(source, target, source_label="Source", target_label="Target"):
             middle = "!!"
 
         # Place the diff into the output
-        out.append(format_str % (str(have), middle, str(want)))
+        out.append(format_str.format(str(have), middle, str(want)))
 
     return "\n".join(out) + "\n"
 


### PR DESCRIPTION
Since `py3status` is Python 3.6+, we can use f-strings for immediate string formatting. Some templates will be still formatted later using `.format`.