### PR TITLE
net_iplist show only non deprecated ipv6 addresses

### DIFF
--- a/py3status/modules/net_iplist.py
+++ b/py3status/modules/net_iplist.py
@@ -78,7 +78,7 @@ class Py3status:
     def post_config_hook(self):
         self.iface_re = re.compile(r"\d+: (?P<iface>[\w\-]+):")
         self.ip_re = re.compile(r"\s+inet (?P<ip4>[\d.]+)(?:/| )")
-        self.ip6_re = re.compile(r"\s+inet6 (?P<ip6>[\da-f:]+)(?:/| )")
+        self.ip6_re = re.compile(r"\s+inet6 (?P<ip6>[\da-f:]+)(?:/\d{1,3}| ) scope global dynamic")
 
     def net_iplist(self):
         response = {

--- a/py3status/modules/net_iplist.py
+++ b/py3status/modules/net_iplist.py
@@ -78,7 +78,9 @@ class Py3status:
     def post_config_hook(self):
         self.iface_re = re.compile(r"\d+: (?P<iface>[\w\-]+):")
         self.ip_re = re.compile(r"\s+inet (?P<ip4>[\d.]+)(?:/| )")
-        self.ip6_re = re.compile(r"\s+inet6 (?P<ip6>[\da-f:]+)(?:/\d{1,3}| ) scope global dynamic")
+        self.ip6_re = re.compile(
+            r"\s+inet6 (?P<ip6>[\da-f:]+)(?:/\d{1,3}| ) scope global dynamic"
+        )
 
     def net_iplist(self):
         response = {


### PR DESCRIPTION
net_iplist shows all ipv6 addresses on a interface which can be alot. This patch removes all old deprecated from the list.