### PR TITLE
Use time.perf_counter to measure short time periods

### DIFF
--- a/py3status/core.py
+++ b/py3status/core.py
@@ -109,7 +109,7 @@ class CheckI3StatusThread(Task):
             self.notify_user(err)
         else:
             # check again in 5 seconds
-            self.timeout_queue_add(self, int(time.time()) + 5)
+            self.timeout_queue_add(self, int(time.perf_counter()) + 5)
 
 
 class ModuleRunner(Task):
@@ -251,7 +251,7 @@ class Py3statusWrapper:
         """
         self.config = vars(options)
         self.i3bar_running = True
-        self.last_refresh_ts = time.time()
+        self.last_refresh_ts = time.perf_counter()
         self.lock = Event()
         self.modules = {}
         self.notified_messages = set()
@@ -344,7 +344,7 @@ class Py3statusWrapper:
         # process any items that need adding to the queue
         while self.timeout_add_queue:
             self.timeout_process_add_queue(*self.timeout_add_queue.popleft())
-        now = time.time()
+        now = time.perf_counter()
         due_timeouts = []
         # find any due timeouts
         for timeout in self.timeout_keys:
@@ -402,7 +402,7 @@ class Py3statusWrapper:
 
         # we return how long till we next need to process the timeout_queue
         if self.timeout_due is not None:
-            return self.timeout_due - time.time()
+            return self.timeout_due - time.perf_counter()
 
     def gevent_monkey_patch_report(self):
         """
@@ -689,7 +689,7 @@ class Py3statusWrapper:
         limit_key = ""
         if rate_limit:
             try:
-                limit_key = time.time() // rate_limit
+                limit_key = time.perf_counter() // rate_limit
             except TypeError:
                 pass
         # We use a hash to see if the message is being repeated.  This is crude
@@ -764,8 +764,8 @@ class Py3statusWrapper:
         refreshes.
         """
         if not module_string:
-            if time.time() > (self.last_refresh_ts + 0.1):
-                self.last_refresh_ts = time.time()
+            if time.perf_counter() > (self.last_refresh_ts + 0.1):
+                self.last_refresh_ts = time.perf_counter()
             else:
                 # rate limiting
                 return

--- a/py3status/i3status.py
+++ b/py3status/i3status.py
@@ -1,4 +1,5 @@
 import sys
+import time
 
 from copy import deepcopy
 from json import loads
@@ -8,7 +9,6 @@ from subprocess import PIPE
 from signal import SIGTSTP, SIGSTOP, SIGUSR1, SIG_IGN, signal
 from tempfile import NamedTemporaryFile
 from threading import Thread
-from time import time
 
 from py3status.profiling import profile
 from py3status.py3 import Py3
@@ -136,7 +136,7 @@ class I3statusModule:
             self.item = item
         else:
             # If no timezone or a minute has passed update timezone
-            t = time()
+            t = time.perf_counter()
             if self.time_zone_check_due < t:
                 # If we are late for our timezone update then schedule the next
                 # update to happen when we next get new data from i3status
@@ -238,7 +238,7 @@ class I3status(Thread):
         self.json_list = None
         self.json_list_ts = None
         self.last_output = None
-        self.last_refresh_ts = time()
+        self.last_refresh_ts = time.perf_counter()
         self.lock = py3_wrapper.lock
         self.new_update = False
         self.py3_config = py3_wrapper.config["py3_config"]
@@ -343,12 +343,12 @@ class I3status(Thread):
 
     def refresh_i3status(self):
         # refresh i3status.  This is rate limited
-        if time() > (self.last_refresh_ts + 0.1):
+        if time.perf_counter() > (self.last_refresh_ts + 0.1):
             if self.py3_wrapper.config["debug"]:
                 self.py3_wrapper.log("refreshing i3status")
             if self.i3status_pipe:
                 self.i3status_pipe.send_signal(SIGUSR1)
-            self.last_refresh_ts = time()
+            self.last_refresh_ts = time.perf_counter()
 
     @profile
     def run(self):

--- a/py3status/module_test.py
+++ b/py3status/module_test.py
@@ -1,7 +1,8 @@
+import time
+
 from ast import literal_eval
 from sys import argv
 from threading import Event
-from time import sleep, time
 
 from py3status.core import Common, Module
 
@@ -97,7 +98,7 @@ def module_test(module_class, config=None):
     while not m.error_messages:
         try:
             for meth in m.methods:
-                m.methods[meth]["cached_until"] = time()
+                m.methods[meth]["cached_until"] = time.perf_counter()
             m.run()
             output = m.get_latest()
             for item in output:
@@ -124,7 +125,7 @@ def module_test(module_class, config=None):
                     output = output[0]
                 print(output)
 
-            sleep(1)
+            time.sleep(1)
         except KeyboardInterrupt:
             m.kill()
             break

--- a/py3status/modules/clock.py
+++ b/py3status/modules/clock.py
@@ -92,8 +92,8 @@ london
 
 import locale
 import re
+import time
 from datetime import datetime
-from time import time
 
 import pytz
 import tzlocal
@@ -184,7 +184,7 @@ class Py3status:
             self.active = 0
 
         # reset the cycle time
-        self._cycle_time = time() + self.cycle
+        self._cycle_time = time.perf_counter() + self.cycle
 
     def _get_timezone(self, tz):
         """
