### PR TITLE
sysdata: optimize cpu_temp

### DIFF
--- a/py3status/modules/sysdata.py
+++ b/py3status/modules/sysdata.py
@@ -288,8 +288,9 @@ class Py3status:
                 raise Exception(INVALID_CPU_TEMP_UNIT)
 
             chips_and_sensors = [
-                ("coretemp-isa-0000", "Core"),
-                ("k10temp-pci-00c3", "Tdie"),
+                ("coretemp-isa-0000", "Core"),  # Intel
+                ("k10temp-pci-00c3", "Tdie"),  # AMD
+                ("cpu_thermal-virtual-0", "temp"),  # RPi
             ]
 
             chips = loads(self.py3.command_output([command, args]))

--- a/py3status/modules/sysdata.py
+++ b/py3status/modules/sysdata.py
@@ -286,6 +286,8 @@ class Py3status:
                 raise Exception(STRING_NOT_INSTALLED)
             if self.cpu_temp_unit not in list("CFK"):
                 raise Exception(INVALID_CPU_TEMP_UNIT)
+            elif self.cpu_temp_unit == "F":
+                args += "f"  # print fahrenheit
 
             chips_and_sensors = [
                 ("coretemp-isa-0000", "Core"),  # Intel
@@ -430,11 +432,7 @@ class Py3status:
 
         cpu_temp = sensor_total / sensor_count
 
-        if cpu_temp_unit == "C":
-            pass
-        elif cpu_temp_unit == "F":
-            cpu_temp = cpu_temp * 9 / 5 + 32
-        elif cpu_temp_unit == "K":
+        if cpu_temp_unit == "K":
             cpu_temp += 273.15
 
         return cpu_temp, cpu_temp_unit


### PR DESCRIPTION
This is my cleanup attempt to really solve #1614, #1928, #1933, and #1995. 


* Rename `temp_unit` to `cpu_temp_unit`. More specific. (Unrelated)

* Replace messy `zone` config/code with auto cpu sensors.
  * This removes sysfs path. Author wanted this so he can point it to `Tdie`.
  * This also removes where you can get temperature data for things that aren't CPUs... to `{cpu_temp}`.


To explain a bit more about this... My understanding is that...
* If you're on `Intel coretemp-isa-000`, you want to parse `Core ?*`.
* If you're on `Ryzen k10temp-pci-00c3`, you want to parse `Tdie`.
* If you're on `...`, you want to parse `...`. We can add more like this now using `chips_and_sensors`.

Feature:
* If you're on `RPi cpu_thermal-virtual-0`, you want to parse `temp?`.

Feature:
* On `Intel`'s `Core ?*`, this should print average CPU temp instead of first CPU temp.

Disclaimer: I'm not on i3 / py3status. This PR is untested. I don't have AMD Ryzen machine.

Closes https://github.com/ultrabug/py3status/pull/1995. 

