### PR TITLE
fix volume_status for default source with pamixer

### DIFF
--- a/py3status/modules/volume_status.py
+++ b/py3status/modules/volume_status.py
@@ -171,10 +171,13 @@ class Amixer(Audio):
 
 class Pamixer(Audio):
     def setup(self, parent):
-        is_input = "--source" if self.is_input else "--sink"
-        self.cmd = ["pamixer", "--allow-boost"] + (
-            [is_input, self.device] if self.device is not None else []
-        )
+        if self.device is not None:
+            dev_target = ["--source" if self.is_input else "--sink", self.device]
+        elif self.is_input:
+            dev_target = ["--default-source"]
+        else:
+            dev_target = []
+        self.cmd = ["pamixer", "--allow-boost"] + dev_target
 
     def get_volume(self):
         try:


### PR DESCRIPTION
Hi,

#2228 and #2230 introduced a regression in `volume_status` when using it with the default source.

Example configuration chunk :

```
order += "volume_status mic"

volume_status "mic" {
      is_input = True
      cache_timeout = 1
}
```

With this configuration, instead of selecting the default source, `volume_status` selects the default sink by calling `pamixer --allow-boost --get-mute --get-volume`

This PR adds `--default-source` to the command in case no device is specified and the option `is_input` is True.