### PR TITLE
fix two DeprecationWarning

### DIFF
--- a/py3status/screenshots.py
+++ b/py3status/screenshots.py
@@ -148,7 +148,7 @@ def create_screenshot(name, data, path, font, is_module):
             color = COLOR_URGENT
             background = COLOR_URGENT_BG
 
-        size = font.getsize(text)
+        size = font.getbbox(text)[-2:]
 
         if background:
             d.rectangle(
@@ -167,7 +167,7 @@ def create_screenshot(name, data, path, font, is_module):
         d_text = ImageDraw.Draw(txt)
         d_text.text((0, 0), text, font=font, fill=color)
         # resize to actual size wanted and add to image
-        txt = txt.resize((size[0] // SCALE, size[1] // SCALE), Image.ANTIALIAS)
+        txt = txt.resize((size[0] // SCALE, size[1] // SCALE), Image.LANCZOS)
         img.paste(txt, (WIDTH - x, TOP_BAR_HEIGHT + PADDING))
 
         if separator:


### PR DESCRIPTION
Fix two DeprecationWarning.
```
INFO     -  DeprecationWarning: getsize is deprecated and will be removed in Pillow 10 (2023-07-01). Use getbbox or getlength instead.
              File "python3.10-pillow-9.4.0/lib/python3.10/site-packages/PIL/_deprecate.py", line 65, in deprecate
                warnings.warn(
              File "py3status/py3status/screenshots.py", line 151, in
                size = font.getsize(text)

INFO     -  DeprecationWarning: ANTIALIAS is deprecated and will be removed in Pillow 10 (2023-07-01). Use LANCZOS or Resampling.LANCZOS instead.
              File "python3.10-pillow-9.4.0/lib/python3.10/site-packages/PIL/_deprecate.py", line 65, in deprecate
                warnings.warn(
              File "py3status/py3status/screenshots.py", line 170, in
                txt = txt.resize((size[0] // SCALE, size[1] // SCALE), Image.ANTIALIAS)
```