### PR TITLE
window module: fix crash on sway / wlroots compositors

### DIFF
--- a/py3status/modules/window.py
+++ b/py3status/modules/window.py
@@ -81,10 +81,14 @@ class I3ipc(Ipc):
         i3.main()
 
     def clear_title(self, i3, event=None):
-        self.update(i3.get_tree().find_focused())
+        focused = i3.get_tree().find_focused()
+        if focused:
+            self.update(focused)
 
     def change_title(self, i3, event=None):
         focused = i3.get_tree().find_focused()
+        if not focused:
+            return
 
         # hide title on containers with window title
         if self.parent.hide_title:


### PR DESCRIPTION
Sway / wlroots compositors have special overlay windows that never get
focus and are floating above everything else. Examples for this are
bemenu or notification daemons.

In some cases it was possible to trigger an update in the window module,
e.g. by calling bemenu twice which crashed the module. I'm not entirely
sure why that happened but this PR fixes it.

All credits go out to @valdur55 who actually authored the patch and
helped me debugging it in the first place.