### PR TITLE
fix an issue with the lm_sensors module 

### DIFF
--- a/py3status/modules/lm_sensors.py
+++ b/py3status/modules/lm_sensors.py
@@ -204,7 +204,7 @@ class Py3status:
                 for chunk in lm_sensors_data.split("\n\n")[:-1]:
                     for line in chunk.splitlines():
                         if fnmatch(line, _filter):
-                            chips.append(line)
+                            chips.append(_filter)
                         break
             self.lm_sensors_command += " {}".format(" ".join(chips))
 


### PR DESCRIPTION
I noticed that on my system, where my USB-connected PSU's connection sometimes drops under high load, that py3status would need to be restarted before it would detect my PSU again. 

I wasn't able to find any regressions or measure a performance difference with this change, but I'm certainly open to other suggestions. 