@@ -217,7 +217,7 @@ class Py3status:
     def _change_active(self, diff):
         self.active = (self.active + diff) % len(self.format)
         # reset the cycle time
-        self._cycle_time = time() + self.cycle
+        self._cycle_time = time.perf_counter() + self.cycle
         # save the active format
         timezone = self.format[self.active]
         self.py3.storage_set("timezone", timezone)
@@ -241,9 +241,9 @@ class Py3status:
     def clock(self):
 
         # cycling
-        if self.cycle and time() >= self._cycle_time:
+        if self.cycle and time.perf_counter() >= self._cycle_time:
             self._change_active(1)
-            self._cycle_time = time() + self.cycle
+            self._cycle_time = time.perf_counter() + self.cycle
 
         # update our times
         times = {}

--- a/py3status/modules/diskdata.py
+++ b/py3status/modules/diskdata.py
@@ -55,8 +55,8 @@ SAMPLE OUTPUT
 {'full_text': 'all:  34.4% ( 82.0 KiB/s)'}
 """
 
+import time
 from pathlib import Path
-from time import time
 
 
 class Py3status:
@@ -92,7 +92,7 @@ class Py3status:
 
         if self.init["diskstats"]:
             self.last_diskstats = self._get_diskstats(self.disk)
-            self.last_time = time()
+            self.last_time = time.perf_counter()
 
         self.thresholds_init = self.py3.get_color_names_list(self.format)
 
@@ -146,7 +146,7 @@ class Py3status:
         return read, write
 
     def _calc_diskstats(self, diskstats):
-        current_time = time()
+        current_time = time.perf_counter()
         timedelta = current_time - self.last_time
         read = (diskstats[0] - self.last_diskstats[0]) / timedelta
         write = (diskstats[1] - self.last_diskstats[1]) / timedelta

--- a/py3status/modules/google_calendar.py
+++ b/py3status/modules/google_calendar.py
@@ -259,7 +259,7 @@ class Py3status:
 
         Returns: The list of events.
         """
-        self.last_update = time.time()
+        self.last_update = time.perf_counter()
         time_min = datetime.datetime.utcnow()
         time_max = time_min + datetime.timedelta(hours=self.events_within_hours)
         events = []
@@ -501,7 +501,7 @@ class Py3status:
                 self.py3.prevent_refresh()
             elif button == self.button_refresh:
                 # wait before the next refresh
-                if time.time() - self.last_update > 1:
+                if time.perf_counter() - self.last_update > 1:
                     self.no_update = False
             elif button == self.button_toggle:
                 self.button_states[button_index] = not self.button_states[button_index]

