### PR TITLE
music modules: implement sanitize_words support for all music modules

### DIFF
--- a/py3status/constants.py
+++ b/py3status/constants.py
@@ -270,3 +270,16 @@ RETIRED_MODULES = {
 MARKUP_LANGUAGES = ["pango", "none"]
 
 ON_ERROR_VALUES = ["hide", "show"]
+
+DEFAULT_SANITIZE_WORDS = [
+    "bonus",
+    "demo",
+    "edit",
+    "explicit",
+    "extended",
+    "feat",
+    "mono",
+    "remaster",
+    "stereo",
+    "version",
+]

--- a/py3status/modules/cmus.py
+++ b/py3status/modules/cmus.py
@@ -16,6 +16,11 @@ Configuration parameters:
         *(default '[\?if=is_started [\?if=is_playing > ][\?if=is_paused \|\| ]'
         '[\?if=is_stopped .. ][[{artist}][\?soft  - ][{title}]'
         '|\?show cmus: waiting for user input]]')*
+    sanitize_titles: whether to remove meta data from album/track title
+        (default True)
+    sanitize_words: which meta data to remove
+        *(default ['bonus', 'demo', 'edit', 'explicit', 'extended',
+            'feat', 'mono', 'remaster', 'stereo', 'version'])*
     sleep_timeout: sleep interval for this module. when cmus is not running,
         this interval will be used. this allows some flexible timing where one
         might want to refresh constantly with some placeholders... or to refresh
@@ -83,6 +88,8 @@ waiting
 {'color': '#FF0000', 'full_text': '.. cmus: waiting for user input'}
 """
 
+from py3status.constants import DEFAULT_SANITIZE_WORDS
+
 STRING_NOT_INSTALLED = "not installed"
 
 
@@ -100,6 +107,8 @@ class Py3status:
         r"[\?if=is_stopped .. ][[{artist}][\?soft  - ][{title}]"
         r"|\?show cmus: waiting for user input]]"
     )
+    sanitize_titles = True
+    sanitize_words = DEFAULT_SANITIZE_WORDS
     sleep_timeout = 20
 
     def post_config_hook(self):
@@ -149,6 +158,9 @@ class Py3status:
                 temporary[key] = True
             elif value in ("false", "disabled"):
                 temporary[key] = False
+            # sanitize album and title
+            elif self.sanitize_titles and key in ("album", "title"):
+                temporary[key] = self.py3.sanitize_title(self.sanitize_words, value)
             # string not modified
             else:
                 temporary[key] = value

--- a/py3status/modules/deadbeef.py
+++ b/py3status/modules/deadbeef.py
@@ -4,6 +4,11 @@ Display songs currently playing in DeaDBeeF.
 Configuration parameters:
     cache_timeout: refresh interval for this module (default 5)
     format: display format for this module (default '[{artist} - ][{title}]')
+    sanitize_titles: whether to remove meta data from album/track title
+        (default True)
+    sanitize_words: which meta data to remove
+        *(default ['bonus', 'demo', 'edit', 'explicit', 'extended',
+            'feat', 'mono', 'remaster', 'stereo', 'version'])*
     sleep_timeout: when deadbeef is not running, this interval will be used
         to allow faster refreshes with time-related placeholders and/or
         to refresh few times per minute rather than every few seconds
@@ -49,6 +54,8 @@ paused
 {'color': '#ffff00', 'full_text': 'Music For Programming - Lackluster'}
 """
 
+from py3status.constants import DEFAULT_SANITIZE_WORDS
+
 STRING_NOT_INSTALLED = "not installed"
 
 
@@ -58,6 +65,8 @@ class Py3status:
     # available configuration parameters
     cache_timeout = 5
     format = "[{artist} - ][{title}]"
+    sanitize_titles = True
+    sanitize_words = DEFAULT_SANITIZE_WORDS
     sleep_timeout = 20
 
     class Meta:
@@ -118,6 +127,14 @@ class Py3status:
             line = self._get_deadbeef_data()
             beef_data = dict(zip(self.placeholders, line.split(self.separator)))
             cached_until = self.cache_timeout
+
+            # Sanitize album and title
+            if self.sanitize_titles:
+                if "album" in beef_data:
+                    beef_data["album"] = self.py3.sanitize_title(self.sanitize_words, beef_data["album"])
+
+                if "title" in beef_data:
+                    beef_data["title"] = self.py3.sanitize_title(self.sanitize_words, beef_data["title"])
 
             if beef_data["isplaying"]:
                 color = self.color_playing

--- a/py3status/modules/mpris.py
+++ b/py3status/modules/mpris.py
@@ -29,13 +29,18 @@ Configuration parameters:
         Keep in mind that the state has a higher priority than
         player_priority. So when player_priority is "[mpd, bomi]" and mpd is
         paused and bomi is playing than bomi wins. (default [])
+    sanitize_titles: whether to remove meta data from album/track title
+        (default True)
+    sanitize_words: which meta data to remove
+        *(default ['bonus', 'demo', 'edit', 'explicit', 'extended',
+            'feat', 'mono', 'remaster', 'stereo', 'version'])*
     state_pause: specify icon for pause state (default u'\u25eb')
     state_play: specify icon for play state (default u'\u25b7')
     state_stop: specify icon for stop state (default u'\u25a1')
 
 Format placeholders:
     {album} album name
-    {artist} artiste name (first one)
+    {artist} artist name (first one)
     {length} time duration of the song
     {player} show name of the player
     {player_shortname} show name of the player from busname (usually command line name)
@@ -117,6 +122,7 @@ from mpris2 import Player as dPlayer
 from mpris2 import get_players_uri
 from mpris2.types import Metadata_Map
 
+from py3status.constants import DEFAULT_SANITIZE_WORDS
 
 class STATE(IntEnum):
     Playing = 0
@@ -282,6 +288,14 @@ class Player:
 
             self._metadata["nowplaying"] = metadata.get("vlc:nowplaying", None)
 
+            # Sanitize album and title
+            if self.parent.sanitize_titles:
+                if "album" in self._metadata:
+                    self._metadata["album"] = self.parent.py3.sanitize_title(self.parent.sanitize_words, self._metadata["album"])
+
+                if "title" in self._metadata:
+                    self._metadata["title"] = self.parent.py3.sanitize_title(self.parent.sanitize_words, self._metadata["title"])
+
         if not self._metadata.get("title"):
             self._metadata["title"] = "No Track"
 
@@ -382,6 +396,8 @@ class Py3status:
     max_width = None
     player_hide_non_canplay = []
     player_priority = []
+    sanitize_titles = True
+    sanitize_words = DEFAULT_SANITIZE_WORDS
     state_pause = "\u25eb"
     state_play = "\u25b7"
     state_stop = "\u25a1"


### PR DESCRIPTION
This PR adds the sanitize_words feature from the spotify module to other music modules. The common functionality has been added to the Py3 module.

I've tested all the modified modules and everything seems to be working as it should.