### PR TITLE
sysdata module: fix amd cpus without Tdie

### DIFF
--- a/py3status/modules/sysdata.py
+++ b/py3status/modules/sysdata.py
@@ -292,12 +292,13 @@ class Py3status:
             chips_and_sensors = [
                 ("coretemp-isa-0000", "Core"),  # Intel
                 ("k10temp-pci-00c3", "Tdie"),  # AMD
-                ("cpu_thermal-virtual-0", "temp"),  # RPi
+                ("k10temp-pci-00c3", "Tctl"),  # AMD without Tdie (4700U)
+                ("cpu_thermal-virtual-0", "temp"),  # RP
             ]
 
             chips = loads(self.py3.command_output([command, args]))
             for chip, sensor in chips_and_sensors:
-                if chip in chips:
+                if chip in chips and sensor in chips[chip]:
                     self.lm_sensors = {
                         "command": [command, args, chip],
                         "chip": chip,
@@ -430,7 +431,7 @@ class Py3status:
                         sensor_total += value
                         break
 
-        cpu_temp = sensor_total / sensor_count
+        cpu_temp = sensor_total / sensor_count if sensor_count else sensor_total
 
         if cpu_temp_unit == "K":
             cpu_temp += 273.15


### PR DESCRIPTION
1) Never divide by zero in _get_cputemp
2) Add (k10temp-pci-00c3, Tctl) as a sensor - for AMD cpus like 4700U
   which lack Tdie
3) Only set self.lm_sensors if both sensor and chip match