### PR TITLE
[events] With pydevd.debugger first click caused error

### DIFF
--- a/py3status/events.py
+++ b/py3status/events.py
@@ -31,7 +31,11 @@ class IOPoller:
         poll_result = self.poller.poll(timeout)
         if poll_result:
             line = self.io.readline().strip()
-            if self.io == sys.stdin and line == "[":
+            # When using pydev.deugger sys.stdin gets overwritten and placed into sys.stdin.original_stdin issue #2090
+            if (
+                self.io == getattr(sys.stdin, "original_stdin", sys.stdin)
+                and line == "["
+            ):
                 # skip first event line wrt issue #19
                 line = self.io.readline().strip()
             try:


### PR DESCRIPTION
With pydevd.debugger first click caused "JSONDecodeError: Expecting value: line 1 column 2 (char 1)". (Fixes #2090)