### PR TITLE
fix hour output to be set as int

### DIFF
--- a/py3status/modules/battery_level.py
+++ b/py3status/modules/battery_level.py
@@ -355,7 +355,7 @@ class Py3status:
     def _seconds_to_hms(self, secs):
         m, s = divmod(secs, 60)
         h, m = divmod(m, 60)
-        return f"{h}:{int(m):02d}:{int(s):02d}"
+        return f"{int(h)}:{int(m):02d}:{int(s):02d}"
 
     def _refresh_battery_info(self, battery_list):
         if type(self.battery_id) == int:


### PR DESCRIPTION
2021-02-17 13:58:59 WARNING Instance `battery_level`, user method `battery_level` failed.
2021-02-17 13:58:59 INFO Traceback
ValueError: invalid literal for int() with base 10: '1.0'
  File "/usr/lib/python3.9/site-packages/py3status/module.py", line 948, in run
    response = method()
  File "/usr/lib/python3.9/site-packages/py3status/modules/battery_level.py", line 183, in battery_level
    self._refresh_battery_info(battery_list)
  File "/usr/lib/python3.9/site-packages/py3status/modules/battery_level.py", line 402, in _refresh_battery_info
    time_remaining_seconds = self._hms_to_seconds(
  File "/usr/lib/python3.9/site-packages/py3status/modules/battery_level.py", line 352, in _hms_to_seconds
    h, m, s = [int(i) for i in t.split(":")]
  File "/usr/lib/python3.9/site-packages/py3status/modules/battery_level.py", line 352, in <listcomp>
    h, m, s = [int(i) for i in t.split(":")]

Hours weren't set as an int after breakout, so they ended up as "h.0".  Calling a single battery still returns, but displays time as "h.0:mm:ss".  Calling with multiple batteries "battery_id = all" wouldn't make it to the second battery and thus would fail to output.