### PR TITLE
whatismyip: add an example with more url_geo choices

### DIFF
--- a/py3status/modules/whatismyip.py
+++ b/py3status/modules/whatismyip.py
@@ -35,6 +35,17 @@ Color options:
     color_degraded: Output is unexpected (IP/country mismatch, etc.)
     color_good: Online
 
+Examples:
+```
+# ip choices
+whatismyip {
+    url_geo = "https://ifconfig.co/json"
+    # url_geo = "https://api.ip2location.io"
+    # url_geo = "https://ipinfo.io/json"
+    # url_geo = "http://ip-api.com/json"
+}
+```
+
 @author ultrabug, Cyril Levis (@cyrinux)
 
 SAMPLE OUTPUT


### PR DESCRIPTION
Adding an example with url_geo choices... This ought to satisfy all parties.

Closes https://github.com/ultrabug/py3status/issues/2259
Closes https://github.com/ultrabug/py3status/issues/2260