### PR TITLE
[scratchpad] Workaround for I3ipc 2.2.1 not finding leaves() in sway

### DIFF
--- a/py3status/modules/scratchpad.py
+++ b/py3status/modules/scratchpad.py
@@ -95,6 +95,8 @@ class I3ipc(Ipc):
 
     def update(self, i3, event=None):
         scratchpad = i3.get_tree().scratchpad()
+        if not scratchpad:
+            return
 
         # Workaround for I3ipc 2.2.1 not finding leaves() in sway. Fixing: #2038
         leaves = getattr(scratchpad, "floating_nodes", [])

--- a/py3status/modules/scratchpad.py
+++ b/py3status/modules/scratchpad.py
@@ -94,7 +94,11 @@ class I3ipc(Ipc):
         i3.main()
 
     def update(self, i3, event=None):
-        leaves = i3.get_tree().scratchpad().leaves()
+        scratchpad = i3.get_tree().scratchpad()
+
+        # Workaround for I3ipc 2.2.1 not finding leaves() in sway. Fixing: #2038
+        leaves = getattr(scratchpad, "floating_nodes", [])
+
         temporary = {
             "ipc": self.parent.ipc,
             "scratchpad": len(leaves),


### PR DESCRIPTION
At first round I applied same approach as Msg module is using.
For short conclusion it was like calling: `Msg.find_scratchpad(i3.get_tree().ipc_data).get("floating_nodes", [])` and output was list of scratchpad windows.
During commenting line about workaround I remembered one changelog line from I3ipc-python v2.2.1 (Version released on Apr 5, 2020) : 
`Fix scratchpad for sway (f11e729).`

And then I ended up calling:
`getattr(i3.get_tree().scratchpad(), "floating_nodes", [])`

Storing scratchpad as separate variable for better debuggability.

Tested it out with sway (v1.4) and i3 (v4.20). Both desktop env works and Msg is already using same approach to get list of scratchpad windows.  (Fixes #2038)