--- a/py3status/modules/group.py
+++ b/py3status/modules/group.py
@@ -86,7 +86,7 @@ cycle_again
 {'full_text': 'module 3'}
 """
 
-from time import time
+import time
 
 # maximum wait for initial content at startup
 MAX_NO_CONTENT_WAIT = 5
@@ -120,7 +120,7 @@ class Py3status:
 
         self.first_run = True
         self.active = 0
-        self.cycle_time = time() + self.cycle
+        self.cycle_time = time.perf_counter() + self.cycle
         self.cycle_timeout = self.cycle
         self.last_active = 0
         self.urgent = False
@@ -223,7 +223,7 @@ class Py3status:
             self.first_run = False
             update_time = 1
         elif self.cycle_timeout and not urgent:
-            current_time = time()
+            current_time = time.perf_counter()
             if current_time >= self.cycle_time - 0.1:
                 self._change_active(1)
                 output, update_time = self._get_output_and_time()
@@ -276,7 +276,7 @@ class Py3status:
                 return
 
         self.cycle = self.cycle_timeout
-        self.cycle_time = time() + self.cycle
+        self.cycle_time = time.perf_counter() + self.cycle
 
         if button == self.button_next:
             if self.open:

--- a/py3status/modules/mpris.py
+++ b/py3status/modules/mpris.py
@@ -96,7 +96,7 @@ SAMPLE OUTPUT
 """
 
 from datetime import timedelta
-from time import time
+import time
 from gi.repository import GObject
 from gi.repository.GLib import GError
 from threading import Thread
@@ -315,7 +315,7 @@ class Py3status:
             and self._data.get("state") == PLAYING
         ):
             # Don't get trapped in aliasing errors!
-            update = time() + 0.5
+            update = time.perf_counter() + 0.5
         else:
             update = self.py3.CACHE_FOREVER
 

--- a/py3status/modules/net_rate.py
+++ b/py3status/modules/net_rate.py
@@ -52,7 +52,7 @@ SAMPLE OUTPUT
 {'full_text': 'eno1:  852.2 KiB/s'}
 """
 
-from time import time
+import time
 
 
 class Py3status:
@@ -103,7 +103,7 @@ class Py3status:
         # last
         self.last_interface = None
         self.last_stat = self._get_stat()
-        self.last_time = time()
+        self.last_time = time.perf_counter()
 
         self.thresholds_init = self.py3.get_color_names_list(self.format)
 
@@ -112,7 +112,7 @@ class Py3status:
         deltas = {}
         try:
             # time from previous check
-            current_time = time()
+            current_time = time.perf_counter()
             timedelta = current_time - self.last_time
 
             # calculate deltas for all interfaces

--- a/py3status/modules/netdata.py
+++ b/py3status/modules/netdata.py
@@ -32,8 +32,8 @@ SAMPLE OUTPUT
 ]
 """
 
+import time
 from pathlib import Path
-from time import time
 
 
 class Py3status:
@@ -109,7 +109,7 @@ class Py3status:
     def post_config_hook(self):
         self.last_transmitted_bytes = 0
         self.last_received_bytes = 0
-        self.last_time = time()
+        self.last_time = time.perf_counter()
         # Get default gateway from /proc.
         if self.nic is None:
             with Path("/proc/net/route").open() as fh:
@@ -135,7 +135,7 @@ class Py3status:
     def netdata(self):
         received_bytes, transmitted_bytes = self._get_bytes()
         # speed
-        current_time = time()
+        current_time = time.perf_counter()
         timedelta = current_time - self.last_time
         self.last_time = current_time
         down = (received_bytes - self.last_received_bytes) / 1024 / timedelta

