### PR TITLE
fix tempfile and new output in conky module

### DIFF
--- a/py3status/modules/conky.py
+++ b/py3status/modules/conky.py
@@ -369,7 +369,9 @@ class Py3status:
         tmp = f"conky.config = {config}\nconky.text = [[{text}]]"
 
         # write tmp output to '/tmp/py3status-conky_*', make a command
-        self.tmpfile = NamedTemporaryFile(prefix="py3status_conky-", suffix=".conf", delete_on_close=False)
+        self.tmpfile = NamedTemporaryFile(
+            prefix="py3status_conky-", suffix=".conf", delete_on_close=False
+        )
         self.tmpfile.write(str.encode(tmp))
         self.tmpfile.close()
         self.conky_command = f"conky -c {self.tmpfile.name}".split()

--- a/py3status/modules/conky.py
+++ b/py3status/modules/conky.py
@@ -369,15 +369,16 @@ class Py3status:
         tmp = f"conky.config = {config}\nconky.text = [[{text}]]"
 
         # write tmp output to '/tmp/py3status-conky_*', make a command
-        self.tmpfile = NamedTemporaryFile(prefix="py3status_conky-", suffix=".conf", delete=False)
+        self.tmpfile = NamedTemporaryFile(prefix="py3status_conky-", suffix=".conf", delete_on_close=False)
         self.tmpfile.write(str.encode(tmp))
         self.tmpfile.close()
         self.conky_command = f"conky -c {self.tmpfile.name}".split()
 
         # skip invalid conky errors
-        self.invalid_conky_errors = [
+        self.ignored_conky_outputs = [
             "conky: invalid setting of type 'table'",
             "conky: FOUND:",
+            "x11 session running",
         ]
 
         # thread
@@ -399,7 +400,7 @@ class Py3status:
             while True:
                 line = self.process.stdout.readline().decode()
                 if self.process.poll() is not None or "conky:" in line:
-                    if any(x in line for x in self.invalid_conky_errors):
+                    if any(x in line for x in self.ignored_conky_outputs):
                         continue
                     raise Exception(line)
                 if self.line != line:


### PR DESCRIPTION
This patch includes:

**Fixes for 2 problems:**
- Conky has a new output that should be ignored
  In my case, with conky `1.21.7-pre-` (default version with latest Fedora) outputs `conky: 'i3' x11 session running 'i3' desktop`
- For some reason `NamedTemporaryFile` needs `delete_on_close=False` (which I thought was implied by `delete=False`, but apparantly that is not sufficient)

**A small refactor:**
- renamed `invalid_conky_errors` to  `ignored_conky_outputs` as they're actually just expected outputs that we don't care about (and not really a runtime problems requiring a warning/exit/exception)