### PR TITLE
Remove obsolete numeric relics from Python 2

### DIFF
--- a/py3status/formatter.py
+++ b/py3status/formatter.py
@@ -325,7 +325,7 @@ class Placeholder:
                 # be successfully converted then the format will be removed.
                 try:
                     if "ceil" in self.format:
-                        value = int(ceil(float(value)))
+                        value = ceil(float(value))
                     if "f" in self.format:
                         value = float(value)
                     if "g" in self.format:

--- a/py3status/module.py
+++ b/py3status/module.py
@@ -518,7 +518,7 @@ class Module:
 
             # sometimes we go under min_length to pad both side evenly,
             # we will add extra space on either side to honor min_length
-            padding = int((min_length / 2.0) - (length / 2.0))
+            padding = min_length // 2 - length // 2
             offset = min_length - ((padding * 2) + length)
 
             # set position

--- a/py3status/modules/battery_level.py
+++ b/py3status/modules/battery_level.py
@@ -102,8 +102,7 @@ FULLY_CHARGED = "?"
 
 
 class Py3status:
-    """
-    """
+    """"""
 
     # available configuration parameters
     battery_id = 0
@@ -333,9 +332,7 @@ class Py3status:
             battery = {}
             battery["capacity"] = capacity
             battery["charging"] = "Charging" in r["POWER_SUPPLY_STATUS"]
-            battery["percent_charged"] = int(
-                math.floor(remaining_energy / capacity * 100)
-            )
+            battery["percent_charged"] = math.floor(remaining_energy / capacity * 100)
             if present_rate == 0:
                 # Battery is either full charged or is not discharging
                 battery["time_remaining"] = FULLY_CHARGED
@@ -346,7 +343,7 @@ class Py3status:
                     time_in_secs = remaining_energy / present_rate * 3600
                 battery["time_remaining"] = self._seconds_to_hms(time_in_secs)
 
-            battery["power"] = current_now * voltage_now / 1e12
+            battery["power"] = current_now * voltage_now / 10 ** 12
 
             battery_list.append(battery)
         return battery_list
@@ -437,12 +434,10 @@ class Py3status:
     def _update_ascii_bar(self):
         self.ascii_bar = FULL_BLOCK * int(self.percent_charged / 10)
         if self.charging:
