### PR TITLE
external_script: add composite placeholder

### DIFF
--- a/py3status/modules/external_script.py
+++ b/py3status/modules/external_script.py
@@ -25,6 +25,7 @@ Configuration parameters:
 Format placeholders:
     {lines} number of lines in the output
     {output} output of script given by "script_path"
+    {composite} composite output of script given by "script_path"
 
 Examples:
 ```
@@ -104,9 +105,12 @@ class Py3status:
         else:
             output = ""
 
-        response["full_text"] = self.py3.safe_format(
-            self.format, {"output": self.py3.safe_format(output), "lines": len(output_lines)}
-        )
+        script_data = {
+            "output": output,
+            "lines": len(output_lines),
+            "composite": self.py3.safe_format(output),
+        }
+        response["full_text"] = self.py3.safe_format(self.format, script_data)
         return response
 
     def on_click(self, event):


### PR DESCRIPTION
Allow users to view plain output
Allow users to view formatted output.

Solves https://github.com/ultrabug/py3status/issues/2243#issuecomment-2346141610