### PR TITLE
Fixes mpris for Chrome, too.

### DIFF
--- a/py3status/modules/mpris.py
+++ b/py3status/modules/mpris.py
@@ -451,12 +451,14 @@ class Py3status:
         if not player_id.startswith(SERVICE_BUS):
             return False
 
-        # Fixes chromium mpris
+        # Fixes chromium/google-chrome mpris
         try:
             player = self._dbus.get(player_id, SERVICE_BUS_URL)
         except KeyError:
             if "chromium" in player_id:
                 player = BrokenDBusMpris(self._dbus, "Chromium", "Stopped")
+            elif "chrome" in player_id:
+                player = BrokenDBusMpris(self._dbus, "Chrome", "Stopped")
             else:
                 return False
 


### PR DESCRIPTION
Chrome is exactly as broken as Chromium, but has the player_id "chrome",
instead of "chromium".

This adds a rather unelegant but simple workaround, to "fix" it in the same way.