### PR TITLE
Update arch_updates.py

### DIFF
--- a/py3status/modules/arch_updates.py
+++ b/py3status/modules/arch_updates.py
@@ -100,7 +100,7 @@ class Py3status:
 
     def _get_auracle_updates(self):
         try:
-            updates = self.py3.command_output(["auracle", "sync"])
+            updates = self.py3.command_output(["auracle", "outdated"])
             return len(updates.splitlines())
         except self.py3.CommandError as ce:
             return None if ce.error else 0


### PR DESCRIPTION
Upstream (https://github.com/falconindy/auracle) changed "sync" to "outdated" via 893c622, on 26 Oct 2019