### PR TITLE
mail: fix pathlib adoption

### DIFF
--- a/py3status/modules/mail.py
+++ b/py3status/modules/mail.py
@@ -216,7 +216,8 @@ class Py3status:
                             if "path" not in account:
                                 raise Exception(STRING_MISSING.format(mail, "path"))
                             path = Path(
-                                os.path.expandvars(account["path"])).expanduser()
+                                os.path.expandvars(account["path"])
+                            ).expanduser()
                             if not path.exists():
                                 path = f"path: {path}"
                                 raise Exception(STRING_MISSING.format(mail, path))

--- a/py3status/modules/mail.py
+++ b/py3status/modules/mail.py
@@ -215,9 +215,8 @@ class Py3status:
                         if mail == box.lower():
                             if "path" not in account:
                                 raise Exception(STRING_MISSING.format(mail, "path"))
-                            path = os.path.expandvars(
-                                Path(account["path"]).expanduser()
-                            )
+                            path = Path(
+                                os.path.expandvars(account["path"])).expanduser()
                             if not path.exists():
                                 path = f"path: {path}"
                                 raise Exception(STRING_MISSING.format(mail, path))


### PR DESCRIPTION
os.path.expandvars() returns a string, not a Path. So, for
commit 37603bf3 to have worked, we needed to expand vars
first into a string, then convert to a path, then call
Path.expanduser().

Observed traceback prior  to the fix for added context, from current master branch:

```
2022-05-29 14:48:49 WARNING Exception in `mail` post_config_hook().
2022-05-29 14:48:49 INFO Traceback
AttributeError: 'str' object has no attribute 'exists'
  File "...py3status.venv/lib/python3.9/site-packages/py3status/module.py", line 143, in prepare_module
    self.module_class.post_config_hook()
  File "...py3status.venv/lib/python3.9/site-packages/py3status/modules/mail.py", line 221, in post_config_hook
    if not path.exists():
```