### PR TITLE
Allow to use pango markup in notify_user

### DIFF
--- a/py3status/core.py
+++ b/py3status/core.py
@@ -661,6 +661,7 @@ class Py3statusWrapper:
         module_name="",
         icon=None,
         title="py3status",
+        escape_html_symbols=True,
     ):
         """
         Display notification to user via i3-nagbar or send-notify
@@ -709,9 +710,10 @@ class Py3statusWrapper:
         try:
             if dbus:
                 # fix any html entities
-                msg = msg.replace("&", "&amp;")
-                msg = msg.replace("<", "&lt;")
-                msg = msg.replace(">", "&gt;")
+                if escape_html_symbols:
+                    msg = msg.replace("&", "&amp;")
+                    msg = msg.replace("<", "&lt;")
+                    msg = msg.replace(">", "&gt;")
                 cmd = ["notify-send"]
                 if icon:
                     cmd += ["-i", icon]

--- a/py3status/py3.py
+++ b/py3status/py3.py
@@ -512,7 +512,15 @@ class Py3:
         """
         self._module.prevent_refresh = True
 
-    def notify_user(self, msg, level="info", rate_limit=5, title=None, icon=None):
+    def notify_user(
+        self,
+        msg,
+        level="info",
+        rate_limit=5,
+        title=None,
+        icon=None,
+        escape_html_symbols=True,
+    ):
         """
         Send a notification to the user.
         level must be 'info', 'error' or 'warning'.
@@ -535,6 +543,7 @@ class Py3:
                 module_name=module_name,
                 title=title,
                 icon=icon,
+                escape_html_symbols=escape_html_symbols,
             )
 
     def register_function(self, function_name, function):


### PR DESCRIPTION
A new flag for notify user is added, no_escape, which will allow
to not to use Pango markup like <span font=...>text</span> without
changing < to &lt; etc in supporting notification daemons, like
Mako.