### PR TITLE
Update documentation for the pomodoro module

### DIFF
--- a/py3status/modules/pomodoro.py
+++ b/py3status/modules/pomodoro.py
@@ -20,12 +20,9 @@ Configuration parameters:
         (default 'Pomodoro ({format})')
     num_progress_bars: number of progress bars (default 5)
     pomodoros: specify a number of pomodoros (intervals) (default 4)
-    sound_break_end: break end sound (file path) (requires pyglet
-        or pygame) (default None)
-    sound_pomodoro_end: pomodoro end sound (file path) (requires pyglet
-        or pygame) (default None)
-    sound_pomodoro_start: pomodoro start sound (file path) (requires pyglet
-        or pygame) (default None)
+    sound_break_end: break end sound (file path) (default None)
+    sound_pomodoro_end: pomodoro end sound (file path) (default None)
+    sound_pomodoro_start: pomodoro start sound (file path) (default None)
     timer_break: normal break time (seconds) (default 300)
     timer_long_break: long break time (seconds) (default 900)
     timer_pomodoro: pomodoro time (seconds) (default 1500)


### PR DESCRIPTION
pyglet and pygame are no longer needed for playing sound files since the merge of #1770 