### PR TITLE
Workaround conky/issues/1479

### DIFF
--- a/py3status/modules/conky.py
+++ b/py3status/modules/conky.py
@@ -392,6 +392,10 @@ class Py3status:
             self.process = Popen(self.conky_command, stdout=PIPE, stderr=STDOUT)
             while True:
                 line = self.process.stdout.readline().decode()
+                # workaround to: https://github.com/brndnmtthws/conky/issues/1479
+                BUG_STR= "conky: invalid setting of type 'table'"
+                if line.startswith(BUG_STR):
+                    continue
                 if self.process.poll() is not None or "conky:" in line:
                     raise Exception(line)
                 if self.line != line:

--- a/py3status/modules/conky.py
+++ b/py3status/modules/conky.py
@@ -392,11 +392,10 @@ class Py3status:
             self.process = Popen(self.conky_command, stdout=PIPE, stderr=STDOUT)
             while True:
                 line = self.process.stdout.readline().decode()
-                # workaround to: https://github.com/brndnmtthws/conky/issues/1479
-                BUG_STR= "conky: invalid setting of type 'table'"
-                if line.startswith(BUG_STR):
-                    continue
                 if self.process.poll() is not None or "conky:" in line:
+                    # workaround to https://github.com/brndnmtthws/conky/issues/1479
+                    if "conky: invalid setting of type 'table'" in line:
+                        continue
                     raise Exception(line)
                 if self.line != line:
                     self.line = line

--- a/py3status/modules/conky.py
+++ b/py3status/modules/conky.py
@@ -384,7 +384,7 @@ class Py3status:
 
     def _cleanup(self):
         self.process.kill()
-        Path(self.tmpfile).unlink()
+        Path(self.tmpfile.name).unlink()
         self.py3.update()
 
     def _start_loop(self):


### PR DESCRIPTION
Hi,
The conky module seems to be broken for some time now.
I took a look at it and it seems some time in 2022 conky devs introduced a change in the text output when `out_to_x=false` that is used by the conky module, as mentioned in https://github.com/brndnmtthws/conky/issues/1479.

This means that there's an unexpected line in the process output that's breaking the formatting. 
