### PR TITLE
Add playerctl module

### DIFF
--- a/py3status/modules/playerctl.py
+++ b/py3status/modules/playerctl.py
@@ -1,0 +1,327 @@
+r"""
+Display song/video and control players supported by playerctl
+
+Playerctl is a command-line utility for controlling media players 
+that implement the MPRIS D-Bus Interface Specification. With Playerctl
+you can bind player actions to keys and get metadata about the currently
+playing song or video.
+
+Configuration parameters:
+    button_next: mouse button to skip to the next track (default None)
+    button_pause: mouse button to pause the playback (default None)
+    button_play: mouse button to play the playback (default None)
+    button_play_pause: mouse button to play/pause the playback (default 1)
+    button_previous: mouse button to skip to the previous track (default None)
+    button_shift: mouse button to manage the next player being tracked (default None)
+    button_stop: mouse button to stop the playback (default 3)
+    button_unshift: mouse button to manage the previous player being tracked (default None)
+    cache_timeout: refresh interval for this module (default 5)
+    format: display format for this module
+        *(default '[\?if=is_started [\?if=is_playing > ][\?if=is_paused \|\| ]'
+        '[\?if=is_stopped .. ][[{artist}][\?soft  - ][{title}]'
+        '|\?show cmus: waiting for user input]]')*
+    ignored_players: list of players to ignore. Playerctld will always be 
+        ignored as it conflicts with this module (default: [])
+    sleep_timeout: sleep interval for this module. When cmus is not running,
+        this interval will be used. This allows some flexible timing where one
+        might want to refresh constantly with some placeholders or to refresh
+        only once every minute rather than every few seconds. (default 20)
+
+Control placeholders:
+    {is_paused} True if the current player is paused. Otherwise, false
+    {is_playing} True if the current player is playing. Otherwise, false
+    {is_started} True if there is at least one active player. Otherwise, false 
+    {is_stopped} True if the current player is stopped. Otherwise, false
+
+Format placeholders:
+    {album} album name
+    {artist} artist name
+    {position} elapsed time in [HH:]MM:SS, eg 00:17
+    {title} track/video title
+
+    Not all media players support every placeholder
+
+Color options:
+    color_paused: Paused, defaults to color_degraded
+    color_playing: Playing, defaults to color_good
+    color_stopped: Stopped, defaults to color_bad
+
+
+Requires:
+    playerctl: mpris media player controller and lib for spotify, vlc, audacious, bmp, xmms2, and others.
+
+@author jdholtz
+
+SAMPLE OUTPUT
+{'color': '#00FF00', 'full_text': '> My Lucky Pants Failed Me Again - Tom Rosenthal'}
+
+paused
+{'color': '#FFFF00', 'full_text': '|| My Lucky Pants Failed Me Again - Tom Rosenthal'}
+
+stopped
+{'color': '#FF0000', 'full_text': '.. My Lucky Pants Failed Me Again - Tom Rosenthal'}
+
+waiting
+{'color': '#FF0000', 'full_text': '.. playerctl: no active players'}
+"""
+from threading import Thread
+
+import gi
+
+gi.require_version("Playerctl", "2.0")
+from gi.repository import GLib, Playerctl
+
+
+class Py3status:
+    """ """
+
+    # available configuration parameters
+    button_next = None
+    button_pause = None
+    button_play = None
+    button_play_pause = 1
+    button_previous = None
+    button_shift = None
+    button_unshift = None
+    button_stop = 3
+    cache_timeout = 5
+    format = (
+        r"[\?if=is_started [\?if=is_playing > ][\?if=is_paused \|\| ]"
+        r"[\?if=is_stopped .. ][[{artist}][\?soft  - ][{title}]"
+        r"|\?show playerctl: no active players]]"
+    )
+    ignored_players = []
+    sleep_timeout = 20
+
+    def post_config_hook(self):
+        if not self.py3.check_commands("playerctl"):
+            raise Exception("command 'playerctl' not installed")
+
+        self.color_paused = self.py3.COLOR_PAUSED or self.py3.COLOR_DEGRADED
+        self.color_playing = self.py3.COLOR_PLAYING or self.py3.COLOR_GOOD
+        self.color_stopped = self.py3.COLOR_STOPPED or self.py3.COLOR_BAD
+
+        # Playerctld conflicts with this module
+        if "playerctld" not in self.ignored_players:
+            self.ignored_players.append("playerctld")
+
+        self._reset()
+        self._init_manager()
+
+    def _get_player_names(self):
+        return [
+            player_name
+            for player_name in self.manager.props.player_names
+            if player_name.name not in self.ignored_players
+        ]
+
+    def _get_players(self):
+        return [
+            player
+            for player in self.manager.props.players
+            if player.props.player_name not in self.ignored_players
+        ]
+
+    def _reset(self):
+        self.status = None
+        self.album = None
+        self.artist = None
+        self.title = None
+        self.position = None
+        self.active_player = None
+        self.is_started = False
+
+    def _init_manager(self):
+        self.manager = Playerctl.PlayerManager()
+        self.manager.connect("name-appeared", self._on_name_appeared)
+        self.manager.connect("name-vanished", self._on_name_vanished)
+
+        # Initialize all currently active players
+        for player_name in self._get_player_names():
+            self.py3.log(player_name.name)
+            self._init_player(player_name)
+
+        players = self._get_players()
+        if len(players) > 0:
+            # Start monitoring the first player
+            self._set_active_player(players[0], False)
+            self.is_started = True
+
+        self._start_loop()
+
+    def _init_player(self, player_name):
+        player = Playerctl.Player.new_from_name(player_name)
+
+        # Set up all event listeners
+        player.connect("playback-status", self._status_changed, self.manager)
+        player.connect("metadata", self._on_metadata, self.manager)
+
+        self.manager.manage_player(player)
+
+    def _set_active_player(self, player, update_module=True):
+        self.py3.log(player.props.player_name)
+        self.active_player = player
+        self.album = player.get_album()
+        self.artist = player.get_artist()
+        self.title = player.get_title()
+        self.status = player.props.playback_status
+
+        try:
+            # Playerctl doesn't support getting positions for all players
+            microseconds = player.get_position()
+            self.position = self._microseconds_to_time(microseconds)
+        except GLib.GError:
+            self.position = None
+
+        if update_module:
+            self.py3.update()
+
+    def _start_loop(self):
+        loop = GLib.MainLoop()
+
+        # The loop is blocking so it needs to be run a separate thread
+        thread = Thread(target=loop.run)
+        thread.daemon = True
+        thread.start()
+
+    def _shift(self, shift):
+        players = self._get_players()
+        if len(players) == 0:
+            return
+
+        active_player_idx = 0
+        if self.active_player in players:
+            # Set the correct index if the player exists (has not been removed)
+            active_player_idx = players.index(self.active_player)
+
+        new_player_idx = (active_player_idx + shift) % len(players)
+        self._set_active_player(players[new_player_idx])
+
+    def _on_name_appeared(self, manager, player_name):
+        if player_name.name in self.ignored_players:
+            return
+
+        self._init_player(player_name)
+
+        players = self._get_players()
+        if len(players) == 1:
+            # It is the only player being tracked
+            self._set_active_player(players[0])
+            self.is_started = True
+
+    def _on_name_vanished(self, manager, name):
+        if len(self._get_players()) == 0:
+            # No players are being tracked
+            self._reset()
+            self.py3.update()
+            return
+
+        # Shift to the next player (shift by 0 because this player
+        # has been removed from tracking)
+        self._shift(0)
+
+    def _on_metadata(self, player, metadata, manager):
+        self._set_active_player(player)
+
+    def _status_changed(self, player, status, manager):
+        self._set_active_player(player)
+
+    def _shift_player(self):
+        """Shift the active player forward by 1"""
+        self._shift(1)
+
+    def _unshift_player(self):
+        """Shift the active player backward by 1"""
+        self._shift(-1)
+
+    @staticmethod
+    def _microseconds_to_time(microseconds):
+        seconds = microseconds // 1_000_000
+        m, s = divmod(seconds, 60)
+        h, m = divmod(m, 60)
+        time = f"{h}:{m:02d}:{s:02d}"
+        return time.lstrip("0").lstrip(":")
+
+    def playerctl(self):
+        is_paused = is_playing = is_stopped = None
+        color = self.py3.COLOR_BAD
+        cached_until = self.cache_timeout if self.is_started else self.sleep_timeout
+
+        data = {
+            "title": self.title,
+            "artist": self.artist,
+            "album": self.album,
+            "position": self.position,
+        }
+
+        if self.status == Playerctl.PlaybackStatus.PLAYING:
+            is_playing = True
+            color = self.color_playing
+        elif self.status == Playerctl.PlaybackStatus.PAUSED:
+            is_paused = True
+            color = self.color_paused
+        elif self.status == Playerctl.PlaybackStatus.STOPPED:
+            is_stopped = True
+            color = self.color_stopped
+
+        # TODO: & in the metadata properties causes module not to display
+        return {
+            "cached_until": self.py3.time_in(cached_until),
+            "color": color,
+            "full_text": self.py3.safe_format(
+                self.format,
+                dict(
+                    is_paused=is_paused,
+                    is_playing=is_playing,
+                    is_started=self.is_started,
+                    is_stopped=is_stopped,
+                    **data,
+                ),
+            ),
+        }
+
+    def on_click(self, event):
+        """
+        Control playerctl with mouse clicks.
+        """
+        if not self.active_player:
+            self.py3.prevent_refresh()
+            return
+
+        button = event["button"]
+        if button == self.button_shift:
+            self._shift_player()
+            return
+
+        if button == self.button_unshift:
+            self._unshift_player()
+            return
+
+        if not self.active_player.props.can_control:
+            self.py3.prevent_refresh()
+            return
+
+        player_props = self.active_player.props
+        if button == self.button_play and player_props.can_play:
+            self.active_player.play()
+        elif button == self.button_pause and player_props.can_pause:
+            self.active_player.pause()
+        elif button == self.button_play_pause and player_props.can_play:
+            self.active_player.play_pause()
+        elif button == self.button_stop:
+            self.active_player.stop()
+        elif button == self.button_next and player_props.can_go_next:
+            self.active_player.next()
+        elif button == self.button_previous and player_props.can_go_previous:
+            self.active_player.previous()
+        else:
+            self.py3.prevent_refresh()
+
+
+if __name__ == "__main__":
+    """
+    Run module in test mode.
+    """
+    from py3status.module_test import module_test
+
+    module_test(Py3status)

