### PR TITLE
added option for the khal_calendar module to limit the number of returned calendar entries

### DIFF
--- a/py3status/modules/khal_calendar.py
+++ b/py3status/modules/khal_calendar.py
@@ -7,6 +7,7 @@ Configuration parameters:
     date_end: Until which datetime the module searches for events (default 'eod')
     format: display format for this module (default '{appointments}')
     output_format: khal conform format for displaying event output (default '{start-time} {title}')
+    limit: limit the number of returned calendar entries (default: no limit)
 
 Format placeholders:
     {appointments} list of events in time range
@@ -38,6 +39,7 @@ class Py3status:
     date_end = "eod"
     format = "{appointments}"
     output_format = "{start-time} {title}"
+    limit = None
 
     def _format_output(self, output):
         ansi_escape = re_compile(r"\x1B\[[0-?]*[ -/]*[@-~]")
@@ -54,7 +56,7 @@ class Py3status:
             str(datetime.now().strftime(self.datetimeformat)) + " " + self.date_end
         )
         output = khal_list(self.collection, daterange, self.config, self.output_format)
-        output = [self._format_output(x) for x in output[1:]]
+        output = [self._format_output(x) for x in output[1:]][:self.limit]
 
         output = " ".join(output)
         khal_data = {"appointments": output}

--- a/py3status/modules/khal_calendar.py
+++ b/py3status/modules/khal_calendar.py
@@ -6,8 +6,8 @@ Configuration parameters:
     config_path: Path to khal configuration file. The default None resolves to /home/$USER/.config/khal/config (default None)
     date_end: Until which datetime the module searches for events (default 'eod')
     format: display format for this module (default '{appointments}')
-    output_format: khal conform format for displaying event output (default '{start-time} {title}')
     limit: limit the number of returned calendar entries (default: no limit)
+    output_format: khal conform format for displaying event output (default '{start-time} {title}')
 
 Format placeholders:
     {appointments} list of events in time range
@@ -38,8 +38,8 @@ class Py3status:
     config_path = None
     date_end = "eod"
     format = "{appointments}"
-    output_format = "{start-time} {title}"
     limit = None
+    output_format = "{start-time} {title}"
 
     def _format_output(self, output):
         ansi_escape = re_compile(r"\x1B\[[0-?]*[ -/]*[@-~]")

--- a/py3status/modules/khal_calendar.py
+++ b/py3status/modules/khal_calendar.py
@@ -6,7 +6,7 @@ Configuration parameters:
     config_path: Path to khal configuration file. The default None resolves to /home/$USER/.config/khal/config (default None)
     date_end: Until which datetime the module searches for events (default 'eod')
     format: display format for this module (default '{appointments}')
-    limit: limit the number of returned calendar entries (default: no limit)
+    max_results: an upper bound for the number of returned calendar entries (default None)
     output_format: khal conform format for displaying event output (default '{start-time} {title}')
 
 Format placeholders:
@@ -38,7 +38,7 @@ class Py3status:
     config_path = None
     date_end = "eod"
     format = "{appointments}"
-    limit = None
+    max_results = None
     output_format = "{start-time} {title}"
 
     def _format_output(self, output):
@@ -56,7 +56,7 @@ class Py3status:
             str(datetime.now().strftime(self.datetimeformat)) + " " + self.date_end
         )
         output = khal_list(self.collection, daterange, self.config, self.output_format)
-        output = [self._format_output(x) for x in output[1:]][:self.limit]
+        output = [self._format_output(x) for x in output[1:]][: self.max_results]
 
         output = " ".join(output)
         khal_data = {"appointments": output}


### PR DESCRIPTION
I noticed that the khal_calendar module quickly overwhelms my status bar when there are multiple events scheduled for today. Introducing a 'limit' config option keeps the space manageable. 