### PR TITLE
Change the reading timeout to infinity

### DIFF
--- a/py3status/events.py
+++ b/py3status/events.py
@@ -272,7 +272,7 @@ class Events(Thread):
         """
         try:
             while self.py3_wrapper.running:
-                event_str = self.poller_inp.readline()
+                event_str = self.poller_inp.readline(timeout=None)
                 if not event_str:
                     continue
                 try:


### PR DESCRIPTION
I'm not exactly sure for the reason for the 500ms timeout in the events thread, but it seems like an unnecessary source of wakeups.

I've been running this patch on my system for a while now and nothing seems different, except the events thread doesn't wake up twice a second.