### PR TITLE
external_script module: allow scripts to specify urgent

### DIFF
--- a/py3status/modules/external_script.py
+++ b/py3status/modules/external_script.py
@@ -5,6 +5,8 @@ Display output of any executable script set by `script_path`. Only the first
 two lines of output will be used. The first line is used as the displayed
 text. If the output has two or more lines, the second line is set as the text
 color (and should hence be a valid hex color code such as #FF0000 for red).
+If the second line is `urgent`, or has `!` prefixing the hex color, then the
+"urgent" flag will be set.
 The script should not have any parameters, but it could work.
 
 Configuration parameters:
@@ -76,8 +78,14 @@ class Py3status:
             output_lines = self.output.splitlines()
             if len(output_lines) > 1:
                 output_color = output_lines[1]
-                if re.search(r"^#[0-9a-fA-F]{6}$", output_color):
-                    response["color"] = output_color
+                if output_color == "urgent":
+                    response["urgent"] = True
+                elif re.search(r"^!?#[0-9a-fA-F]{6}$", output_color):
+                    if output_color[0] == "!":
+                        response["urgent"] = True
+                        response["color"] = output_color[1:]
+                    else:
+                        response["color"] = output_color
         except self.py3.CommandError as e:
             # something went wrong show error to user
             output = e.output or e.error


### PR DESCRIPTION
I had a need for an external script to specify not just the output color, but also whether or not the output should be "urgent".