### PR TITLE
added timezone information to times implicitly using local system tim…

### DIFF
--- a/py3status/modules/clock.py
+++ b/py3status/modules/clock.py
@@ -250,10 +250,11 @@ class Py3status:
 
                 # special case for handling Local timezone
                 if zone is None:
-                    timezone, tzname = None, None
+                    t = t.astimezone()
+                    timezone = t.tzname()
                 else:
                     timezone = zone.key
-                    tzname = timezone.split("/")[-1].replace("_", " ")
+                tzname = timezone.split("/")[-1].replace("_", " ")
 
                 if self.multiple_tz:
                     name_unclear = tzname


### PR DESCRIPTION
the changes introduced in #2188 and #2189 will produce native datetime objects, which will cause the %Z format specifier to unconditionally expand to the empty string. This may not be desirable. Alternatively, it is possible to convert the datetime object to a timezone datetime object relative to the local timezone using `astimezone()`, and then the timezone name is available from `tzname()`.

This would cause the %Z and %z parameters to be correctly populated.

Alternatively, it should be documented somewhere that to cause %Z and %z to be expanded correctly, the timezone needs to be specified explicitly in the py3status config file.