--- a/py3status/modules/pomodoro.py
+++ b/py3status/modules/pomodoro.py
@@ -58,9 +58,10 @@ running
 {'color': '#00FF00', 'full_text': u'Pomodoro [1483]'}
 """
 
+import time
 from math import ceil
 from threading import Timer
-from time import time
+
 
 PROGRESS_BAR_ITEMS = "▏▎▍▌▋▊▉"
 
@@ -160,12 +161,12 @@ class Py3status:
         if event["button"] == 1:
             if self._running:
                 self._running = False
-                self._time_left = self._end_time - time()
+                self._time_left = self._end_time - time.perf_counter()
                 if self._timer:
                     self._timer.cancel()
             else:
                 self._running = True
-                self._end_time = time() + self._time_left
+                self._end_time = time.perf_counter() + self._time_left
                 if self._timer:
                     self._timer.cancel()
                 self._timer = Timer(self._time_left, self._time_up)
@@ -210,7 +211,7 @@ class Py3status:
 
         cached_until = self.py3.time_in(0)
         if self._running:
-            self._time_left = ceil(self._end_time - time())
+            self._time_left = ceil(self._end_time - time.perf_counter())
             time_left = ceil(self._time_left)
         else:
             time_left = ceil(self._time_left)

--- a/py3status/modules/rainbow.py
+++ b/py3status/modules/rainbow.py
@@ -67,7 +67,7 @@ SAMPLE OUTPUT
 
 import re
 import math
-from time import time
+import time
 
 HEX_RE = re.compile("#([0-9a-fA-F]{3}|[0-9a-fA-F]{6})")
 
@@ -155,7 +155,7 @@ class Py3status:
         """
         Set next cycle update time synced to nearest second or 0.1 of second.
         """
-        now = time()
+        now = time.perf_counter()
         try:
             cycle_time = now - self._cycle_time
             if cycle_time < 0:
@@ -188,7 +188,7 @@ class Py3status:
         if not self.items:
             return {"full_text": "", "cached_until": self.py3.CACHE_FOREVER}
 
-        if time() >= self._cycle_time - (self.cycle_time / 10):
+        if time.perf_counter() >= self._cycle_time - (self.cycle_time / 10):
             self.active_color = (self.active_color + 1) % len(self.colors)
             self._set_cycle_time()
 

--- a/py3status/modules/rate_counter.py
+++ b/py3status/modules/rate_counter.py
@@ -78,7 +78,7 @@ class Py3status:
 
         Using a helper property to make it easy to keep consistency.
         """
-        return time.time()
+        return time.perf_counter()
 
     @staticmethod
     def secs_to_dhms(time_in_secs):

--- a/py3status/modules/speedtest.py
+++ b/py3status/modules/speedtest.py
@@ -126,9 +126,10 @@ details
 ]
 """
 
+import time
 from json import loads
 from threading import Thread
-from time import time
+
 
 STRING_NOT_INSTALLED = "not installed"
 
@@ -198,7 +199,7 @@ class Py3status:
 
     def _set_speedtest_data(self):
         # start
-        self.start_time = time()
+        self.start_time = time.perf_counter()
         self.speedtest_data["elapsed"] = True
 
         try:
@@ -217,12 +218,12 @@ class Py3status:
 
         # end
         self.speedtest_data["elapsed"] = False
-        self.speedtest_data["elapsed_time"] = time() - self.start_time
+        self.speedtest_data["elapsed_time"] = time.perf_counter() - self.start_time
 
     def speedtest(self):
         if self.speedtest_data.get("elapsed"):
             cached_until = 0
-            self.speedtest_data["elapsed_time"] = time() - self.start_time
+            self.speedtest_data["elapsed_time"] = time.perf_counter() - self.start_time
         else:
             cached_until = self.py3.CACHE_FOREVER
             self.py3.storage_set("speedtest_data", self.speedtest_data)

--- a/py3status/modules/timer.py
+++ b/py3status/modules/timer.py
@@ -44,7 +44,7 @@ paused
 ]
 """
 
-from time import time
+import time
 from threading import Timer
 
 
@@ -81,7 +81,7 @@ class Py3status:
 
     def timer(self):
         if self.running or self.done:
-            t = int(self.end_time - time())
+            t = int(self.end_time - time.perf_counter())
             if t <= 0:
                 t = 0
         else:
@@ -143,7 +143,7 @@ class Py3status:
             if self.running:
                 # pause timer
                 self.running = False
-                self.time_left = int(self.end_time - time())
+                self.time_left = int(self.end_time - time.perf_counter())
                 self.color = self.py3.COLOR_DEGRADED
                 if self.alarm_timer:
                     self.alarm_timer.cancel()
@@ -151,9 +151,9 @@ class Py3status:
                 # start/restart timer
                 self.running = True
                 if self.time_left:
-                    self.end_time = time() + self.time_left
+                    self.end_time = time.perf_counter() + self.time_left
                 else:
