### PR TITLE
Specify report in task export for taskwarrior module

### DIFF
--- a/py3status/modules/taskwarrior.py
+++ b/py3status/modules/taskwarrior.py
@@ -5,6 +5,7 @@ Configuration parameters:
     cache_timeout: refresh interval for this module (default 5)
     filter: specify one or more criteria to use (default 'status:pending')
     format: display format for this module (default '{descriptions}')
+    report: report to export, for TaskWarrior 2.6.0 and above (default '')
 
 Format placeholders:
     {descriptions} descriptions of active tasks
@@ -33,6 +34,7 @@ class Py3status:
     cache_timeout = 5
     filter = "status:pending"
     format = "{descriptions}"
+    report = ""
 
     class Meta:
         deprecated = {
@@ -53,6 +55,8 @@ class Py3status:
             self.taskwarrior_command = f"task {self.filter} export"
         else:
             self.taskwarrior_command = "task export"
+        if self.report:
+            self.taskwarrior_command += " " + self.report
 
     @staticmethod
     def descriptions(tasks_json):


### PR DESCRIPTION
Starting from TW 2.6.0 it's possible to specify a report to export in addition to just a filter. Most importantly, the exported data will respect the order of the specified report, rather than being ordered by ID number.

For example, by setting
```
filter = 'limit:3'
report = 'next'
```
we get the three most urgent tasks from the `next` report, in decreasing order of urgency (assuming the next report is sorted by urgency as is the default). As far as I know this is not possible using just a filter alone; using `task status:pending limit:3 export` returns the pending tasks with the three lowest ID numbers.

This is backwards-compatible since the default value of report is the empty string.