### PR TITLE
playerctl: gi.require_version notification fix

### DIFF
--- a/py3status/modules/playerctl.py
+++ b/py3status/modules/playerctl.py
@@ -72,9 +72,9 @@ from fnmatch import fnmatch
 from threading import Thread
 
 import gi
-from gi.repository import GLib, Playerctl
 
 gi.require_version("Playerctl", "2.0")
+from gi.repository import GLib, Playerctl  # noqa e402
 
 
 class Py3status:


### PR DESCRIPTION
playerctl throwing error to console.
`PyGIWarning: Playerctl was imported without specifying a version first. Use gi.require_version('Playerctl', '2.0') before import to ensure that the right version gets loaded.
  from gi.repository import GLib, Playerctl
`

Code is there but in wrong order because linter suggested other version.
This PR proposes fix for using lines in correct order by adding lint ignore statement.

Commit which made it broked: https://github.com/ultrabug/py3status/commit/3bc4946f6c60f066389ab72a62cc56e2d079f3ed and it was OK in original version.