### PR TITLE
audiosink: fix screenshots

### DIFF
--- a/py3status/modules/audiosink.py
+++ b/py3status/modules/audiosink.py
@@ -26,12 +26,14 @@ audiosink {
 }
 ```
 
-SAMPLE OUTPUT
-{'full_text': 'Dock'}
-{'full_text': 'Int'}
-
 @author Jens Brandt <py3status@brandt-george.de>
 @license BSD
+
+SAMPLE OUTPUT
+{'full_text': 'Dock'}
+
+int
+{'full_text': 'Int'}
 """
 
 import os


### PR DESCRIPTION
This make it `audiosink-1-int.png` instead.
```
Creating screenshots in ~/src/py3status/docs/user-guide/screenshots...
...
async_script-0.png
async_script-1-example.png
audiosink-0.png
audiosink-1-@author Jens Brandt <py3status@brandt-george.de>.png    <---- 
aws_bill-0.png
backlight-0.png
...
```