### PR TITLE
Try to fix root cause of negative update_due

### DIFF
--- a/py3status/core.py
+++ b/py3status/core.py
@@ -297,10 +297,17 @@ class Py3statusWrapper:
     def clear_timeout_due(self, module):
         old = self.timeout_queue_lookup_previous.get(module, None)
         if old and old == self.timeout_due:
-            if len(self.timeout_keys):
-                self.timeout_due = self.timeout_keys[0]
-            else:
-                self.timeout_due = None
+            self.set_new_timeout_due()
+
+    def set_new_timeout_due(self):
+        # sort keys so earliest is first
+        self.timeout_keys.sort()
+
+        # when is next timeout due?
+        try:
+            self.timeout_due = self.timeout_keys[0]
+        except IndexError:
+            self.timeout_due = None
 
     def timeout_process_add_queue(self, module, cache_time):
         """
@@ -335,14 +342,8 @@ class Py3statusWrapper:
             if cache_time not in self.timeout_keys:
                 self.timeout_queue[cache_time] = {module}
                 self.timeout_keys.append(cache_time)
-                # sort keys so earliest is first
-                self.timeout_keys.sort()
 
-                # when is next timeout due?
-                try:
-                    self.timeout_due = self.timeout_keys[0]
-                except IndexError:
-                    self.timeout_due = None
+                self.set_new_timeout_due()
             else:
                 self.timeout_queue[cache_time].add(module)
             # note that the module is in the timeout_queue

--- a/py3status/core.py
+++ b/py3status/core.py
@@ -296,10 +296,14 @@ class Py3statusWrapper:
 
     def clear_timeout_due(self, module):
         old = self.timeout_queue_lookup_previous.get(module, None)
-        if old and old == self.timeout_due:
-            self.set_new_timeout_due()
+        if old:
+            if old == self.timeout_due:
+                self._set_new_timeout_due()
+            elif old in self.timeout_keys:
+                self.timeout_keys.remove(old)
+                self._set_new_timeout_due()
 
-    def set_new_timeout_due(self):
+    def _set_new_timeout_due(self):
         # sort keys so earliest is first
         self.timeout_keys.sort()
 
@@ -343,7 +347,7 @@ class Py3statusWrapper:
                 self.timeout_queue[cache_time] = {module}
                 self.timeout_keys.append(cache_time)
 
-                self.set_new_timeout_due()
+                self._set_new_timeout_due()
             else:
                 self.timeout_queue[cache_time].add(module)
             # note that the module is in the timeout_queue

--- a/py3status/core.py
+++ b/py3status/core.py
@@ -405,7 +405,13 @@ class Py3statusWrapper:
         # we return how long till we next need to process the timeout_queue
         # this value should not be negative to avoid cpu overwhelming loops
         if self.timeout_due is not None:
-            return max(0, self.timeout_due - time.monotonic())
+            new_update_due = self.timeout_due - time.monotonic()
+            if new_update_due < 0:
+                self.log(
+                    f"prevented negative update time ({new_update_due})", level="warning"
+                )
+            else:
+                return new_update_due
 
     def gevent_monkey_patch_report(self):
         """

--- a/py3status/core.py
+++ b/py3status/core.py
@@ -277,6 +277,7 @@ class Py3statusWrapper:
         self.timeout_missed = {}
         self.timeout_queue = {}
         self.timeout_queue_lookup = {}
+        self.timeout_queue_lookup_previous = {}
         self.timeout_running = set()
         self.timeout_update_due = deque()
 
@@ -292,6 +293,14 @@ class Py3statusWrapper:
         # update request is due then trigger an update now.
         if self.timeout_due is None or cache_time < self.timeout_due:
             self.update_request.set()
+
+    def clear_timeout_due(self, module):
+        old = self.timeout_queue_lookup_previous.get(module, None)
+        if old and old == self.timeout_due:
+            if len(self.timeout_keys):
+                self.timeout_due = self.timeout_keys[0]
+            else:
+                self.timeout_due = None
 
     def timeout_process_add_queue(self, module, cache_time):
         """
@@ -338,6 +347,7 @@ class Py3statusWrapper:
                 self.timeout_queue[cache_time].add(module)
             # note that the module is in the timeout_queue
             self.timeout_queue_lookup[module] = cache_time
+            self.timeout_queue_lookup_previous[module] = cache_time
 
     def timeout_queue_process(self):
         """

--- a/py3status/core.py
+++ b/py3status/core.py
@@ -329,7 +329,7 @@ class Py3statusWrapper:
             return
 
         # remove if already in the queue
-        key = self.timeout_queue_lookup.get(module)
+        key = self.timeout_queue_lookup.get(module, None)
         if key:
             queue_item = self.timeout_queue[key]
             queue_item.remove(module)
@@ -340,7 +340,8 @@ class Py3statusWrapper:
         if cache_time == 0:
             # if cache_time is 0 we can just trigger the module update
             self.timeout_update_due.append(module)
-            self.timeout_queue_lookup[module] = None
+            if module in self.timeout_queue_lookup.keys():
+                del self.timeout_queue_lookup[module]
         else:
             # add the module to the timeout queue
             if cache_time not in self.timeout_keys:

--- a/py3status/core.py
+++ b/py3status/core.py
@@ -408,7 +408,8 @@ class Py3statusWrapper:
             new_update_due = self.timeout_due - time.monotonic()
             if new_update_due < 0:
                 self.log(
-                    f"prevented negative update time ({new_update_due})", level="warning"
+                    f"prevented negative update time ({new_update_due})",
+                    level="warning",
                 )
             else:
                 return new_update_due

--- a/py3status/module.py
+++ b/py3status/module.py
@@ -1055,6 +1055,7 @@ class Module:
             self.cache_time = cache_time
             # new style modules can signal they want to cache forever
             if cache_time == Py3.CACHE_FOREVER:
+                self._py3_wrapper.clear_timeout_due(self)
                 return
             # don't be hasty mate
             # set timeout to do update next time one is needed


### PR DESCRIPTION
Auto update makes assumption that there isn't interruption between updates.
Now when module sends CACHE_FOREVER then system checks if pending update_due is from module (from previous auto update cycle) and then sets next update_due.... 
Address #2085 