### PR TITLE
battery_level module: fix converting seconds to H:M:S format

### DIFF
--- a/py3status/modules/battery_level.py
+++ b/py3status/modules/battery_level.py
@@ -355,7 +355,7 @@ class Py3status:
     def _seconds_to_hms(self, secs):
         m, s = divmod(secs, 60)
         h, m = divmod(m, 60)
-        return f"{int(h):02d}:{int(m):02d}:{int(s):02d}"
+        return f"{int(h):2d}:{int(m):02d}:{int(s):02d}"
 
     def _refresh_battery_info(self, battery_list):
         if type(self.battery_id) == int:

--- a/py3status/modules/battery_level.py
+++ b/py3status/modules/battery_level.py
@@ -355,7 +355,7 @@ class Py3status:
     def _seconds_to_hms(self, secs):
         m, s = divmod(secs, 60)
         h, m = divmod(m, 60)
-        return f"{h}:{int(m):02d}:{int(s):02d}"
+        return f"{int(h):02d}:{int(m):02d}:{int(s):02d}"
 
     def _refresh_battery_info(self, battery_list):
         if type(self.battery_id) == int:


### PR DESCRIPTION
This PR fixes computing of the battery remaining time. The `h` value was not ensured to be an integer which caused issues in function `_hms_to_seconds` trying to call someting like `int("0.0")` and resulting with an error.