### PR TITLE
core: fix detection of instances of user provided modules fix #2020

### DIFF
--- a/py3status/core.py
+++ b/py3status/core.py
@@ -505,7 +505,7 @@ class Py3statusWrapper:
                 continue
             try:
                 instance = None
-                payload = user_modules.get(module)
+                payload = user_modules.get(module.split(" ")[0])
                 if payload:
                     kind, Klass = payload
                     if kind == ENTRY_POINT_KEY:


### PR DESCRIPTION
before this fix, users could add their modules from local paths
or entry points but not have multiple instances of them

thanks to @mcgillij @lasers and @eumiro