### PR TITLE
argparsers: use shutil.which instead of external which binary

### DIFF
--- a/py3status/argparsers.py
+++ b/py3status/argparsers.py
@@ -2,6 +2,7 @@ import argparse
 import os
 import subprocess
 from pathlib import Path
+from shutil import which
 
 from platform import python_version
 from py3status.version import version
@@ -17,14 +18,7 @@ def parse_cli_args():
     xdg_dirs_path = Path(os.environ.get("XDG_CONFIG_DIRS", "/etc/xdg"))
 
     # get i3status path
-    try:
-        with Path(os.devnull).open("w") as devnull:
-            command = ["which", "i3status"]
-            i3status_path = (
-                subprocess.check_output(command, stderr=devnull).decode().strip()
-            )
-    except subprocess.CalledProcessError:
-        i3status_path = None
+    i3status_path = which("i3status")
 
     # get window manager
     with Path(os.devnull).open("w") as devnull:

--- a/py3status/py3.py
+++ b/py3status/py3.py
@@ -9,6 +9,7 @@ from fnmatch import fnmatch
 from math import log10
 from pathlib import Path
 from pprint import pformat
+from shutil import which
 from subprocess import Popen, PIPE, STDOUT
 from uuid import uuid4
 
@@ -926,7 +927,7 @@ class Py3:
 
     def check_commands(self, cmd_list):
         """
-        Checks to see if commands in list are available using ``which``.
+        Checks to see if commands in list are available using shutil.which().
 
         returns the first available command.
 
@@ -938,7 +939,7 @@ class Py3:
             cmd_list = [cmd_list]
 
         for cmd in cmd_list:
-            if self.command_run(f"which {cmd}") == 0:
+            if which(cmd) is not None:
                 return cmd
 
     def command_run(self, command):


### PR DESCRIPTION
As promised, here is the PR to replace the external `which` binary with pure Python code: [`shutil.which`](https://docs.python.org/3/library/shutil.html#shutil.which) has been introduced in Python 3.3 and follows the same conventions as the current code, returning either a string with the full path to the executable or None if the executable wasn't found on `$PATH`. This helps reducing the amount of external utilities that py3status has to rely on.

Closes: #1994