### PR TITLE
Migrate to new Twitch API, fix #2123

### DIFF
--- a/py3status/modules/twitch.py
+++ b/py3status/modules/twitch.py
@@ -80,14 +80,16 @@ STRING_MISSING = "missing {}"
 
 import time, datetime
 
+
 def time_since(s):
-    ts = datetime.datetime.strptime(s, '%Y-%m-%dT%H:%M:%SZ').timestamp()
+    ts = datetime.datetime.strptime(s, "%Y-%m-%dT%H:%M:%SZ").timestamp()
     seconds = int(datetime.datetime.utcnow().timestamp() - ts)
     if seconds > 3600:
-        return "%dh %dm" % (seconds/3600, (seconds%3600)/60), seconds
+        return "%dh %dm" % (seconds / 3600, (seconds % 3600) / 60), seconds
     if seconds > 60:
-        return "%dm" % (seconds/60), seconds
+        return "%dm" % (seconds / 60), seconds
     return "0m", seconds
+
 
 class Py3status:
     """
@@ -131,7 +133,7 @@ class Py3status:
         auth_request = {
             "client_id": self.client_id,
             "client_secret": self.client_secret,
-            "grant_type": "client_credentials"
+            "grant_type": "client_credentials",
         }
 
         try:
@@ -176,7 +178,8 @@ class Py3status:
             return
 
         have_tags = (
-            self.py3.format_contains(self.format, "tags") or
+            self.py3.format_contains(self.format, "tags")
+            or
             # it doesn't make any sense here... but we'll check
             self.py3.format_contains(self.format_offline, "tags")
         )
@@ -191,12 +194,13 @@ class Py3status:
         if len(self.locale) == 0:
             try:
                 import locale
-                self.locale = [locale.getdefaultlocale()[0].lower().replace('_', '-')]
+
+                self.locale = [locale.getdefaultlocale()[0].lower().replace("_", "-")]
             except (ModuleNotFoundError, IndexError):
                 pass
 
-        if not 'en-us' in self.locale:
-            self.locale.append('en-us')
+        if not "en-us" in self.locale:
+            self.locale.append("en-us")
 
     def _get_twitch_data(self, url, first=True):
         try:
@@ -259,7 +263,7 @@ class Py3status:
         twitch_data = {
             "user": self.user,
             # ensure display name is still there, deprecate+remove later?
-            "display_name": self.user["display_name"]
+            "display_name": self.user["display_name"],
         }
         current_format = ""
         color = None
@@ -277,7 +281,9 @@ class Py3status:
             del stream["user_name"]
 
             # calculate runtime and  update data dict
-            stream["runtime"], stream["runtime_seconds"] = time_since(stream["started_at"])
+            stream["runtime"], stream["runtime_seconds"] = time_since(
+                stream["started_at"]
+            )
             twitch_data["stream"] = stream
             twitch_data["is_streaming"] = True
 
@@ -289,7 +295,9 @@ class Py3status:
             current_format = self.format_offline
 
         twitch_data = self.py3.flatten_dict(twitch_data, delimiter="_")
-        twitch_data["tags"] = self.py3.composite_join(self.tag_delimiter, self._get_tags(self.user["id"]))
+        twitch_data["tags"] = self.py3.composite_join(
+            self.tag_delimiter, self._get_tags(self.user["id"])
+        )
 
         self._trace("fields available: {}".format(list(twitch_data.keys())))
 
@@ -302,6 +310,7 @@ class Py3status:
             response["color"] = color
 
         return response
+
 
 if __name__ == "__main__":
     """
@@ -317,8 +326,7 @@ if __name__ == "__main__":
         "format": "{display_name} is playing {stream_game_name} for {stream_runtime} with title '{stream_title}'\n\tlanguage: {stream_language}\n\tviewers: {stream_viewer_count}\n\ttags:\n{tags}",
         "format_tag": "\t\t{name} -> {desc}",
         "tag_delimiter": "\n",
-        "locale": 'invalid',
-
+        "locale": "invalid",
         "trace": True,
     }
 

--- a/py3status/modules/twitch.py
+++ b/py3status/modules/twitch.py
@@ -192,7 +192,7 @@ class Py3status:
             try:
                 import locale
                 self.locale = [locale.getdefaultlocale()[0].lower().replace('_', '-')]
