### PR TITLE
module: bring back error messages

### DIFF
--- a/py3status/module.py
+++ b/py3status/module.py
@@ -154,7 +154,7 @@ class Module:
                         self.module_nice_name, str(e) or e.__class__.__name__
                     ),
                 ]
-                self.runtime_error(self.error_messages[0], "post_config_hook")
+                self.error_output(self.error_messages[0])
                 msg = f"Exception in `{self.module_full_name}` post_config_hook()"
                 self._py3_wrapper.report_exception(msg, notify_user=False)
                 self._py3_wrapper.log(f"terminating module {self.module_full_name}")


### PR DESCRIPTION
I added `nvidia_smi` to py3status on VM -- It doesn't print anything. Strange... Not even an error too?

https://github.com/ultrabug/py3status/pull/1972 is the first bad commit.

This bring back error messages (i.e. package not installed) on `post_config_hook` and maybe others too.

Simple diff test w/ `static_string`.
```diff
+++ b/py3status/modules/static_string.py
@@ -17,6 +17,9 @@ class Py3status:
     # available configuration parameters
     format = "Hello, world!"
 
+    def post_config_hook(self):
+        self.py3.error("Bye, world!")
+
     def static_string(self):
         return {
             "cached_until": self.py3.CACHE_FOREVER,

```
Note: I don't know if this changes your code. Just a small tweak to bring it back. Idk about your code. Thanks.