### PR TITLE
mpris module: improve documentation and set chrome and chromium as default player_hide_non_canplay value.

### DIFF
--- a/py3status/modules/mpris.py
+++ b/py3status/modules/mpris.py
@@ -7,14 +7,13 @@ to define the button parameters in your config.
 
 Configuration parameters:
     button_next: mouse button to play the next entry (default None)
-    button_next_player: (Experimental) mouse button to switch next player in list (Same status as top player) (default None)
-    button_prev_player: (Experimental) mouse button to switch previous player in list (Same status as top player) (default None)
+    button_next_player: mouse button to switch next player in list (Same status as top player) (default None)
+    button_prev_player: mouse button to switch previous player in list (Same status as top player) (default None)
     button_previous: mouse button to play the previous entry (default None)
     button_stop: mouse button to stop the player (default None)
     button_switch_to_top_player: mouse button to switch to top player (default None)
     button_toggle: mouse button to toggle between play and pause mode (default 1)
     cache_timeout: time (s) between Position update (default 0.5)
-    format: see placeholders below
     format: display format for this module
         (default '[{artist} - ][{title}] {previous} {toggle} {next}')
     format_none: define output if no player is running (default 'no player running')
@@ -24,7 +23,9 @@ Configuration parameters:
     icon_previous: specify icon for previous button (default u'\u25c3')
     icon_stop: specify icon for stop button (default u'\u25a1')
     max_width: maximum status length (default None)
-    player_hide_non_canplay: Experimental. Used to hide chrome/chromium players on idle state. Add 'chromium' into list and try. (default [])
+    player_hide_non_canplay: For hiding players which doesn't close mpris interface after media closing
+        (for example chromium based browsers)
+        (default [])
     player_priority: priority of the players.
         Keep in mind that the state has a higher priority than
         player_priority. So when player_priority is "[mpd, bomi]" and mpd is
@@ -61,7 +62,8 @@ Color options:
 
 Requires:
     mpris2: Python usable definiton of MPRIS2
-    dbus: Python bindings for dbus
+    dbus-python: Python bindings for dbus
+    PyGObject: Python bindings for GObject Introspection
 
 Tested players:
     bomi: powerful and easy-to-use gui multimedia player based on mpv


### PR DESCRIPTION
To improve first user UX i decided to put chrome/chromium as default players to hide on idle status. (#2255)
Removed (experimental) feature flags because they are not so experimental anymore.
Corrected requirments list.