### PR TITLE
timewarrior: remove timezone info from end date

### DIFF
--- a/py3status/modules/timewarrior.py
+++ b/py3status/modules/timewarrior.py
@@ -239,7 +239,7 @@ class Py3status:
             # duraton
             if time["state_time"]:
                 self.tracking = True
-                end = dt.datetime.now(dt.timezone.utc)
+                end = dt.datetime.now()
             else:
                 end = dt.datetime.strptime(time["end"], DATETIME)
 

--- a/py3status/modules/timewarrior.py
+++ b/py3status/modules/timewarrior.py
@@ -239,7 +239,7 @@ class Py3status:
             # duraton
             if time["state_time"]:
                 self.tracking = True
-                end = dt.datetime.now()
+                end = dt.datetime.utcnow()
             else:
                 end = dt.datetime.strptime(time["end"], DATETIME)
 


### PR DESCRIPTION
Hello,

This little PR intends to fix a bug in the timewarrior module.

Timewarrior module was crashlooping on my pc and py3status was consuming ~90% cpu times.

I investigated and found that an internal error occured inside the timewarrior module by looking at the logs:

```
Apr 14 21:21:39 z-dev py3status: Instance `timewarrior`, user method `timewarrior` failed.
```

I found that each module has a main function with tests so i tried running it:

```sh
$ python3 ~/.local/lib/python3.9/site-packages/py3status/modules/timewarrior.py

can't compare offset-naive and offset-aware datetimes.
Traceback
TypeError: can't compare offset-naive and offset-aware datetimes
  File "/home/gfeun/.local/lib/python3.9/site-packages/py3status/module.py", line 948, in run
    response = method()
  File "/home/gfeun/.local/lib/python3.9/site-packages/py3status/modules/timewarrior.py", line 282, in timewarrior
    format_time = self._manipulate(timewarrior_data)
  File "/home/gfeun/.local/lib/python3.9/site-packages/py3status/modules/timewarrior.py", line 247, in _manipulate
    duration = relativedelta(end, start)
  File "/usr/lib/python3/dist-packages/dateutil/relativedelta.py", line 154, in __init__
    if dt1 < dt2:
```

So it seems that the error is related to date handling, and in this case incorrect date formats.

Printing the end and start variables gave me:

```
start=2021-04-14 19:15:52
end=2021-04-14 21:45:18.939472
```

With a little help from Stack Overflow, i tried removing the timezone info from the `end` variable and it worked.

The tests passes on my pc now. 

However i'm not sure about why this timezone info might have been needed so it may break other things ...