### PR TITLE
Use list/generator/dict comprehensions where appropriate

### DIFF
--- a/py3status/composite.py
+++ b/py3status/composite.py
@@ -74,7 +74,7 @@ class Composite:
         """
         Return the text only component of the composite.
         """
-        return "".join([x.get("full_text", "") for x in self._content])
+        return "".join(x.get("full_text", "") for x in self._content)
 
     def simplify(self):
         """

--- a/py3status/core.py
+++ b/py3status/core.py
@@ -943,7 +943,7 @@ class Py3statusWrapper:
                 if "color" not in output:
                     output["color"] = color
         # Create the json string output.
-        return ",".join([dumps(x) for x in outputs])
+        return ",".join(dumps(x) for x in outputs)
 
     def i3bar_stop(self, signum, frame):
         self.log("received SIGTSTP")
@@ -1038,7 +1038,7 @@ class Py3statusWrapper:
                         output[index] = out
 
                 # build output string
-                out = ",".join([x for x in output if x])
+                out = ",".join(x for x in output if x)
                 # dump the line to stdout
                 write(f",[{out}]\n")
                 flush()

--- a/py3status/events.py
+++ b/py3status/events.py
@@ -106,7 +106,7 @@ class Events(Thread):
         index = event.get("index")
         module_info = self.py3_wrapper.output_modules.get(module_name)
         output = module_info["module"].get_latest()
-        full_text = "".join([out["full_text"] for out in output])
+        full_text = "".join(out["full_text"] for out in output)
 
         partial = None
         if index is not None:

--- a/py3status/module.py
+++ b/py3status/module.py
@@ -512,7 +512,7 @@ class Module:
             min_length = self.py3status_module_options["min_length"]
 
             # get length, skip if length exceeds min_length
-            length = sum([len(x["full_text"]) for x in response["composite"]])
+            length = sum(len(x["full_text"]) for x in response["composite"])
             if length >= min_length:
                 return
 

--- a/py3status/modules/battery_level.py
+++ b/py3status/modules/battery_level.py
@@ -369,23 +369,19 @@ class Py3status:
             self.power_now = battery["power"]
 
         elif self.battery_id == "all":
-            total_capacity = sum([battery["capacity"] for battery in battery_list])
+            total_capacity = sum(battery["capacity"] for battery in battery_list)
 
             # Average and weigh % charged by the capacities of the batteries so
             # that self.percent_charged properly represents batteries that have
             # different capacities.
             self.percent_charged = int(
                 sum(
-                    [
-                        battery["capacity"]
-                        / total_capacity
-                        * battery["percent_charged"]
-                        for battery in battery_list
-                    ]
+                    battery["capacity"] / total_capacity * battery["percent_charged"]
+                    for battery in battery_list
                 )
             )
 
-            self.charging = any([battery["charging"] for battery in battery_list])
+            self.charging = any(battery["charging"] for battery in battery_list)
 
             # Assumes a system has at max two batteries
             active_battery = None
@@ -433,7 +429,7 @@ class Py3status:
             else:
                 self.time_remaining = None
 
-            self.power_now = sum([battery["power"] for battery in battery_list])
+            self.power_now = sum(battery["power"] for battery in battery_list)
 
         if self.time_remaining and self.hide_seconds:
             self.time_remaining = self.time_remaining[:-3]

--- a/py3status/modules/conky.py
+++ b/py3status/modules/conky.py
@@ -366,7 +366,7 @@ class Py3status:
 
         # make an output.
         config = dumps(self.config, separators=(",", "=")).replace('"', "")
-        text = self.separator.join(["${%s}" % x for x in conky_placeholders])
+        text = self.separator.join("${%s}" % x for x in conky_placeholders)
         tmp = f"conky.config = {config}\nconky.text = [[{text}]]"
 
         # write tmp output to '/tmp/py3status-conky_*', make a command

--- a/py3status/modules/deadbeef.py
+++ b/py3status/modules/deadbeef.py
@@ -87,7 +87,7 @@ class Py3status:
             set(self.py3.get_placeholders_list(self.format) + ["isplaying"])
         )
         self.deadbeef_command = 'deadbeef --nowplaying-tf "{}"'.format(
-            self.separator.join([f"%{x}%" for x in self.placeholders])
+            self.separator.join(f"%{x}%" for x in self.placeholders)
         )
         self.color_paused = self.py3.COLOR_PAUSED or self.py3.COLOR_DEGRADED
         self.color_playing = self.py3.COLOR_PLAYING or self.py3.COLOR_GOOD

--- a/py3status/modules/google_calendar.py
+++ b/py3status/modules/google_calendar.py
@@ -305,8 +305,8 @@ class Py3status:
 
                 # filter out blacklisted event names
                 if event["summary"] is not None:
-                    if event["summary"].lower() in map(
-                        lambda e: e.lower(), self.blacklist_events
+                    if event["summary"].lower() in (
+                        e.lower() for e in self.blacklist_events
                     ):
                         continue
 

--- a/py3status/modules/group.py
+++ b/py3status/modules/group.py
@@ -170,7 +170,7 @@ class Py3status:
             if not output:
                 widths.append(0)
             else:
-                widths.append(sum([len(x["full_text"]) for x in output]))
+                widths.append(sum(len(x["full_text"]) for x in output))
             if i == self.active:
                 current = output
                 current_width = widths[-1]

--- a/py3status/modules/hddtemp.py
+++ b/py3status/modules/hddtemp.py
@@ -145,7 +145,7 @@ class Py3status:
             try:
                 hdd["name"] = self.cache_names[hdd["name"]]
             except KeyError:
-                key = "".join([x for x in hdd["name"] if x in printable]).strip()
+                key = "".join(x for x in hdd["name"] if x in printable).strip()
                 if key.endswith("G B") and key[-4].isdigit():
                     key = "GB".join(key.rsplit("G B", 1))
                 hdd["name"] = self.cache_names[hdd["name"]] = key

--- a/py3status/modules/khal_calendar.py
+++ b/py3status/modules/khal_calendar.py
@@ -54,7 +54,7 @@ class Py3status:
             str(datetime.now().strftime(self.datetimeformat)) + " " + self.date_end
         )
         output = khal_list(self.collection, daterange, self.config, self.output_format)
-        output = list(map(lambda x: self._format_output(x), output[1:]))
+        output = [self._format_output(x) for x in output[1:]]
 
         output = " ".join(output)
         khal_data = {"appointments": output}

--- a/py3status/modules/net_rate.py
+++ b/py3status/modules/net_rate.py
@@ -210,8 +210,8 @@ class Py3status:
         x = filter(dev_filter, open(self.devfile).readlines()[2:])
 
         try:
-            # split info into words, filter empty ones
-            return [list(filter(lambda x: x, _x.split(" "))) for _x in x]
+            # split info into words
+            return [_x.split() for _x in x]
 
         except StopIteration:
             return None

--- a/py3status/modules/net_rate.py
+++ b/py3status/modules/net_rate.py
@@ -129,8 +129,8 @@ class Py3status:
             # get the interface with max rate
             if self.sum_values:
                 interface = "sum"
-                sum_up = sum([itm["up"] for _, itm in deltas.items()])
-                sum_down = sum([itm["down"] for _, itm in deltas.items()])
+                sum_up = sum(itm["up"] for _, itm in deltas.items())
+                sum_down = sum(itm["down"] for _, itm in deltas.items())
                 deltas[interface] = {
                     "total": sum_up + sum_down,
                     "up": sum_up,

--- a/py3status/modules/scratchpad.py
+++ b/py3status/modules/scratchpad.py
@@ -127,7 +127,7 @@ class Msg(Ipc):
         return {
             "ipc": self.parent.ipc,
             "scratchpad": len(leaves),
-            "urgent": sum([window["urgent"] for window in leaves]),
+            "urgent": sum(window["urgent"] for window in leaves),
         }
 
     def find_scratchpad(self, tree):

--- a/py3status/modules/screenshot.py
+++ b/py3status/modules/screenshot.py
@@ -83,7 +83,7 @@ class Py3status:
         pathname = self.save_path / basename
         self.shot_data["basename"] = basename
 
-        self.py3.command_run(" ".join([self.screenshot_command, pathname]))
+        self.py3.command_run(" ".join(self.screenshot_command, pathname))
 
         if self.upload_server and self.upload_user and self.upload_path:
             self.py3.command_run(

--- a/py3status/modules/sysdata.py
+++ b/py3status/modules/sysdata.py
@@ -313,7 +313,7 @@ class Py3status:
         # if avg, return (name, idle, total)
         if avg:
             fields = stat[0].split()
-            return "avg", int(fields[4]), sum(map(int, fields[1:]))
+            return "avg", int(fields[4]), sum(int(x) for x in fields[1:])
 
         # return a list of (name, idle, total)
         new_stat = []
@@ -328,7 +328,7 @@ class Py3status:
                 if cpu_name not in self.cpus["list"]:
                     continue
 
-            new_stat.append((cpu_name, int(fields[4]), sum(map(int, fields[1:]))))
+            new_stat.append((cpu_name, int(fields[4]), sum(int(x) for x in fields[1:])))
         return new_stat
 
     def _calc_mem_info(self, unit, meminfo, memory):

--- a/py3status/modules/taskwarrior.py
+++ b/py3status/modules/taskwarrior.py
@@ -56,10 +56,7 @@ class Py3status:
 
     @staticmethod
     def descriptions(tasks_json):
-        def _describeTask(taskObj):
-            return str(taskObj["id"]) + " " + taskObj["description"]
-
-        return ", ".join(map(_describeTask, tasks_json))
+        return ", ".join(f"{t['id']} {t['description']}" for t in tasks_json)
 
     @staticmethod
     def tasks(tasks_json):

--- a/py3status/modules/weather_owm.py
+++ b/py3status/modules/weather_owm.py
@@ -392,8 +392,8 @@ class Py3status:
                         raise Exception("Invalid icon range: %s" % key)
 
                     # Populate each code
-                    (start, end) = tuple(map(int, key.split("_")))
-                    for code in range(start, end + 1):
+                    start, _, end = key.partition("_")
+                    for code in range(int(start), int(end) + 1):
                         data[code] = source[key]
 
                 else:
@@ -477,7 +477,7 @@ class Py3status:
 
     def _get_loc_tz_info(self):
         # Preference a user-set location
-        if all(map(lambda x: x is not None, (self.location, self.city, self.country))):
+        if all(x is not None for x in (self.location, self.city, self.country)):
             return (self.location, self.city, self.country)
 
         data = {}

--- a/py3status/modules/xkb_input.py
+++ b/py3status/modules/xkb_input.py
@@ -310,7 +310,7 @@ class Xkblayout_State(Xkb):
         self.placeholders = list("cnsveC")
         self.separator = "|SEPARATOR|"
         self.xkblayout_command = "xkblayout-state print {}".format(
-            self.separator.join(["%" + x for x in self.placeholders])
+            self.separator.join("%" + x for x in self.placeholders)
         )
 
     def get_xkb_inputs(self):

--- a/py3status/modules/xrandr.py
+++ b/py3status/modules/xrandr.py
@@ -287,7 +287,7 @@ class Py3status:
         show = getattr(self, f"icon_{mode}").join(
             tuple(getattr(self, f"{x}_icon", x) for x in combination)
         )
-        self.max_width = max([self.max_width, len(show)])
+        self.max_width = max(self.max_width, len(show))
         return show
 
     def _choose_what_to_display(self, force_refresh=False):

--- a/py3status/modules/xrandr_rotate.py
+++ b/py3status/modules/xrandr_rotate.py
@@ -78,7 +78,7 @@ class Py3status:
     def _get_current_rotation_icon(self, all_outputs):
         data = self.py3.command_output(["xrandr"]).splitlines()
         output = self.screen or all_outputs[0]
-        output_line = "".join([x for x in data if x.startswith(output)])
+        output_line = "".join(x for x in data if x.startswith(output))
 
         for x in output_line.split():
             if "normal" in x or "inverted" in x:

--- a/tests/test_module_doc.py
+++ b/tests/test_module_doc.py
@@ -121,21 +121,19 @@ def get_module_attributes(path):
                 attr_value = getattr(value, value_type)
             else:
                 if class_name == "Dict":
-                    attr_value = dict(
-                        zip(
-                            list(map(get_value, value.keys)),
-                            list(map(get_value, value.values)),
-                        )
-                    )
+                    attr_value = {
+                        get_value(k): get_value(v)
+                        for k, v in zip(value.keys, value.values)
+                    }
                 elif class_name == "List":
-                    attr_value = list(map(get_value, value.elts))
+                    attr_value = [get_value(e) for e in value.elts]
                 elif class_name == "Name":
                     # in python 2 True, False, None are Names rather than
                     # NameConstant so we use them for the default
                     default = python2_names.get(value.id)
                     attr_value = extra.get(value.id, default)
                 elif class_name == "Tuple":
-                    attr_value = tuple(map(get_value, value.elts))
+                    attr_value = tuple(get_value(e) for e in value.elts)
                 elif class_name == "UnaryOp":
                     op = value.op.__class__.__name__
                     attr_value = get_value(value.operand)

--- a/tests/test_module_doc.py
+++ b/tests/test_module_doc.py
@@ -192,7 +192,7 @@ def _gen_diff(source, target, source_label="Source", target_label="Target"):
         lst.extend([blank for i in range(max_len - len(lst))])
 
     # Determine the length of the longest item in the list
-    max_elem_len = max([len(str(elem)) for elem in source])
+    max_elem_len = max(len(str(elem)) for elem in source)
     padding = "    "
     format_str = padding + ("%%%ds %%s %%s" % max_elem_len)
 


### PR DESCRIPTION
Remove some redundant code, such as square brackets, as well as `map/lambda` calls and use list/generator/dict comprehensions where appropriate.