### PR TITLE
volume_status: run with either pulseaudio or pipewire installed

### DIFF
--- a/py3status/modules/volume_status.py
+++ b/py3status/modules/volume_status.py
@@ -352,7 +352,7 @@ class Py3status:
         if not self.command:
             commands = ["pamixer", "pactl", "amixer"]
             # pamixer, pactl requires pulseaudio to work
-            if not self.py3.check_commands("pulseaudio"):
+            if not self.py3.check_commands(["pulseaudio", "pipewire"]):
                 commands = ["amixer"]
             self.command = self.py3.check_commands(commands)
         elif self.command not in ["amixer", "pamixer", "pactl"]:


### PR DESCRIPTION
pipewire is now able to completely replace pulseaudio, so there may be
no "pulseaudio" command.