-            except:
+            except (ModuleNotFoundError, IndexError):
                 pass
 
         if not 'en-us' in self.locale:

--- a/py3status/modules/twitch.py
+++ b/py3status/modules/twitch.py
@@ -14,7 +14,7 @@ Configuration parameters:
         (default "{display_name} is offline.")
     format_tag: Tag formatting
         (default "{name}")
-    locale: List of locales to try for tag translations, eg. ["cs-cz", "en-uk", "en-us"]. If none is specified, auto-detect from environment, with a fallback to "en-us".
+    locales: List of locales to try for tag translations, eg. ["cs-cz", "en-uk", "en-us"]. If none is specified, auto-detect from environment, with a fallback to "en-us".
         (default [])
     stream_name: name of streamer(twitch.tv/<stream_name>)
         (default None)
@@ -49,7 +49,7 @@ Stream format placeholders:
     {stream_runtime} (string) Stream runtime as a human readable, non-localized string. eg "3h 5m"
     {stream_runtime_seconds} (int) Stream runtime in seconds.
 
-Tag format placeholders: (see locale)
+Tag format placeholders: (see locales)
     {name} The tag name
     {desc} The tag description
 
@@ -103,7 +103,7 @@ class Py3status:
     format = "{display_name} is live!"
     format_offline = "{display_name} is offline."
     format_tag = "{name}"
-    locale = []
+    locales = []
     stream_name = None
     tag_delimiter = " "
     trace = False
@@ -175,7 +175,7 @@ class Py3status:
         self.user = {}
         self._token = self.py3.storage_get("oauth_token")
 
-        if self.locale is False:
+        if self.locales is False:
             return
 
         have_tags = (
@@ -186,22 +186,22 @@ class Py3status:
         )
 
         if not have_tags:
-            self.locale = False
+            self.locales = False
             return
 
-        if not isinstance(self.locale, list):
-            self.locale = [x for x in [str(self.locale)] if x]
+        if not isinstance(self.locales, list):
+            self.locales = [x for x in [str(self.locales)] if x]
 
-        if len(self.locale) == 0:
+        if len(self.locales) == 0:
             try:
                 import locale
 
-                self.locale = [locale.getdefaultlocale()[0].lower().replace("_", "-")]
+                self.locales = [locale.getdefaultlocale()[0].lower().replace("_", "-")]
             except (ModuleNotFoundError, IndexError):
                 pass
 
-        if "en-us" not in self.locale:
-            self.locale.append("en-us")
+        if "en-us" not in self.locales:
+            self.locales.append("en-us")
 
     def _get_twitch_data(self, url, first=True):
         try:
@@ -228,7 +228,7 @@ class Py3status:
         return data["data"], cursor
 
     def _get_tags(self, user_id, cursor=None):
-        if self.locale is False:
+        if self.locales is False:
             return self.py3.composite_create([])
 
         url = self.url["tags"] + f"?broadcaster_id={user_id}"
@@ -243,7 +243,7 @@ class Py3status:
         if page:
             for tag in page:
                 tag_data = {}
-                for loc in self.locale:
+                for loc in self.locales:
                     if loc in tag["localization_names"] and "name" not in tag_data:
                         tag_data["name"] = tag["localization_names"][loc]
                     if (
@@ -330,7 +330,7 @@ if __name__ == "__main__":
         "format": "{display_name} is playing {stream_game_name} for {stream_runtime} with title '{stream_title}'\n\tlanguage: {stream_language}\n\tviewers: {stream_viewer_count}\n\ttags:\n{tags}",
         "format_tag": "\t\t{name} -> {desc}",
         "tag_delimiter": "\n",
-        "locale": "invalid",
+        "locales": "invalid",
         "trace": True,
     }
 


### PR DESCRIPTION
This PR fixes the twitch module, that relied on an API that is no longer available. (closes #2123)

While I was at it, I documented the fields that were there all along (though they now have a prefix, depending on which endpoint provides them), documented the new fields provided by the new API and added the option to fetch stream tags. Some of the fields probably don't seem very useful at first glance, but might be interesting for some, if combined with `?if=` expressions, so I left them in.