### PR TITLE
sysdata: add tctl sensor

### DIFF
--- a/py3status/modules/sysdata.py
+++ b/py3status/modules/sysdata.py
@@ -290,19 +290,23 @@ class Py3status:
                 args += "f"  # print fahrenheit
 
             chips_and_sensors = [
-                ("coretemp-isa-0000", "Core"),  # Intel
-                ("k10temp-pci-00c3", "Tdie"),  # AMD
-                ("cpu_thermal-virtual-0", "temp"),  # RPi
+                ("coretemp-isa-0000", ["Core"]),  # Intel
+                ("k10temp-pci-00c3", ["Tdie", "Tctl"]),  # AMD
+                ("cpu_thermal-virtual-0", ["temp"]),  # RPi
             ]
 
             chips = loads(self.py3.command_output([command, args]))
-            for chip, sensor in chips_and_sensors:
+            for chip, sensors in chips_and_sensors:
                 if chip in chips:
-                    self.lm_sensors = {
-                        "command": [command, args, chip],
-                        "chip": chip,
-                        "sensor": sensor,
-                    }
+                    for sensor in sensors:
+                        for temp_sensor in chips[chip]:
+                            if sensor in temp_sensor:
+                                self.lm_sensors = {
+                                    "command": [command, args, chip],
+                                    "chip": chip,
+                                    "sensor": sensor,
+                                }
+                                break
                     break
             else:
                 self.init["cpu_temp"] = []


### PR DESCRIPTION
This PR turns our supported CPU sensors into a list each so `k10temp` chip can display Tdie or Tctl, but not both because  `{cpu_temp}` is strictly one placeholder / one sensor / one cpu_temperature. If you happen to have both sensors, `Tdie` will be used. Testers needed. 

Closes https://github.com/ultrabug/py3status/issues/2079.
