### PR TITLE
[Module : Google Calendar] Additional options

### DIFF
--- a/py3status/modules/google_calendar.py
+++ b/py3status/modules/google_calendar.py
@@ -82,6 +82,7 @@ Configuration parameters:
     warn_timeout: The number of seconds before a warning should be issued again.
         (default 300)
 
+
 Control placeholders:
     {is_toggled} a boolean toggled by button_toggle
 
@@ -413,7 +414,9 @@ class Py3status:
             event_dict["summary"] = event.get("summary")
             event_dict["location"] = event.get("location")
             event_dict["description"] = event.get("description")
-            self.event_urls.append(event.get(self.preferred_event_link, event.get("htmlLink")))
+            self.event_urls.append(
+                event.get(self.preferred_event_link, event.get("htmlLink"))
+            )
 
             if event["start"].get("date") is not None:
                 start_dt = self._gstr_to_date(event["start"].get("date"))

--- a/py3status/modules/google_calendar.py
+++ b/py3status/modules/google_calendar.py
@@ -5,6 +5,9 @@ This module will display information about upcoming Google Calendar events
 in one of two formats which can be toggled with a button press. The event
 URL may also be opened in a web browser with a button press.
 
+Some events details can be retreived in the Google Calendar API Documentation.
+https://developers.google.com/calendar/v3/reference/events
+
 Configuration parameters:
     auth_token: The path to where the access/refresh token will be saved
         after successful credential authorization.
@@ -54,12 +57,16 @@ Configuration parameters:
     num_events: The maximum number of events to display.
         (default 3)
     preferred_event_link: link to open in the browser.
-        accepted values : hangoutLink (open the VC room associated with the event),
-        htmlLink (open the event's details in Google Calendar).
+        accepted values :
+        hangoutLink (open the VC room associated with the event),
+        htmlLink (open the event's details in Google Calendar)
         fallback to htmlLink if the preferred_event_link does not exist it the event.
-        (default 'htmlLink')
+        (default "htmlLink")
     response: Only display events for which the response status is
-        on the list. (default ['accepted'])
+        on the list.
+        Available values in the Google Calendar API's documentation,
+        look for the attendees[].responseStatus.
+        (default ['accepted'])
     thresholds: Thresholds for events. The first entry is the color for event 1,
         the second for event 2, and so on.
         (default [])
@@ -406,10 +413,7 @@ class Py3status:
             event_dict["summary"] = event.get("summary")
             event_dict["location"] = event.get("location")
             event_dict["description"] = event.get("description")
-            if self.preferred_event_link == "hangoutLink":
-                self.event_urls.append(event.get("hangoutLink", event.get("htmlLink")))
-            else:
-                self.event_urls.append(event.get("htmlLink"))
+            self.event_urls.append(event.get(self.preferred_event_link, event.get("htmlLink")))
 
             if event["start"].get("date") is not None:
                 start_dt = self._gstr_to_date(event["start"].get("date"))

--- a/py3status/modules/google_calendar.py
+++ b/py3status/modules/google_calendar.py
@@ -57,7 +57,7 @@ Configuration parameters:
         accepted values : hangoutLink (open the VC room associated with the event),
         htmlLink (open the event's details in Google Calendar).
         fallback to htmlLink if the preferred_event_link does not exist it the event.
-        (default: htmlLink)
+        (default 'htmlLink')
     response: Only display events for which the response status is
         on the list. (default ['accepted'])
     thresholds: Thresholds for events. The first entry is the color for event 1,

--- a/py3status/modules/google_calendar.py
+++ b/py3status/modules/google_calendar.py
@@ -12,6 +12,8 @@ Configuration parameters:
     blacklist_events: Event names in this list will not be shown in the module
         (case insensitive).
         (default [])
+    browser_invocation: Command to run to open browser. Curly braces stands for URL opened.
+        (default "xdg-open {}")
     button_open: Opens the event URL in the default web browser.
         (default 3)
     button_refresh: Refreshes the module and updates the list of events.
@@ -51,10 +53,13 @@ Configuration parameters:
         (default False)
     num_events: The maximum number of events to display.
         (default 3)
+    preferred_event_link: link to open in the browser.
+        accepted values : hangoutLink (open the VC room associated with the event),
+        htmlLink (open the event's details in Google Calendar).
+        fallback to htmlLink if the preferred_event_link does not exist it the event.
+        (default: htmlLink)
     response: Only display events for which the response status is
         on the list. (default ['accepted'])
-    browser_invocation: Command to run to open browser. Curly braces stands for URL opened.
-    (default "xdg-open {}")
     thresholds: Thresholds for events. The first entry is the color for event 1,
         the second for event 2, and so on.
         (default [])
@@ -62,10 +67,6 @@ Configuration parameters:
         string; e.g. if time_to_max is 60, `{format_timer}` will only be
         displayed for events starting in 60 minutes or less.
         (default 180)
-    preferred_event_link: link to open in the browser.
-        accepted values : hangoutLink (open the VC room associated with the event),
-           (default)    : htmlLink (open the event's details in Google Calendar).
-        fallback to htmlLink if the preferred_event_link does not exist it the event.
     warn_threshold: The number of minutes until an event starts before a
         warning is displayed to notify the user; e.g. if warn_threshold is 30
         and an event is starting in 30 minutes or less, a notification will be


### PR DESCRIPTION
This pull requests adds two options to the Google Calendar plugin :
1. The call to the browser can be customized if required (you might not
want use the browser default while opening an event).

2. It is now possible to open the Meet Hangout VC link (associated from the caledar details)
instead of the google calendar event.
We'll always fallback to the htmlLink (event itself) in the case the
hangout VC does not exists.

Those two parameters are optional.

Example of usage :
```
google_calendar {
    browser_invocation = "i3-msg '[title=\".*?Meet.*?\" workspace=\"0\"] kill; workspace 0; exec /usr/bin/google-chrome --app={}'"
    preferred_event_link = "hangoutLink"
}
```
This way, I ask my window manager i3 to close any previous opened
google meet before reopening one in a dedicated workspace.

These changes have been tested on my local computer.