### PR TITLE
vpn_status module: add wireguard support

### DIFF
--- a/py3status/modules/vpn_status.py
+++ b/py3status/modules/vpn_status.py
@@ -101,7 +101,7 @@ class Py3status:
         ids = []
         for name in self.active:
             conn = bus.get(".NetworkManager", name)
-            if conn.Vpn:
+            if conn.Vpn or conn.Type == "wireguard":
                 ids.append(conn.Id)
         # No active VPN
         return ids


### PR DESCRIPTION
Add wireguard support. These connections are identified by `Type: wireguard` instead of the `Vpn` attribute.