### PR TITLE
playerctl: Add python-gobject dependency

### DIFF
--- a/py3status/modules/playerctl.py
+++ b/py3status/modules/playerctl.py
@@ -53,6 +53,7 @@ Format player placeholders:
 Requires:
     playerctl: mpris media player controller and lib for spotify, vlc, audacious,
         bmp, xmms2, and others.
+    python-gobject: Python Bindings for GLib/GObject/GIO/GTK+
 
 @author jdholtz
 


### PR DESCRIPTION
This is a dependency of the module and doesn't come with py3status by default. I used the same description as the usbguard module.