-                    self.end_time = time() + self.time
+                    self.end_time = time.perf_counter() + self.time
                 self.cache_offset = self.end_time % 1
                 self.color = self.py3.COLOR_GOOD
                 if self.alarm_timer:

--- a/py3status/modules/uptime.py
+++ b/py3status/modules/uptime.py
@@ -60,7 +60,7 @@ SAMPLE OUTPUT
 {'full_text': 'up 1 days 18 hours 20 minutes'}
 """
 
-from time import time
+import time
 from datetime import datetime
 from collections import OrderedDict
 from pathlib import Path
@@ -94,7 +94,7 @@ class Py3status:
     def uptime(self):
         with Path("/proc/uptime").open() as f:
             up = int(float(f.readline().split()[0]))
-            offset = time() - up
+            offset = time.time() - up
 
         uptime = {}
         for unit, interval in self.time_periods.items():

--- a/py3status/modules/velib_metropole.py
+++ b/py3status/modules/velib_metropole.py
@@ -77,8 +77,9 @@ no_velib
 {'full_text': 'No Velib'}
 """
 
+import time
 from re import sub
-from time import time
+
 
 STRING_MISSING_STATIONS = "missing stations"
 VELIB_ENDPOINT = "https://www.velib-metropole.fr/webapi/map/details"
@@ -223,7 +224,7 @@ class Py3status:
 
     def velib_metropole(self):
         # refresh
-        current_time = time()
+        current_time = time.perf_counter()
         refresh = current_time >= self.idle_time
 
         # time

--- a/py3status/modules/whatismyip.py
+++ b/py3status/modules/whatismyip.py
@@ -47,7 +47,7 @@ mode
 {'color': '#00FF00', 'full_text': u'\u25cf'}
 """
 
-from time import time
+import time
 
 URL_GEO_OLD_DEFAULT = "http://ip-api.com/json"
 URL_GEO_NEW_DEFAULT = "https://ifconfig.co/json"
@@ -120,7 +120,7 @@ class Py3status:
 
     def whatismyip(self):
         # refresh
-        current_time = time()
+        current_time = time.perf_counter()
         refresh = current_time >= self.idle_time
 
         # time

--- a/py3status/py3.py
+++ b/py3status/py3.py
@@ -1,6 +1,7 @@
 import os
 import sys
 import shlex
+import time
 
 from collections.abc import Mapping
 from copy import deepcopy
@@ -9,7 +10,6 @@ from math import log10
 from pathlib import Path
 from pprint import pformat
 from subprocess import Popen, PIPE, STDOUT
-from time import time
 from uuid import uuid4
 
 from py3status import exceptions
@@ -624,7 +624,7 @@ class Py3:
                 if seconds:
                     seconds -= 0.1
 
-        requested = time() + seconds - offset
+        requested = time.perf_counter() + seconds - offset
 
         # if sync_to then we find the sync time for the requested time
         if sync_to:

--- a/py3status/storage.py
+++ b/py3status/storage.py
@@ -1,9 +1,9 @@
 import os
+import time
 
 from pathlib import Path
 from pickle import dump, load
 from tempfile import NamedTemporaryFile
-from time import time
 
 
 class Storage:
@@ -90,7 +90,7 @@ class Storage:
         if module_name not in self.data:
             self.data[module_name] = {}
         self.data[module_name][key] = value
-        ts = time()
+        ts = time.time()
         if "_ctime" not in self.data[module_name]:
             self.data[module_name]["_ctime"] = ts
         self.data[module_name]["_mtime"] = ts


### PR DESCRIPTION
When using `time.time()` twice to get a short timedelta, such as refresh rate, timeout, or elapsed time, where the zero (unix epoch) is not important, this may return false (even negative) results if the system clock gets updated during that time.

To measure such short timedeltas, `time.perf_counter()` is better, because at each call it returns a positive float that is higher than the previous value.

The negative point is that this float is process-dependent and cannot be shared between processes. Therefore I have avoided modification of the code that stores this value on disk for the next instance to load it.

There are several name misuses of `time` in the code. They should be renamed to something more meaningful.