### PR TITLE
[window] I3ipc backend uses incoming event data and relies less on get_tree.focused() data.

### DIFF
--- a/py3status/modules/window.py
+++ b/py3status/modules/window.py
@@ -91,7 +91,8 @@ class I3ipc(Ipc):
         self.update(self._last_workspace)
 
     def _on_window_close(self, i3, event):
-        self.update(self._last_workspace)
+        if event.container.focused:
+            self.update(self._last_workspace)
 
     def _on_binding(self, i3, event):
         self.update(i3.get_tree().find_focused())

--- a/py3status/modules/window.py
+++ b/py3status/modules/window.py
@@ -78,7 +78,7 @@ class I3ipc(Ipc):
 
         self.i3 = Connection()
 
-        self.update(self.i3.get_tree().find_focused())
+        self._update(self.i3.get_tree().find_focused())
 
         self.i3.on(Event.WORKSPACE_FOCUS, self._on_workplace_focus)
         self.i3.on(Event.WINDOW_CLOSE, self._on_window_close)
@@ -91,25 +91,25 @@ class I3ipc(Ipc):
         self._focused_workspace = event.current
         if event.current.nodes or event.current.floating_nodes:
             return
-        self.update(event.current)
+        self._update(event.current)
 
     def _on_window_close(self, i3, event):
         if event.container.window == self._focused_window:
             self._focused_window = None
-            self.update(self._focused_workspace)
+            self._update(self._focused_workspace)
 
     def _on_binding(self, i3, event):
-        self.update(i3.get_tree().find_focused())
+        self._update(i3.get_tree().find_focused())
 
     def _on_window_title(self, i3, event):
         if event.container.focused:
-            self.update(event.container)
+            self._update(event.container)
 
     def _on_window_focus(self, i3, event):
         self._focused_window = event.container.window
-        self.update(event.container)
+        self._update(event.container)
 
-    def update(self, event_element):
+    def _update(self, event_element):
         if not event_element:
             return
 

--- a/py3status/modules/window.py
+++ b/py3status/modules/window.py
@@ -48,7 +48,7 @@ class Ipc:
         # specify width to truncate title with ellipsis
         if self.parent.max_width:
             title = window_properties["title"]
-            if title and title > self.parent.max_width:
+            if title and len(title) > self.parent.max_width:
                 window_properties["title"] = title[: self.parent.max_width - 1] + "…"
 
         return window_properties

--- a/py3status/modules/window.py
+++ b/py3status/modules/window.py
@@ -59,8 +59,6 @@ class I3ipc(Ipc):
     i3ipc - an improved python library to control i3wm and sway
     """
 
-    _last_workspace = None
-
     def setup(self, parent):
         from threading import Thread
 
@@ -87,12 +85,11 @@ class I3ipc(Ipc):
         i3.main()
 
     def _on_workplace_focus(self, i3, event):
-        self._last_workspace = event.current
-        self.update(self._last_workspace)
+        self.update(event.current)
 
     def _on_window_close(self, i3, event):
-        if event.container.focused:
-            self.update(self._last_workspace)
+        # Event data based update needs more work. Checking just container.focus is not enough
+        self.update(i3.get_tree().find_focused())
 
     def _on_binding(self, i3, event):
         self.update(i3.get_tree().find_focused())

--- a/py3status/modules/window.py
+++ b/py3status/modules/window.py
@@ -89,6 +89,7 @@ class I3ipc(Ipc):
 
     def _on_workplace_focus(self, i3, event):
         self._focused_workspace = event.current
+        self._focused_window = None
         if event.current.nodes or event.current.floating_nodes:
             return
         self._update(event.current)
@@ -96,7 +97,7 @@ class I3ipc(Ipc):
     def _on_window_close(self, i3, event):
         if event.container.window == self._focused_window:
             self._focused_window = None
-            self._update(self._focused_workspace)
+            self._update(i3.get_tree().find_focused())
 
     def _on_binding(self, i3, event):
         self._update(i3.get_tree().find_focused())

--- a/py3status/modules/window.py
+++ b/py3status/modules/window.py
@@ -59,6 +59,9 @@ class I3ipc(Ipc):
     i3ipc - an improved python library to control i3wm and sway
     """
 
+    _focused_workspace = None
+    _focused_window = None
+
     def setup(self, parent):
         from threading import Thread
 
@@ -85,13 +88,15 @@ class I3ipc(Ipc):
         i3.main()
 
     def _on_workplace_focus(self, i3, event):
+        self._focused_workspace = event.current
         if event.current.nodes or event.current.floating_nodes:
             return
         self.update(event.current)
 
     def _on_window_close(self, i3, event):
-        # Event data based update needs more work. Checking just container.focus is not enough
-        self.update(i3.get_tree().find_focused())
+        if event.container.window == self._focused_window:
+            self._focused_window = None
+            self.update(self._focused_workspace)
 
     def _on_binding(self, i3, event):
         self.update(i3.get_tree().find_focused())
@@ -101,6 +106,7 @@ class I3ipc(Ipc):
             self.update(event.container)
 
     def _on_window_focus(self, i3, event):
+        self._focused_window = event.container.window
         self.update(event.container)
 
     def update(self, event_element):

--- a/py3status/modules/window.py
+++ b/py3status/modules/window.py
@@ -85,6 +85,8 @@ class I3ipc(Ipc):
         i3.main()
 
     def _on_workplace_focus(self, i3, event):
+        if event.current.nodes or event.current.floating_nodes:
+            return
         self.update(event.current)
 
     def _on_window_close(self, i3, event):


### PR DESCRIPTION
In process of testing #2086 found deeper issue.
There is no point for looking focused window/container inside of window tree when needed data is already provided by event argument.

Additional changes:
* Window cleaning uses last workspace as placeholder.
