### PR TITLE
battery_level: Allow icon to not use charging_character

### DIFF
--- a/py3status/modules/battery_level.py
+++ b/py3status/modules/battery_level.py
@@ -477,7 +477,7 @@ class Py3status:
             self.status = self.format_status_discharging
 
     def _update_icon(self):
-        if self.charging:
+        if self.charging and self.charging_character is not None:
             self.icon = self.charging_character
         else:
             self.icon = self.blocks[


### PR DESCRIPTION
I want to `{icon}` to only display the info from `blocks`, even when the battery is charging, but currently there is no way to do this (AFAICT).  This change allows the user to obtain that behaviour, if they explicitly configure `charging_character = None`.