### PR TITLE
Minor patch to get the local timezone.

### DIFF
--- a/py3status/modules/clock.py
+++ b/py3status/modules/clock.py
@@ -189,10 +189,7 @@ class Py3status:
         """
         # special Local timezone
         if tz == "Local":
-            try:
-                return zoneinfo.ZoneInfo("localtime")
-            except zoneinfo.ZoneInfoNotFoundError:
-                return "?"
+            return None
         # get the timezone
         try:
             zone = zoneinfo.ZoneInfo(tz)
@@ -251,8 +248,12 @@ class Py3status:
                     idx = int(h / self.block_hours * len(self.blocks))
                     icon = self.blocks[idx]
 
-                timezone = zone.key
-                tzname = timezone.split("/")[-1].replace("_", " ")
+                # special case for handling Local timezone
+                if zone is None:
+                    timezone, tzname = None, None
+                else:
+                    timezone = zone.key
+                    tzname = timezone.split("/")[-1].replace("_", " ")
 
                 if self.multiple_tz:
                     name_unclear = tzname


### PR DESCRIPTION
This PR is a small patch to resolve the issue detailed in:

https://github.com/ultrabug/py3status/issues/2188

The `ZoneInfo` class doesn't seem to cater for local timezones (most likely no file detailing local information can be loaded), and the [datetime](https://docs.python.org/3/library/datetime.html#datetime.datetime.now) module indicates the default call returns the local timezone, eg `datetime.now(None)`.

Looking into `ZoneInfo` and I couldn't see much in the way for specifics regarding local timezones. So the safest thing seemed to return None, and explicitly handle it later.