### PR TITLE
[window] Window without title will not produce error on i3msg mode.

### DIFF
--- a/py3status/modules/window.py
+++ b/py3status/modules/window.py
@@ -45,10 +45,12 @@ class Ipc:
 
     def compatibility(self, window_properties):
         # specify width to truncate title with ellipsis
-        if self.parent.max_width:
-            title = window_properties["title"]
-            if title and len(title) > self.parent.max_width:
+        title = window_properties.get("title", "")
+        if title:
+            if self.parent.max_width and len(title) > self.parent.max_width:
                 window_properties["title"] = title[: self.parent.max_width - 1] + "…"
+        else:
+            window_properties["title"] = ""
 
         return window_properties
 


### PR DESCRIPTION
(For example Pluma closing confirmation window)