### PR TITLE
clock module: migrate to standard zoneinfo with 3.7, 3.8 support.

### DIFF
--- a/py3status/modules/clock.py
+++ b/py3status/modules/clock.py
@@ -90,7 +90,11 @@ import re
 import time
 from datetime import datetime
 
-import zoneinfo
+try:
+    import zoneinfo
+# Fall back for python 3.7 and python 3.8
+except ImportError:
+    from backports import zoneinfo
 
 CLOCK_BLOCKS = "🕛🕧🕐🕜🕑🕝🕒🕞🕓🕟🕔🕠🕕🕡🕖🕢🕗🕣🕘🕤🕙🕥🕚🕦"
 


### PR DESCRIPTION
closes #2150 