### PR TITLE
formatter: add {:sanitize} to return song or song [feat]

### DIFF
--- a/py3status/constants.py
+++ b/py3status/constants.py
@@ -270,3 +270,31 @@ RETIRED_MODULES = {
 MARKUP_LANGUAGES = ["pango", "none"]
 
 ON_ERROR_VALUES = ["hide", "show"]
+
+SANITIZE_TITLES = "|".join(
+    [
+        "bonus",
+        "demo",
+        "edit",
+        "explicit",
+        "extended",
+        "feat",
+        "mono",
+        "remaster",
+        "stereo",
+        "version",
+    ]
+)
+
+SANITIZE_PATTERNS = {
+    # Match brackets with their content containing any metadata word.
+    #   (Remastered 2017)
+    #   [Single]
+    #   (Bonus Track)
+    "inside_brackets": r"([\(\[][^)\]]*?({})[^)\]]*?[\)\]])".format(SANITIZE_TITLES),
+    # Match string after hyphen, comma, semicolon or slash containing any metadata word.
+    #   - Remastered 2012
+    #   / Radio Edit
+    #   ; Remastered
+    "after_delimiter": r"([\-,;/])([^\-,;/])*({}).*".format(SANITIZE_TITLES),
+}


### PR DESCRIPTION
**DO NOT MERGE.**  An alternative to @dpeukert's https://github.com/ultrabug/py3status/pull/2234.

Pro: 
* Works on all modules. Not restricted to music modules.
* Doesn't have to add anything to existing music modules.
* Remove couple of spotify configs.

Con:
* Non-config metadata patterns. I think users might not care. If they do, they can make PR that will help everybody.
* Abuse (?) Not what it was originally for. Got `:d`, `:.2f`, `:g`, `:ceil`, and now `:escape` and `:sanitize`... Lol.

Instruction:
* To use this, just use `{title:sanitize}`, `{album:sanitize}` in any modules (music or not).
* You even can use `{title:escape,sanitize}` too. My testing is limited and short, but everything seems OK.

Default behavior:
* This can be set as default behavior for music modules by adding `class Meta` or `self.py3.update_placeholder_formats` in `post_config_hook`... but if you add them on, there will no way for users to turn them off in the `format` config. This is same for other placeholders not related to this PR. Just a FYI.