### PR TITLE
playerctl module: hide non-can-play players and use chrome and chromium as default value.

### DIFF
--- a/py3status/modules/playerctl.py
+++ b/py3status/modules/playerctl.py
@@ -24,6 +24,8 @@ Configuration parameters:
         *(default '[\?color=status [\?if=status=Playing > ][\?if=status=Paused \|\| ]'
         '[\?if=status=Stopped .. ][[{artist}][\?soft  - ][{title}|{player}]]]')*
     format_player_separator: show separator if more than one player (default ' ')
+    player_hide_non_canplay: For hiding players which doesn't close mpris interface after media closing
+        (default ['chromium', 'chrome'])
     players: list of players to track. An empty list tracks all players (default [])
     seek_delta: time (in seconds) to change the playback's position by (default 5)
     thresholds: specify color thresholds to use for different placeholders
@@ -98,6 +100,7 @@ class Py3status:
         r"[\?if=status=Stopped .. ][[{artist}][\?soft  - ][{title}|{player}]]]"
     )
     format_player_separator = " "
+    player_hide_non_canplay = ["chromium", "chrome"]
     players = []
     seek_delta = 5
     thresholds = {"status": [("Playing", "good"), ("Paused", "degraded"), ("Stopped", "bad")]}
@@ -273,6 +276,12 @@ class Py3status:
         players = []
         cached_until = self.py3.CACHE_FOREVER
         for player in tracked_players:
+            if (
+                not player.props.can_play
+                and player.props.player_name in self.player_hide_non_canplay
+            ):
+                continue
+
             player_data = self._get_player_data(player)
 
             # Check if the player should cause the module to continuously update

--- a/py3status/modules/playerctl.py
+++ b/py3status/modules/playerctl.py
@@ -24,8 +24,6 @@ Configuration parameters:
         *(default '[\?color=status [\?if=status=Playing > ][\?if=status=Paused \|\| ]'
         '[\?if=status=Stopped .. ][[{artist}][\?soft  - ][{title}|{player}]]]')*
     format_player_separator: show separator if more than one player (default ' ')
-    player_hide_non_canplay: For hiding players which doesn't close mpris interface after media closing
-        (default ['chromium', 'chrome'])
     players: list of players to track. An empty list tracks all players (default [])
     seek_delta: time (in seconds) to change the playback's position by (default 5)
     thresholds: specify color thresholds to use for different placeholders
@@ -100,7 +98,6 @@ class Py3status:
         r"[\?if=status=Stopped .. ][[{artist}][\?soft  - ][{title}|{player}]]]"
     )
     format_player_separator = " "
-    player_hide_non_canplay = ["chromium", "chrome"]
     players = []
     seek_delta = 5
     thresholds = {"status": [("Playing", "good"), ("Paused", "degraded"), ("Stopped", "bad")]}
@@ -276,10 +273,7 @@ class Py3status:
         players = []
         cached_until = self.py3.CACHE_FOREVER
         for player in tracked_players:
-            if (
-                not player.props.can_play
-                and player.props.player_name in self.player_hide_non_canplay
-            ):
+            if not player.props.can_play:
                 continue
 
             player_data = self._get_player_data(player)


### PR DESCRIPTION
Proposes improvement for issue #2255.