### PR TITLE
Add configurable status string to battery_level module

### DIFF
--- a/py3status/modules/battery_level.py
+++ b/py3status/modules/battery_level.py
@@ -42,7 +42,7 @@ Configuration parameters:
     status_string_charging: a string to put in {status} when charging (default "CHG")
     status_string_degraded: a string to put in {status} when degraded (default "LOW")
     status_string_discharging: a string to put in {status} when discharging (default "BAT")
-    status_string_full: a string to put in {status} when charging (default "FULL")
+    status_string_full: a string to put in {status} when full (default "FULL")
     sys_battery_path: set the path to your battery(ies), without including its
         number
         (default "/sys/class/power_supply/")


### PR DESCRIPTION
Add the option to have a configurable status string (rather than an icon) in the output. (Roughly) this functionality is available in the original i3status.