### PR TITLE
kdeconnector module: fix for battery unavailable

### DIFF
--- a/py3status/modules/kdeconnector.py
+++ b/py3status/modules/kdeconnector.py
@@ -194,7 +194,7 @@ class Py3status:
         """
         Get the battery status
         """
-        if battery["charge"] == -1:
+        if not battery or battery["charge"] == -1:
             return (UNKNOWN_SYMBOL, UNKNOWN, "#FFFFFF")
 
         if battery["isCharging"]:


### PR DESCRIPTION
If the battery is unavailable, the following error occurs:

```
TypeError: 'NoneType' object is not subscriptable
  File "/usr/lib/python3.9/site-packages/py3status/module.py", line 948, in run
    response = method()
  File "/usr/lib/python3.9/site-packages/py3status/modules/kdeconnector.py", line 268, in kdeconnector
    (text, color) = self._get_text()
  File "/usr/lib/python3.9/site-packages/py3status/modules/kdeconnector.py", line 244, in _get_text
    (charge, bat_status, color) = self._get_battery_status(battery)
  File "/usr/lib/python3.9/site-packages/py3status/modules/kdeconnector.py", line 197, in _get_battery_status
    if battery["charge"] == -1:
```

This is a similar issue to #461.