### PR TITLE
Fix sys.path manipulation in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ module_path = Path(__file__).resolve().parent / "py3status"
 sys.path.insert(0, str(module_path))
 from version import version  # noqa e402
 
-sys.path.remove(module_path)
+sys.path.remove(str(module_path))
 
 
 # Utility function to read the README file.


### PR DESCRIPTION
Fixes bug introduced in 37603bf3d08d08ebf8fe38ef5d419e51f03821ec and reported by @X-dark within #1978

`sys.path` contains `str` only and so should be all `Path`s converted to `str`.