--- a/py3status/modules/playerctl.py
+++ b/py3status/modules/playerctl.py
@@ -53,6 +53,7 @@ SAMPLE OUTPUT
     {'color': '#FFFF00', 'full_text': '|| Too Much Skunk Tonight - Birdy Nam Nam'}
 ]
 """
+import time
 from fnmatch import fnmatch
 from threading import Thread
 
@@ -145,6 +146,8 @@ class Py3status:
         self._init_player(player_name)
 
     def _on_name_vanished(self, manager, name):
+        # Add a very small delay to give Playerctl time to remove the player
+        time.sleep(0.01)
         self.py3.update()
 
     def _on_metadata(self, player, metadata, manager):
@@ -230,8 +233,6 @@ class Py3status:
             if player.props.player_name == index:
                 return player
 
-        # Should never be reached as the user can't click on a player
-        # that doesn't exist
         return None
 
     def on_click(self, event):
@@ -246,7 +247,7 @@ class Py3status:
         self.py3.prevent_refresh()
 
         player = self._get_player_from_index(index)
-        if not player.props.can_control:
+        if not player or not player.props.can_control:
             return
 
         if button == self.button_play and player.props.can_play:

--- a/py3status/modules/playerctl.py
+++ b/py3status/modules/playerctl.py
@@ -7,7 +7,7 @@ you can bind player actions to keys and get metadata about the currently
 playing song or video.
 
 Configuration parameters:
-    button_loop_status: mouse button to cycle the loop status of the player (default None)
+    button_loop: mouse button to cycle the loop status of the player (default None)
     button_next: mouse button to skip to the next track (default None)
     button_pause: mouse button to pause the playback (default None)
     button_play: mouse button to play the playback (default None)
@@ -39,7 +39,7 @@ Format player placeholders:
     {album} album name
     {artist} artist name
     {duration} length of track/video in [HH:]MM:SS, e.g. 03:22
-    {loop_status} loop status of the player, e.g. None, playlist, Track
+    {loop} loop status of the player, e.g. None, playlist, Track
     {player} name of the player
     {position} elapsed time in [HH:]MM:SS, e.g. 00:17
     {shuffle} boolean indicating if the player's shuffle mode is on
@@ -79,7 +79,7 @@ class Py3status:
     """ """
 
     # available configuration parameters
-    button_loop_status = None
+    button_loop = None
     button_next = None
     button_pause = None
     button_play = None
@@ -230,7 +230,7 @@ class Py3status:
 
         # Player attributes
         data["player"] = player.props.player_name
-        data["loop_status"] = player.props.loop_status.value_nick
+        data["loop"] = player.props.loop_status.value_nick
         data["shuffle"] = player.props.shuffle
         data["status"] = player.props.status
         data["volume"] = int(player.props.volume * 100)
@@ -339,7 +339,7 @@ class Py3status:
             self._change_player_volume(player, 1)
         elif button == self.button_volume_down:
             self._change_player_volume(player, -1)
-        elif button == self.button_loop_status:
+        elif button == self.button_loop:
             self._cycle_player_loop_status(player)
         elif button == self.button_shuffle:
             self._toggle_player_shuffle(player)

--- a/py3status/modules/playerctl.py
+++ b/py3status/modules/playerctl.py
@@ -19,13 +19,13 @@ Configuration parameters:
     format: display format for this module
         *(default '[\?if=is_started [\?if=is_playing > ][\?if=is_paused \|\| ]'
         '[\?if=is_stopped .. ][[{artist}][\?soft  - ][{title}]'
-        '|\?show cmus: waiting for user input]]')*
+        '|\?show playerctl: no active players]]')*
     ignored_players: list of players to ignore. Playerctld will always be 
         ignored as it conflicts with this module (default: [])
-    sleep_timeout: sleep interval for this module. When cmus is not running,
-        this interval will be used. This allows some flexible timing where one
-        might want to refresh constantly with some placeholders or to refresh
-        only once every minute rather than every few seconds. (default 20)
+    sleep_timeout: sleep interval for this module. When playerctl is not controlling
+        any media players, this interval will be used. This allows some flexible
+        timing where one might want to refresh constantly with some placeholders or to
+        refresh only once every minute rather than every few seconds. (default 20)
 
 Control placeholders:
     {is_paused} True if the current player is paused. Otherwise, false

--- a/py3status/modules/playerctl.py
+++ b/py3status/modules/playerctl.py
@@ -12,31 +12,30 @@ Configuration parameters:
     button_play: mouse button to play the playback (default None)
     button_play_pause: mouse button to play/pause the playback (default 1)
     button_previous: mouse button to skip to the previous track (default None)
-    button_shift: mouse button to manage the next player being tracked (default None)
     button_stop: mouse button to stop the playback (default 3)
-    button_unshift: mouse button to manage the previous player being tracked (default None)
     cache_timeout: refresh interval for this module (default 5)
-    format: display format for this module
-        *(default '[\?if=is_started [\?if=is_playing > ][\?if=is_paused \|\| ]'
-        '[\?if=is_stopped .. ][[{artist}][\?soft  - ][{title}]'
-        '|\?show playerctl: no active players]]')*
-    ignored_players: list of players to ignore. Playerctld will always be 
-        ignored as it conflicts with this module (default: [])
-    sleep_timeout: sleep interval for this module. When playerctl is not controlling
-        any media players, this interval will be used. This allows some flexible
-        timing where one might want to refresh constantly with some placeholders or to
-        refresh only once every minute rather than every few seconds. (default 20)
+    format: display format for this module (default: '{format_player}')
+    format_player: display format for players:
+        *(default '[\?if=is_playing > ][\?if=is_paused \|\| ]'
+        '[\?if=is_stopped .. ][[{artist}][\?soft  - ][{title}]]')*
+    format_separator: show separator if more than one (default: ' ')
+    players: list of players to track. An empty list tracks all players (default: [])
+    sleep_timeout: sleep interval for this module. When playerctl is not tracking any
+        players, this interval will be used. This allows some flexible timing where
+        one might want to refresh constantly with some placeholders or to refresh
+        only once every minute rather than every few seconds. (default 20)
 
 Control placeholders:
-    {is_paused} True if the current player is paused. Otherwise, false
-    {is_playing} True if the current player is playing. Otherwise, false
-    {is_started} True if there is at least one active player. Otherwise, false 
-    {is_stopped} True if the current player is stopped. Otherwise, false
+    {is_paused} True if the player is paused. Otherwise, false
+    {is_playing} True if the player is playing. Otherwise, false
+    {is_stopped} True if the player is stopped. Otherwise, false
 
 Format placeholders:
     {album} album name
     {artist} artist name
-    {position} elapsed time in [HH:]MM:SS, eg 00:17
+    {duration} length of track/video in [HH:]MM:SS, e.g. 03:22
+    {player} name of the player
+    {position} elapsed time in [HH:]MM:SS, e.g. 00:17
     {title} track/video title
 
     Not all media players support every placeholder
@@ -46,23 +45,17 @@ Color options:
     color_playing: Playing, defaults to color_good
     color_stopped: Stopped, defaults to color_bad
 
-
 Requires:
-    playerctl: mpris media player controller and lib for spotify, vlc, audacious, bmp, xmms2, and others.
+    playerctl: mpris media player controller and lib for spotify, vlc, audacious,
+        bmp, xmms2, and others.
 
 @author jdholtz
 
 SAMPLE OUTPUT
-{'color': '#00FF00', 'full_text': '> My Lucky Pants Failed Me Again - Tom Rosenthal'}
-
-paused
-{'color': '#FFFF00', 'full_text': '|| My Lucky Pants Failed Me Again - Tom Rosenthal'}
-
-stopped
-{'color': '#FF0000', 'full_text': '.. My Lucky Pants Failed Me Again - Tom Rosenthal'}
-
-waiting
-{'color': '#FF0000', 'full_text': '.. playerctl: no active players'}
+[
+    {'color': '#00FF00', 'full_text': '> My Lucky Pants Failed Me Again - Tom Rosenthal'}
+    {'color': '#FFFF00', 'full_text': '|| Too Much Skunk Tonight - Birdy Nam Nam'}
+]
 """
 from threading import Thread
 
