### PR TITLE
events: strip whitespaces from OUTPUT, OUTPUT_PART

### DIFF
--- a/py3status/events.py
+++ b/py3status/events.py
@@ -118,7 +118,7 @@ class Events(Thread):
             partial_text = partial["full_text"]
         else:
             partial_text = full_text
-        return full_text, partial_text
+        return (x.strip() for x in (full_text, partial_text))
 
     def on_click_dispatcher(self, module_name, event, command):
         """


### PR DESCRIPTION

Users can use `OUTPUT`, `OUTPUT_PART` to do something useful with them. Sometimes, `OUTPART_PART` will include either leading or trailing whitespace because it's not the only composite. This just strips both of them off anyway. 

  
Solves https://github.com/ultrabug/py3status/issues/2243#issuecomment-2032012748.