### PR TITLE
volume_status module: pamixer: Use default device if none specified

### DIFF
--- a/py3status/modules/volume_status.py
+++ b/py3status/modules/volume_status.py
@@ -172,7 +172,7 @@ class Amixer(Audio):
 class Pamixer(Audio):
     def setup(self, parent):
         is_input = "--source" if self.is_input else "--sink"
-        self.cmd = ["pamixer", "--allow-boost", is_input, self.device or "0"]
+        self.cmd = ["pamixer", "--allow-boost"] + ([is_input, self.device] if self.device else [])
 
     def get_volume(self):
         try:


### PR DESCRIPTION
Not specifying the device should use whatever pamixer thinks is the default. Using 0 might not be always the default, especially because the default (or whatever pamixer thinks is the default) can change at runtime.