### PR TITLE
vpn_status: use proper dbus signal handler signature

### DIFF
--- a/py3status/modules/vpn_status.py
+++ b/py3status/modules/vpn_status.py
@@ -75,14 +75,17 @@ class Py3status:
         # Loop forever
         loop.run()
 
-    def _vpn_signal_handler(self, args):
+    def _vpn_signal_handler(
+        self, interface_name, changed_properties, invalidated_properties
+    ):
         """Called on NetworkManager PropertiesChanged signal"""
-        # Args is a dictionary of changed properties
         # We only care about changes in ActiveConnections
         active = "ActiveConnections"
         # Compare current ActiveConnections to last seen ActiveConnections
-        if active in args and sorted(self.active) != sorted(args[active]):
-            self.active = args[active]
+        if active in changed_properties and sorted(self.active) != sorted(
+            changed_properties[active]
+        ):
+            self.active = changed_properties[active]
             self.py3.update()
 
     def _get_vpn_status(self):


### PR DESCRIPTION
Hi, 

The `vpn_status` module has not been working for a while.

It appears the expected signature for the dbus signal
handler has changed :

``` text
Traceback (most recent call last):                                                                                                                                                                                                             
  File "/usr/lib/python3.9/site-packages/pydbus/subscription.py", line 52, in <lambda>                                                                                                                                                         
    callback = (lambda con, sender, object, iface, signal, params: signal_fired(sender, object, iface, signal, params.unpack())) if signal_fired is not None else lambda *args: None                                                           
  File "/usr/lib/python3.9/site-packages/pydbus/proxy_signal.py", line 15, in signal_fired                                                                                                                                                     
    callback(*params)                                                                                                                                                                                                                          
TypeError: _vpn_signal_handler() takes 2 positional arguments but 4 were given                                                                                                                                                                 
```

`params` sent to `_vpn_signal_handler` look like this : 
```
('org.freedesktop.NetworkManager', {'ActiveConnections': ['/org/freedesktop/NetworkManager/ActiveConnection/19', '/org/freedesktop/NetworkManager/ActiveConnection/18']}, [])
```

It looks like it might be related to :
https://gitlab.freedesktop.org/NetworkManager/NetworkManager/-/merge_requests/853/ , which disabled legacy PropertiesChanged signals in networkmanager.

Still, I don't know a thing about dbus and its friends, so I could be completely wrong on the underlying cause, but it works well enough.

Also, it looks like the `pydbus` library, on which we depend, is no longer maintained.