### PR TITLE
arch_updates module: paru exits with a non-zero status if there are no updates

### DIFF
--- a/py3status/modules/arch_updates.py
+++ b/py3status/modules/arch_updates.py
@@ -114,8 +114,8 @@ class Py3status:
         try:
             updates = self.py3.command_output(["paru", "-Qua"])
             return len(updates.splitlines())
-        except self.py3.CommandError:
-            return None
+        except self.py3.CommandError as ce:
+            return None if ce.error else 0
 
     def arch_updates(self):
         pacman, aur, total, full_text = None, None, None, ""


### PR DESCRIPTION
Fixes update checks with paru.
Unlike yay, paru exits with return value `1` after `paru -Qua`, if there are no AUR updates available (conforming to the behavior of `pacman` itself)
Thus we should return `0` if `-Qua` exits with `1`.