### PR TITLE
module_test: add clear_timeout_due

### DIFF
--- a/py3status/module_test.py
+++ b/py3status/module_test.py
@@ -54,6 +54,9 @@ class MockPy3statusWrapper:
     def timeout_queue_add(self, *arg, **kw):
         pass
 
+    def clear_timeout_due(self, *arg, **kw):
+        pass
+
     def log(self, *arg, **kw):
         print(arg[0])
 


### PR DESCRIPTION
Make test_modules work again since https://github.com/ultrabug/py3status/pull/2109. 
```shell
[py3status/py3status/modules]$ python static_string.py
Traceback (most recent call last):
  File "py3status/py3status/modules/static_string.py", line 34, in <module>
    module_test(Py3status)
  File "py3status/py3status/module_test.py", line 102, in module_test
    m.run()
  File "py3status/py3status/module.py", line 1058, in run
    self._py3_wrapper.clear_timeout_due(self)
AttributeError: 'MockPy3statusWrapper' object has no attribute 'clear_timeout_due'
```
```shell
[py3status/py3status/modules]$ git merge test_clear_timeout_due 
Updating e5173c7..ca24540
Fast-forward
 py3status/module_test.py | 3 +++
 1 file changed, 3 insertions(+)
```
```shell
[py3status/py3status/modules]$ python static_string.py 
{'full_text': 'Hello, world!', 'cached_until': -1}
{'full_text': 'Hello, world!', 'cached_until': -1}
{'full_text': 'Hello, world!', 'cached_until': -1}
^C
```