### PR TITLE
conky: add fallback delete parameter

### DIFF
--- a/py3status/modules/conky.py
+++ b/py3status/modules/conky.py
@@ -369,9 +369,15 @@ class Py3status:
         tmp = f"conky.config = {config}\nconky.text = [[{text}]]"
 
         # write tmp output to '/tmp/py3status-conky_*', make a command
-        self.tmpfile = NamedTemporaryFile(
-            prefix="py3status_conky-", suffix=".conf", delete_on_close=False
-        )
+        try:
+            # python 3.12+
+            self.tmpfile = NamedTemporaryFile(
+                prefix="py3status_conky-", suffix=".conf", delete_on_close=False
+            )
+        except TypeError:
+            self.tmpfile = NamedTemporaryFile(
+                prefix="py3status_conky-", suffix=".conf", delete=False
+            )
         self.tmpfile.write(str.encode(tmp))
         self.tmpfile.close()
         self.conky_command = f"conky -c {self.tmpfile.name}".split()


### PR DESCRIPTION
This adds a fallback delete parameter just in case for older python versions. Untested.

Solves https://github.com/ultrabug/py3status/pull/2273#issuecomment-2556330478