### PR TITLE
Revert time.perf_counter back to time.time in clock

### DIFF
--- a/py3status/modules/clock.py
+++ b/py3status/modules/clock.py
@@ -184,7 +184,7 @@ class Py3status:
             self.active = 0
 
         # reset the cycle time
-        self._cycle_time = time.perf_counter() + self.cycle
+        self._cycle_time = time.time() + self.cycle
 
     def _get_timezone(self, tz):
         """
@@ -217,7 +217,7 @@ class Py3status:
     def _change_active(self, diff):
         self.active = (self.active + diff) % len(self.format)
         # reset the cycle time
-        self._cycle_time = time.perf_counter() + self.cycle
+        self._cycle_time = time.time() + self.cycle
         # save the active format
         timezone = self.format[self.active]
         self.py3.storage_set("timezone", timezone)
@@ -241,9 +241,9 @@ class Py3status:
     def clock(self):
 
         # cycling
-        if self.cycle and time.perf_counter() >= self._cycle_time:
+        if self.cycle and time.time() >= self._cycle_time:
             self._change_active(1)
-            self._cycle_time = time.perf_counter() + self.cycle
+            self._cycle_time = time.time() + self.cycle
 
         # update our times
         times = {}


### PR DESCRIPTION
Using `time.perf_counter()` to decide when to update the clock was my wrong decision in #1996 because its zero does not necessarily start at xx:xx:00. Revert to `time.time()`.

Thanks to @ya-isakov for reporting the bug
Resolves #2028