### PR TITLE
Revert to tz-naive UTC timestamps in timewarrior (fix #2039)

### DIFF
--- a/py3status/modules/timewarrior.py
+++ b/py3status/modules/timewarrior.py
@@ -239,7 +239,7 @@ class Py3status:
             # duraton
             if time["state_time"]:
                 self.tracking = True
-                end = dt.datetime.now(dt.timezone.utc)
+                end = dt.datetime.utcnow()
             else:
                 end = dt.datetime.strptime(time["end"], DATETIME)
 


### PR DESCRIPTION
Later we should review the time zones stuff in the whole code. But for now this reverts to tz-naive UTC timestamp in the timewarrior module.

Fixes #2039 