### PR TITLE
do_not_disturb module: Use 'makoctl mode' to check current mode.

### DIFF
--- a/py3status/modules/do_not_disturb.py
+++ b/py3status/modules/do_not_disturb.py
@@ -129,8 +129,19 @@ class Mako(Notification):
     Mako Notification.
     """
 
+    # From version mako 1.7 we can use "makoctl mode"
     def setup(self, parent):
         self.toggle(parent.state)
+        self.has_makoctl_mode = bool(
+            self.parent.py3.check_commands(["makoctl"])
+        ) and not self.parent.py3.command_run("makoctl mode")
+
+    def get_state(self):
+        if self.has_makoctl_mode:
+            state = self.parent.py3.command_output("makoctl mode")
+            return state.strip() == "do-not-disturb"
+        else:
+            return self.parent.state
 
     def toggle(self, state):
         if state is True:

--- a/py3status/modules/do_not_disturb.py
+++ b/py3status/modules/do_not_disturb.py
@@ -131,7 +131,6 @@ class Mako(Notification):
 
     # From version mako 1.7 we can use "makoctl mode"
     def setup(self, parent):
-        self.toggle(parent.state)
         self.has_makoctl_mode = bool(
             self.parent.py3.check_commands(["makoctl"])
         ) and not self.parent.py3.command_run("makoctl mode")


### PR DESCRIPTION
Requested change by irc user Steinex.