### PR TITLE
py3: add new helper: get_replacements_list

### DIFF
--- a/py3status/modules/deadbeef.py
+++ b/py3status/modules/deadbeef.py
@@ -4,6 +4,7 @@ Display songs currently playing in DeaDBeeF.
 Configuration parameters:
     cache_timeout: refresh interval for this module (default 5)
     format: display format for this module (default '[{artist} - ][{title}]')
+    replacements: specify a list/dict of string placeholders to modify (default None)
     sleep_timeout: when deadbeef is not running, this interval will be used
         to allow faster refreshes with time-related placeholders and/or
         to refresh few times per minute rather than every few seconds
@@ -58,6 +59,7 @@ class Py3status:
     # available configuration parameters
     cache_timeout = 5
     format = "[{artist} - ][{title}]"
+    replacements = None
     sleep_timeout = 20
 
     class Meta:
@@ -89,6 +91,7 @@ class Py3status:
         self.color_paused = self.py3.COLOR_PAUSED or self.py3.COLOR_DEGRADED
         self.color_playing = self.py3.COLOR_PLAYING or self.py3.COLOR_GOOD
         self.color_stopped = self.py3.COLOR_STOPPED or self.py3.COLOR_BAD
+        self.replacements_init = self.py3.get_replacements_list(self.format)
 
     def _is_running(self):
         try:
@@ -123,6 +126,10 @@ class Py3status:
                 color = self.color_playing
             else:
                 color = self.color_paused