@@ -81,16 +74,15 @@ class Py3status:
     button_play = None
     button_play_pause = 1
     button_previous = None
-    button_shift = None
-    button_unshift = None
     button_stop = 3
     cache_timeout = 5
-    format = (
-        r"[\?if=is_started [\?if=is_playing > ][\?if=is_paused \|\| ]"
-        r"[\?if=is_stopped .. ][[{artist}][\?soft  - ][{title}]"
-        r"|\?show playerctl: no active players]]"
+    format = "{format_player}"
+    format_player = (
+        r"[\?if=is_playing > ][\?if=is_paused \|\| ]"
+        r"[\?if=is_stopped .. ][[{artist}][\?soft  - ][{title}]]"
     )
-    ignored_players = []
+    format_separator = " "
+    players = []
     sleep_timeout = 20
 
     def post_config_hook(self):
@@ -101,35 +93,7 @@ class Py3status:
         self.color_playing = self.py3.COLOR_PLAYING or self.py3.COLOR_GOOD
         self.color_stopped = self.py3.COLOR_STOPPED or self.py3.COLOR_BAD
 
-        # Playerctld conflicts with this module
-        if "playerctld" not in self.ignored_players:
-            self.ignored_players.append("playerctld")
-
-        self._reset()
         self._init_manager()
-
-    def _get_player_names(self):
-        return [
-            player_name
-            for player_name in self.manager.props.player_names
-            if player_name.name not in self.ignored_players
-        ]
-
-    def _get_players(self):
-        return [
-            player
-            for player in self.manager.props.players
-            if player.props.player_name not in self.ignored_players
-        ]
-
-    def _reset(self):
-        self.status = None
-        self.album = None
-        self.artist = None
-        self.title = None
-        self.position = None
-        self.active_player = None
-        self.is_started = False
 
     def _init_manager(self):
         self.manager = Playerctl.PlayerManager()
@@ -137,19 +101,15 @@ class Py3status:
         self.manager.connect("name-vanished", self._on_name_vanished)
 
         # Initialize all currently active players
-        for player_name in self._get_player_names():
-            self.py3.log(player_name.name)
+        for player_name in self.manager.props.player_names:
             self._init_player(player_name)
-
-        players = self._get_players()
-        if len(players) > 0:
-            # Start monitoring the first player
-            self._set_active_player(players[0], False)
-            self.is_started = True
 
         self._start_loop()
 
     def _init_player(self, player_name):
+        if len(self.players) > 0 and player_name.name not in self.players:
+            return
+
         player = Playerctl.Player.new_from_name(player_name)
 
         # Set up all event listeners
@@ -157,24 +117,6 @@ class Py3status:
         player.connect("metadata", self._on_metadata, self.manager)
 
         self.manager.manage_player(player)
-
-    def _set_active_player(self, player, update_module=True):
-        self.py3.log(player.props.player_name)
-        self.active_player = player
-        self.album = player.get_album()
-        self.artist = player.get_artist()
-        self.title = player.get_title()
-        self.status = player.props.playback_status
-
-        try:
-            # Playerctl doesn't support getting positions for all players
-            microseconds = player.get_position()
-            self.position = self._microseconds_to_time(microseconds)
-        except GLib.GError:
-            self.position = None
-
-        if update_module:
-            self.py3.update()
 
     def _start_loop(self):
         loop = GLib.MainLoop()
@@ -184,55 +126,27 @@ class Py3status:
         thread.daemon = True
         thread.start()
 
-    def _shift(self, shift):
-        players = self._get_players()
-        if len(players) == 0:
-            return
-
-        active_player_idx = 0
-        if self.active_player in players:
-            # Set the correct index if the player exists (has not been removed)
-            active_player_idx = players.index(self.active_player)
-
-        new_player_idx = (active_player_idx + shift) % len(players)
-        self._set_active_player(players[new_player_idx])
-
     def _on_name_appeared(self, manager, player_name):
-        if player_name.name in self.ignored_players:
-            return
-
         self._init_player(player_name)
 
-        players = self._get_players()
-        if len(players) == 1:
-            # It is the only player being tracked
-            self._set_active_player(players[0])
-            self.is_started = True
-
     def _on_name_vanished(self, manager, name):
-        if len(self._get_players()) == 0:
-            # No players are being tracked
-            self._reset()
-            self.py3.update()
-            return
-
-        # Shift to the next player (shift by 0 because this player
-        # has been removed from tracking)
-        self._shift(0)
+        self.py3.update()
 
     def _on_metadata(self, player, metadata, manager):
-        self._set_active_player(player)
+        self.py3.update()
 
     def _status_changed(self, player, status, manager):
-        self._set_active_player(player)
+        self.py3.update()
 
-    def _shift_player(self):
-        """Shift the active player forward by 1"""
-        self._shift(1)
+    def _get_player_position(self, player):
+        try:
+            # Playerctl doesn't support getting positions for all players
+            microseconds = player.get_position()
+            position = self._microseconds_to_time(microseconds)
+        except GLib.GError:
+            position = None
 
-    def _unshift_player(self):
-        """Shift the active player backward by 1"""
-        self._shift(-1)
+        return position
 
     @staticmethod
     def _microseconds_to_time(microseconds):
@@ -242,80 +156,107 @@ class Py3status:
         time = f"{h}:{m:02d}:{s:02d}"
         return time.lstrip("0").lstrip(":")
 
+    def _set_color(self, player, data):
+        """Set the color and the control variables for a player"""
+        status = player.props.playback_status
+        if status == Playerctl.PlaybackStatus.PLAYING:
+            data["color"] = self.color_playing
+            data["is_playing"] = True
+        elif status == Playerctl.PlaybackStatus.PAUSED:
+            data["color"] = self.color_paused
+            data["is_paused"] = True
+        else:
+            data["color"] = self.color_stopped
+            data["is_stopped"] = True
+
+    def _set_data_from_metadata(self, player, data):
+        """Set any data retrieved directly from the metadata for a player"""
+        metadata = dict(player.props.metadata)
+
+        duration_ms = metadata.get("mpris:length")
+        if duration_ms:
+            data["duration"] = self._microseconds_to_time(duration_ms)
+        else:
+            data["duration"] = None
+
+    def _get_player_data(self, player):
+        data = {}
+
+        data["album"] = player.get_album()
+        data["artist"] = player.get_artist()
+        data["title"] = player.get_title()
+        data["player"] = player.props.player_name
+
+        self._set_color(player, data)
+
+        data["position"] = self._get_player_position(player)
+        self._set_data_from_metadata(player, data)
+
+        return data
+
     def playerctl(self):
-        is_paused = is_playing = is_stopped = None
-        color = self.py3.COLOR_BAD
-        cached_until = self.cache_timeout if self.is_started else self.sleep_timeout
+        tracked_players = self.manager.props.players
+        cached_until = self.cache_timeout if tracked_players else self.sleep_timeout
 
-        data = {
-            "title": self.title,
-            "artist": self.artist,
-            "album": self.album,
-            "position": self.position,
-        }
+        players = []
+        for player in tracked_players:
+            player_data = self._get_player_data(player)
 
-        if self.status == Playerctl.PlaybackStatus.PLAYING:
-            is_playing = True
-            color = self.color_playing
-        elif self.status == Playerctl.PlaybackStatus.PAUSED:
-            is_paused = True
-            color = self.color_paused
-        elif self.status == Playerctl.PlaybackStatus.STOPPED:
-            is_stopped = True
-            color = self.color_stopped
+            # Delete after referencing because it shouldn't be a valid placeholder
+            color = player_data["color"]
+            del player_data["color"]
 
-        # TODO: & in the metadata properties causes module not to display
+            format_player = self.py3.safe_format(self.format_player, player_data)
+            self.py3.composite_update(format_player, {"index": player_data["player"]})
+            self.py3.composite_update(format_player, {"color": color})
+            players.append(format_player)
+
+        format_separator = self.py3.safe_format(self.format_separator)
+        format_players = self.py3.composite_join(format_separator, players)
+
         return {
             "cached_until": self.py3.time_in(cached_until),
-            "color": color,
             "full_text": self.py3.safe_format(
-                self.format,
-                dict(
-                    is_paused=is_paused,
-                    is_playing=is_playing,
-                    is_started=self.is_started,
-                    is_stopped=is_stopped,
-                    **data,
-                ),
+                self.format, {"format_player": format_players}
             ),
         }
+
+    def _get_player_from_index(self, index):
+        for player in self.manager.props.players:
+            if player.props.player_name == index:
+                return player
+
+        # Should never be reached as the user can't click on a player
+        # that doesn't exist
+        return None
 
     def on_click(self, event):
         """
         Control playerctl with mouse clicks.
         """
-        if not self.active_player:
-            self.py3.prevent_refresh()
-            return
-
         button = event["button"]
-        if button == self.button_shift:
-            self._shift_player()
+        index = event["index"]
+
+        # Always prevent a refresh because this module updates whenever
+        # a player's status or metadata changes
+        self.py3.prevent_refresh()
+
+        player = self._get_player_from_index(index)
+        if not player.props.can_control:
             return
 
-        if button == self.button_unshift:
-            self._unshift_player()
-            return
-
-        if not self.active_player.props.can_control:
-            self.py3.prevent_refresh()
-            return
-
-        player_props = self.active_player.props
-        if button == self.button_play and player_props.can_play:
-            self.active_player.play()
-        elif button == self.button_pause and player_props.can_pause:
-            self.active_player.pause()
-        elif button == self.button_play_pause and player_props.can_play:
-            self.active_player.play_pause()
+        if button == self.button_play and player.props.can_play:
+            player.play()
+        elif button == self.button_pause and player.props.can_pause:
+            player.pause()
+        elif button == self.button_play_pause and player.props.can_play:
+            player.play_pause()
         elif button == self.button_stop:
-            self.active_player.stop()
-        elif button == self.button_next and player_props.can_go_next:
-            self.active_player.next()
-        elif button == self.button_previous and player_props.can_go_previous:
-            self.active_player.previous()
-        else:
-            self.py3.prevent_refresh()
+            player.stop()
+        elif button == self.button_next and player.props.can_go_next:
+            player.next()
+        elif button == self.button_previous and player.props.can_go_previous:
+            player.previous()
 
 
 if __name__ == "__main__":

--- a/py3status/modules/playerctl.py
+++ b/py3status/modules/playerctl.py
@@ -116,10 +116,6 @@ class Py3status:
         }
 
     def post_config_hook(self):
