### PR TITLE
Fix TypeError on xsel module

### DIFF
--- a/py3status/modules/xsel.py
+++ b/py3status/modules/xsel.py
@@ -50,7 +50,8 @@ class Py3status:
 
     def post_config_hook(self):
         self.selection_cache = None
-        self.log_file = Path(self.log_file).expanduser()
+        if self.log_file:
+            self.log_file = Path(self.log_file).expanduser()
 
     def xsel(self):
         selection = self.py3.command_output(self.command).strip()


### PR DESCRIPTION
If `log_file` is `None`, then actual source will raise a `TypeError`:

``` 
TypeError: expected str, bytes or os.PathLike object, not NoneType
```