-            self.ascii_bar += EMPTY_BLOCK_CHARGING * (
-                10 - int(self.percent_charged / 10)
-            )
+            self.ascii_bar += EMPTY_BLOCK_CHARGING * (10 - self.percent_charged // 10)
         else:
             self.ascii_bar += EMPTY_BLOCK_DISCHARGING * (
-                10 - int(self.percent_charged / 10)
+                10 - self.percent_charged // 10
             )
 
     def _update_icon(self):

--- a/py3status/modules/clock.py
+++ b/py3status/modules/clock.py
@@ -257,9 +257,9 @@ class Py3status:
                 icon = None
                 if self.py3.format_contains(format_time, "icon"):
                     # calculate the decimal hour
-                    h = t.hour + t.minute / 60.0
+                    h = t.hour + t.minute / 60
                     if self.round_to_nearest_block:
-                        h += (self.block_hours / len(self.blocks)) / 2
+                        h += self.block_hours / len(self.blocks) / 2
                     # make 12 hourly etc
                     h = h % self.block_hours
                     idx = int(h / self.block_hours * len(self.blocks))

--- a/py3status/modules/graphite.py
+++ b/py3status/modules/graphite.py
@@ -75,12 +75,12 @@ from syslog import syslog, LOG_INFO
 
 def format_value(num, value_round=True):
     for unit in ["", "K", "M", "G", "T", "P", "E", "Z"]:
-        if abs(num) < 1000.0:
+        if abs(num) < 1000:
             if value_round:
                 return f"{num:1.0f}{unit}"
             else:
                 return f"{num:3.1f}{unit}"
-        num /= 1000.0
+        num /= 1000
     if value_round:
         return "{:.0f}{}".format(num, "Y")
     else:

--- a/py3status/modules/lm_sensors.py
+++ b/py3status/modules/lm_sensors.py
@@ -296,11 +296,11 @@ class Py3status:
                         if _min >= _input:
                             auto_input.append((_min, self.color_min))
                         if _max:
-                            _near_max = _max - _max / 100.0 * 10.0
+                            _near_max = _max - _max / 100 * 10
                             auto_input.append((_near_max, self.color_near_max))
                             auto_input.append((_max, self.color_max))
                         if _crit:
-                            _near_crit = _crit - _crit / 100.0 * 10.0
+                            _near_crit = _crit - _crit / 100 * 10
                             auto_input.append((_near_crit, self.color_near_crit))
                             auto_input.append((_crit, self.color_crit))
 

--- a/py3status/modules/nvidia_smi.py
+++ b/py3status/modules/nvidia_smi.py
@@ -131,7 +131,7 @@ class Py3status:
         for line in nvidia_data.splitlines():
             gpu = dict(zip(self.properties, line.split(", ")))
             gpu["memory.used_percent"] = (
-                float(gpu["memory.used"]) / float(gpu["memory.total"]) * 100.0
+                float(gpu["memory.used"]) / float(gpu["memory.total"]) * 100
             )
 
             for key in self.memory_properties:

--- a/py3status/modules/pomodoro.py
+++ b/py3status/modules/pomodoro.py
@@ -191,10 +191,9 @@ class Py3status:
         """
         bar = ""
         items_cnt = len(PROGRESS_BAR_ITEMS)
-        bar_val = float(self._time_left) / self._section_time * self.num_progress_bars
+        bar_val = self._time_left / self._section_time * self.num_progress_bars
         while bar_val > 0:
-            selector = int(bar_val * items_cnt)
-            selector = min(selector, items_cnt - 1)
+            selector = min(int(bar_val * items_cnt), items_cnt - 1)
             bar += PROGRESS_BAR_ITEMS[selector]
             bar_val -= 1
 
@@ -215,7 +214,7 @@ class Py3status:
         else:
             time_left = ceil(self._time_left)
 
-        vals = {"ss": int(time_left), "mm": int(ceil(time_left / 60))}
+        vals = {"ss": int(time_left), "mm": ceil(time_left / 60)}
 
         if self.py3.format_contains(self.format, "mmss"):
             hours, rest = divmod(time_left, 3600)

--- a/py3status/modules/rate_counter.py
+++ b/py3status/modules/rate_counter.py
@@ -43,7 +43,7 @@ from pathlib import Path
 
 
 # No "magic numbers"
-SECS_IN_MIN = 60.0
+SECS_IN_MIN = 60
 SECS_IN_HOUR = 60 * SECS_IN_MIN  # 3600
 SECS_IN_DAY = 24 * SECS_IN_HOUR  # 86400
 
@@ -87,12 +87,9 @@ class Py3status:
         Using days as the largest unit of time.  Blindly using the days in
         `time.gmtime()` will fail if it's more than one month (days > 31).
         """
-        days = int(time_in_secs / SECS_IN_DAY)
-        remaining_secs = time_in_secs % SECS_IN_DAY
-        hours = int(remaining_secs / SECS_IN_HOUR)
-        remaining_secs = remaining_secs % SECS_IN_HOUR
-        mins = int(remaining_secs / SECS_IN_MIN)
-        secs = int(remaining_secs % SECS_IN_MIN)
+        days, secs = divmod(int(time_in_secs), SECS_IN_DAY)
+        hours, secs = divmod(secs, SECS_IN_HOUR)
+        mins, secs = divmod(secs, SECS_IN_MIN)
         return days, hours, mins, secs
 
     def _start_timer(self):
@@ -138,7 +135,7 @@ class Py3status:
             running_time = self.saved_time
 
         days, hours, mins, secs = self.secs_to_dhms(running_time)
-        subtotal = float(self.hour_price) * (running_time / SECS_IN_HOUR)
+        subtotal = self.hour_price * running_time / SECS_IN_HOUR
         total = subtotal * float(self.tax)
         subtotal_cost = self.py3.safe_format(
             self.format_money, {"price": f"{subtotal:.2f}"}

--- a/py3status/modules/sysdata.py
+++ b/py3status/modules/sysdata.py
@@ -292,10 +292,10 @@ class Py3status:
         freq_avg, freq_max = None, None
         for key in keys:
             if key == "cpu_freq_avg":
-                value = sum(cpu_freqs) / len(cpu_freqs) * 1e6
+                value = sum(cpu_freqs) / len(cpu_freqs) * 10 ** 6
                 freq_avg, _ = self.py3.format_units(value, unit, si=True)
             elif key == "cpu_freq_max":
-                value = max(cpu_freqs) * 1e6
+                value = max(cpu_freqs) * 10 ** 6
                 freq_max, _ = self.py3.format_units(value, unit, si=True)
         return freq_avg, freq_max
 
@@ -437,7 +437,7 @@ class Py3status:
 
         if cpu_temp is float:
             if unit == "°F":
-                cpu_temp = cpu_temp * (9.0 / 5.0) + 32
+                cpu_temp = cpu_temp * 9 / 5 + 32
             elif unit == "K":
                 cpu_temp += 273.15
 

--- a/py3status/modules/volume_status.py
+++ b/py3status/modules/volume_status.py
@@ -387,7 +387,7 @@ class Py3status:
             icon = self.blocks[
                 min(
                     len(self.blocks) - 1,
-                    int(math.ceil(int(perc) / 100 * (len(self.blocks) - 1))),
+                    math.ceil(int(perc) / 100 * (len(self.blocks) - 1)),
                 )
             ]
 

--- a/py3status/modules/weather_owm.py
+++ b/py3status/modules/weather_owm.py
@@ -661,7 +661,7 @@ class Py3status:
             return val - 273.15
 
         def kToF(val):
-            return val * (9.0 / 5.0) - 459.67
+            return val * 9 / 5 - 459.67
 
         options = {
             "c": {

--- a/py3status/modules/wifi.py
+++ b/py3status/modules/wifi.py
@@ -148,10 +148,10 @@ class Py3status:
             self.py3.log(msg)
 
     def _dbm_to_percent(self, dbm):
-        return 2.0 * (dbm + 100)
+        return 2 * (dbm + 100)
 
     def _percent_to_dbm(self, percent):
-        return (percent / 2.0) - 100
+        return (percent / 2) - 100
 
     def _get_wifi_data(self, command):
         for time in range(2):
@@ -209,7 +209,7 @@ class Py3status:
         freq_out = re.search(r"freq: ([\-0-9]+)", iw)
         if freq_out:
             freq_mhz = int(freq_out.group(1))
-            freq_ghz = freq_mhz / 1000.0
+            freq_ghz = freq_mhz / 1000
 
         # ip
         if self.py3.format_contains(self.format, "ip"):
@@ -229,7 +229,7 @@ class Py3status:
 
         # wifi
         if ssid is not None:
-            icon = self.blocks[int(math.ceil(quality / 100.0 * (len(self.blocks) - 1)))]
+            icon = self.blocks[math.ceil(quality / 100 * (len(self.blocks) - 1))]
             color = self.py3.COLOR_GOOD
             if bitrate:
                 if bitrate <= self.bitrate_bad:

--- a/py3status/modules/xsel.py
+++ b/py3status/modules/xsel.py
@@ -66,7 +66,7 @@ class Py3status:
         selection = " ".join(selection.split())
         if len(selection) >= self.max_size:
             if self.symmetric is True:
-                split = int(self.max_size / 2) - 1
+                split = self.max_size // 2 - 1
                 selection = selection[:split] + ".." + selection[-split:]
             else:
                 selection = selection[: self.max_size]


### PR DESCRIPTION
Remove unnecessary int/float conversions in Python3 code that were needed in Python2.

Another idea would be to use `ratio` (0.0–1.0) instead of `percents` (0–100) and only convert them to string at the end (`f'{0.1234:.1%}'` converts nicely to `12.3%`), which would save a lot of multiplication/division by 100 in the code. What do you think?