-        self.color_paused = self.py3.COLOR_PAUSED or self.py3.COLOR_DEGRADED
-        self.color_playing = self.py3.COLOR_PLAYING or self.py3.COLOR_GOOD
-        self.color_stopped = self.py3.COLOR_STOPPED or self.py3.COLOR_BAD
-
         self.thresholds_init = self.py3.get_color_names_list(self.format_player)
         self.position = self.py3.format_contains(self.format_player, "position")
         self.cache_timeout = getattr(self, "cache_timeout", 1)

--- a/py3status/modules/playerctl.py
+++ b/py3status/modules/playerctl.py
@@ -13,8 +13,6 @@ Configuration parameters:
     button_play_pause: mouse button to play/pause the playback (default 1)
     button_previous: mouse button to skip to the previous track (default None)
     button_stop: mouse button to stop the playback (default 3)
-    cache_timeout: refresh interval for this module. When no players are being
-        tracked, it will be cached forever (default 5)
     format: display format for this module (default: '{format_player}')
     format_player: display format for players:
         *(default '[\?color=status [\?if=status=playing > ][\?if=status=paused \|\| ]'
@@ -70,7 +68,6 @@ class Py3status:
     button_play_pause = 1
     button_previous = None
     button_stop = 3
-    cache_timeout = 5
     format = "{format_player}"
     format_player = (
         r"[\?color=status [\?if=status=playing > ][\?if=status=paused \|\| ]"
@@ -196,7 +193,15 @@ class Py3status:
 
     def playerctl(self):
         tracked_players = self.manager.props.players
-        cached_until = self.cache_timeout if tracked_players else self.py3.CACHE_FOREVER
+
+        # Only have a cache timeout if the user wants to know the players' positions
+        if tracked_players and (
+            self.py3.format_contains(self.format, "position")
+            or self.py3.format_contains(self.format_player, "position")
+        ):
+            cached_until = 1
+        else:
+            cached_until = self.py3.CACHE_FOREVER
 
         players = []
         for player in tracked_players:

--- a/py3status/modules/playerctl.py
+++ b/py3status/modules/playerctl.py
@@ -43,10 +43,13 @@ Requires:
 @author jdholtz
 
 SAMPLE OUTPUT
-[
-    {'color': '#00FF00', 'full_text': '> My Lucky Pants Failed Me Again - Tom Rosenthal'}
-    {'color': '#FFFF00', 'full_text': '|| Too Much Skunk Tonight - Birdy Nam Nam'}
-]
+{'color': '#00FF00', 'full_text': '> Don’t Eat the Yellow Snow - Frank Zappa'}
+
+Paused
+{'color': '#FFFF00', 'full_text': '|| Too Much Skunk Tonight - Birdy Nam Nam'}
+
+Stopped
+{'color': '#FF0000', 'full_text': '.. This Song Has No Title - Elton John'}
 """
 import time
 from fnmatch import fnmatch
@@ -195,6 +198,13 @@ class Py3status:
 
         return data
 
+    def _get_player_from_index(self, index):
+        for player in self.manager.props.players:
+            if player.props.player_name == index:
+                return player
+
+        return None
+
     def playerctl(self):
         tracked_players = self.manager.props.players
 
@@ -232,13 +242,6 @@ class Py3status:
                 self.format, {"format_player": format_players}
             ),
         }
-
-    def _get_player_from_index(self, index):
-        for player in self.manager.props.players:
-            if player.props.player_name == index:
-                return player
-
-        return None
 
     def on_click(self, event):
         """

--- a/py3status/modules/playerctl.py
+++ b/py3status/modules/playerctl.py
@@ -13,12 +13,12 @@ Configuration parameters:
     button_play_pause: mouse button to play/pause the playback (default 1)
     button_previous: mouse button to skip to the previous track (default None)
     button_stop: mouse button to stop the playback (default 3)
-    format: display format for this module (default: '{format_player}')
-    format_player: display format for players:
+    format: display format for this module (default '{format_player}')
+    format_player: display format for players
         *(default '[\?color=status [\?if=status=playing > ][\?if=status=paused \|\| ]'
         '[\?if=status=stopped .. ][[{artist}][\?soft  - ][{title}|{player}]]]')*
-    format_player_separator: show separator if more than one player (default: ' ')
-    players: list of players to track. An empty list tracks all players (default: [])
+    format_player_separator: show separator if more than one player (default ' ')
+    players: list of players to track. An empty list tracks all players (default [])
     thresholds: specify color thresholds to use for different placeholders
         (default {"status": [("playing", "good"), ("paused", "degraded"), ("stopped", "bad")]})
 


### PR DESCRIPTION
Fixes #2205.

This PR adds support for the playerctl module. It uses [Playerctl's Python binding library](https://lazka.github.io/pgi-docs/Playerctl-2.0/) to monitor and extract information from players. Most of the configuration options are the same as the `cmus` module. There are three more added: `button_shift`, `button_unshift`, and `ignored_players`.

An important thing to note: If any text sent to i3bar contains an `&`, the text will not render. The `&` is common in videos and therefore creates a problem. I also see this issue in the `cmus` module, so it isn't directly an issue with this module, but should be solved to provide users with a better experience.

There are two ways I see solving this: 
1. Fix it in the playerctl module by doing some sort of `str.replace("&", "and")`
2. Fix it in py3status, which would also fix this issue for other modules

I also have a few more configuration options in mind but would like to get others' opinions:
1. A `max_width` option to render the text with an `...` if it is too long. There are a lot of videos that span half the i3bar. However, I am not sure if this can be handled in Py3status's formatter or not.
2. A `player_priority` option to initially select the active player. Currently, it selects the first one that playerctl selects. I don't think this option is necessary as I only see it being a factor during the post_config_hook (mostly only run when the user starts i3). After the initial start, active players will be cycled through by the most recent player to change status, metadata, or be opened. Additionally, configuration options are provided for the user to manually switch the active player (`button_shift` and `button_unshift`)

This might remove the need for the `mpris` module, but more information about a player is provided in that module so that be good to still keep. Additionally, the `player_control` module probably doesn't need to be kept as this module controls the same players.

Any feedback is appreciated. I will be willing to maintain this module (fixing bugs, adding new features, refactoring, etc.).