### PR TITLE
_format_sunrise and _format_sunset as aware dt

### DIFF
--- a/py3status/modules/weather_owm.py
+++ b/py3status/modules/weather_owm.py
@@ -735,7 +735,7 @@ class Py3status:
 
     def _format_sunrise(self, wthr):
         # Get the time for sunrise (default is the start of time)
-        dt = datetime.datetime.utcfromtimestamp(self._jpath(wthr, OWM_SUNRISE, 0))
+        dt = datetime.datetime.fromtimestamp(self._jpath(wthr, OWM_SUNRISE, 0))
 
         # Format the sunrise
         replaced = dt.strftime(self.format_sunrise)
@@ -743,7 +743,7 @@ class Py3status:
 
     def _format_sunset(self, wthr):
         # Get the time for sunset (default is the start of time)
-        dt = datetime.datetime.utcfromtimestamp(self._jpath(wthr, OWM_SUNSET, 0))
+        dt = datetime.datetime.fromtimestamp(self._jpath(wthr, OWM_SUNSET, 0))
 
         # Format the sunset
         replaced = dt.strftime(self.format_sunset)


### PR DESCRIPTION
Because naive datetime objects are treated by many datetime methods as local times, it would be better to make those objects aware to show correct time.
Also if we would like to force UTC it is recommended way to create an object representing a specific timestamp in UTC is by calling datetime.fromtimestamp(timestamp, tz=timezone.utc)