### PR TITLE
stop warning py3status/tests/test_module_load.py:5

### DIFF
--- a/tests/test_module_load.py
+++ b/tests/test_module_load.py
@@ -5,8 +5,9 @@ from py3status.module import Module
 class TestModule:
     static_variable = 123
 
-    def __init__(self):
-        self.instance_variable = 321
+    @classmethod
+    def setup_class(cls):
+        cls.instance_variable = 321
 
     def post_config_hook(self):
         pass


### PR DESCRIPTION
Stop the warning by removing `__init__` in favor of something like this or pytest fixture.

```python
PytestCollectionWarning: cannot collect test class 'TestModule'
because it has a __init__ constructor (from: tests/test_module_load.py)
	class TestModule
```
EDIT: I can't verify using `self` or `cls`, but it doesn't look that important because of `assert` checking (approved) instance method, not variables.