### PR TITLE
playerctl: Ensure duration and position are always integers

### DIFF
--- a/py3status/modules/playerctl.py
+++ b/py3status/modules/playerctl.py
@@ -193,7 +193,7 @@ class Py3status:
 
     @staticmethod
     def _microseconds_to_time(microseconds):
-        seconds = microseconds // 1_000_000
+        seconds = int(microseconds // 1_000_000)
         m, s = divmod(seconds, 60)
         h, m = divmod(m, 60)
         time = f"{h}:{m:02d}:{s:02d}"


### PR DESCRIPTION
Occasionally, a player could return its position/duration in the song as a float (e.g. SMPlayer), but the module expects it to be an integer (causing an error while formatting the time). This commit ensures that the position/duration will always be an integer before formatting the time, as both arguments to `divmod` will always be integers (thus, returning an integer).