### PR TITLE
ns_checker module: replace query() with resolve()

### DIFF
--- a/py3status/modules/ns_checker.py
+++ b/py3status/modules/ns_checker.py
@@ -72,7 +72,7 @@ class Py3status:
         if self.resolvers:
             my_resolver.nameservers = self.resolvers
 
-        my_ns = my_resolver.query(self.domain, "NS")
+        my_ns = my_resolver.resolve(self.domain, "NS")
 
         # Insert each NS ip address in nameservers
         for ns in my_ns:
@@ -84,7 +84,7 @@ class Py3status:
         for ns in nameservers:
             my_resolver.nameservers = [ns]
             try:
-                my_resolver.query(self.domain, "A")
+                my_resolver.resolve(self.domain, "A")
                 count_ok += 1
             except:  # noqa e722
                 count_nok += 1


### PR DESCRIPTION
This fixes a dnspython deprecation warning:
"please use dns.resolver.Resolver.resolve() instead"