+
+        for x in self.replacements_init:
+            if x in beef_data:
+                beef_data[x] = self.py3.replace(beef_data[x], x)
 
         return {
             "cached_until": self.py3.time_in(cached_until),

--- a/py3status/modules/spotify.py
+++ b/py3status/modules/spotify.py
@@ -15,11 +15,8 @@ Configuration parameters:
         (default 'Spotify not running')
     format_stopped: define output if spotify is not playing
         (default 'Spotify stopped')
-    sanitize_titles: whether to remove meta data from album/track title
-        (default True)
-    sanitize_words: which meta data to remove
-        *(default ['bonus', 'demo', 'edit', 'explicit', 'extended',
-            'feat', 'mono', 'remaster', 'stereo', 'version'])*
+    replacements: specify a list/dict of string placeholders to modify
+        (default None)
 
 Format placeholders:
     {album} album name
@@ -45,6 +42,12 @@ spotify {
     button_previous = 5
     format = "{title} by {artist} -> {time}"
     format_down = "no Spotify"
+
+    # sanitize
+    replacements = {
+        "album": [("\s?[\(\[\-,;/][^)\],;/]*?(bonus|demo|edit|explicit|extended|feat|mono|remaster|stereo|version)[^)\],;/]*[\)\]]?", "")],
+        "title": [("\s?[\(\[\-,;/][^)\],;/]*?(bonus|demo|edit|explicit|extended|feat|mono|remaster|stereo|version)[^)\],;/]*[\)\]]?", "")]
+    }
 }
 ```
 
@@ -60,7 +63,6 @@ stopped
 {'color': '#FF0000', 'full_text': 'Spotify stopped'}
 """
 
-import re
 from datetime import timedelta
 from time import sleep
 
@@ -82,46 +84,10 @@ class Py3status:
     format = "{artist} : {title}"
     format_down = "Spotify not running"
     format_stopped = "Spotify stopped"
-    sanitize_titles = True
-    sanitize_words = [
-        "bonus",
-        "demo",
-        "edit",
-        "explicit",
-        "extended",
-        "feat",
-        "mono",
-        "remaster",
-        "stereo",
-        "version",
-    ]
+    replacements = None
 
     def _spotify_cmd(self, action):
         return SPOTIFY_CMD.format(dbus_client=self.dbus_client, cmd=action)
-
-    def post_config_hook(self):
-        """ """
-        # Match string after hyphen, comma, semicolon or slash containing any metadata word
-        # examples:
-        # - Remastered 2012
-        # / Radio Edit
-        # ; Remastered
-        self.after_delimiter = self._compile_re(r"([\-,;/])([^\-,;/])*(META_WORDS_HERE).*")
-
-        # Match brackets with their content containing any metadata word
-        # examples:
-        # (Remastered 2017)
-        # [Single]
-        # (Bonus Track)
-        self.inside_brackets = self._compile_re(r"([\(\[][^)\]]*?(META_WORDS_HERE)[^)\]]*?[\)\]])")
-
-    def _compile_re(self, expression):
-        """
-        Compile given regular expression for current sanitize words
-        """
-        meta_words = "|".join(self.sanitize_words)
-        expression = expression.replace("META_WORDS_HERE", meta_words)
-        return re.compile(expression, re.IGNORECASE)
 
     def _get_playback_status(self):
         """
@@ -145,10 +111,6 @@ class Py3status:
                 microtime = metadata.get("mpris:length")
                 rtime = str(timedelta(seconds=microtime // 1_000_000))
                 title = metadata.get("xesam:title")
-                if self.sanitize_titles:
-                    album = self._sanitize_title(album)
-                    title = self._sanitize_title(title)
-
                 playback_status = self._get_playback_status()
                 if playback_status == "Playing":
                     color = self.py3.COLOR_PLAYING or self.py3.COLOR_GOOD
@@ -160,29 +122,24 @@ class Py3status:
                     self.py3.COLOR_PAUSED or self.py3.COLOR_DEGRADED,
                 )
 
-            return (
-                self.py3.safe_format(
-                    self.format,
-                    dict(
-                        title=title,
-                        artist=artist,
-                        album=album,
-                        time=rtime,
-                        playback=playback_status,
-                    ),
-                ),
-                color,
-            )
+            spotify_data = {
+                "title": title,
+                "artist": artist,
+                "album": album,
+                "time": rtime,
+                "playback": playback_status,
+            }
+
+            for x in self.replacements_init:
+                if x in spotify_data:
+                    spotify_data[x] = self.py3.replace(spotify_data[x], x)
+
+            return (self.py3.safe_format(self.format, spotify_data), color)
         except Exception:
             return (self.format_down, self.py3.COLOR_OFFLINE or self.py3.COLOR_BAD)
 
-    def _sanitize_title(self, title):
-        """
-        Remove redundant metadata from title and return it
-        """
-        title = re.sub(self.inside_brackets, "", title)
-        title = re.sub(self.after_delimiter, "", title)
-        return title.strip()
+    def post_config_hook(self):
+        self.replacements_init = self.py3.get_replacements_list(self.format)
 
     def spotify(self):
         """


### PR DESCRIPTION
An alternative to PRs listed below.

I copied `thresholds` code. Minimal test. Allow users to be more specific.

Get placeholders_list first so we can target existing placeholders rather than all placeholders.
I don't know if this PR is the optimal solution, just an alternative.

Code untested on this player.. I tested on `nvidia_smi`.  Sorry if you ran into issues.

This is just an idea / experiment.

Please test this.

```python
# Ought to do dict (perform on matched string placeholders)
    replacements = {
        "artist": [
            "([\(\[][^)\]]*?(bonus|demo|edit|explicit|extended|feat|mono|remaster|stereo|version)[^)\]]*?[\)\]])",
            "([\-,;/])([^\-,;/])*(bonus|demo|edit|explicit|extended|feat|mono|remaster|stereo|version).*"
        ],
    }

# Ought to do list. (perform on all string placeholders)
    replacements = [
            "([\(\[][^)\]]*?(bonus|demo|edit|explicit|extended|feat|mono|remaster|stereo|version)[^)\]]*?[\)\]])",
            "([\-,;/])([^\-,;/])*(bonus|demo|edit|explicit|extended|feat|mono|remaster|stereo|version).*"
        ]
```

Solves https://github.com/ultrabug/py3status/pull/2234#issuecomment-2017989862.

Closes https://github.com/ultrabug/py3status/pull/2234.
Closes https://github.com/ultrabug/py3status/pull/2237.
#