### PR TITLE
core: autodetect output_format

### DIFF
--- a/py3status/constants.py
+++ b/py3status/constants.py
@@ -7,7 +7,7 @@ GENERAL_DEFAULTS = {
     "color_separator": "#333333",
     "colors": True,
     "interval": 5,
-    "output_format": "i3bar",
+    "output_format": None,
 }
 
 MAX_NESTING_LEVELS = 4

--- a/py3status/core.py
+++ b/py3status/core.py
@@ -613,6 +613,16 @@ class Py3statusWrapper:
         self.log("config file: {}".format(self.config["i3status_config_path"]))
         self.config["py3_config"] = process_config(config_path, self)
 
+        # autodetect output_format
+        output_format = self.config["py3_config"]["general"]["output_format"]
+        if output_format is None:
+            if sys.stdout.isatty():
+                print("py3status: trying to auto-detect output_format setting")
+                print('py3status: auto-detected "term"')
+                output_format = "term"
+
+        self.config["py3_config"]["general"]["output_format"] = output_format or "i3bar"
+
         # read resources
         if "resources" in str(self.config["py3_config"].values()):
             from subprocess import check_output


### PR DESCRIPTION
Feature parity? py3status top, i3status bottom.
![Screenshot_20230618_052611](https://github.com/ultrabug/py3status/assets/852504/33ca949a-b258-4b19-b504-f3c8043aea03)
