### PR TITLE
Remove default title escape in playerctl module

### DIFF
--- a/py3status/modules/playerctl.py
+++ b/py3status/modules/playerctl.py
@@ -110,8 +110,6 @@ class Py3status:
         update_config = {
             "update_placeholder_format": [
                 {
-                    # Escape the title by default because many contain special characters
-                    "placeholder_formats": {"title": ":escape"},
                     "format_strings": ["format_player"],
                 }
             ]


### PR DESCRIPTION
I originall saw the need for escaping titles because I had pango set to markup in my bar config. However, removing that removes the need for escaping. If users still use pango markup in their bar config, they can add the escape themselves in the format_player. This is a **breaking change** for users who use the pango markup for this module without having the escape in their format.

This specifically was found annoying when the escape translated an ampersand (`&`) to `&amp;`, which then showed up in the title. I also had a `max_length` in the format_player. When the max length cut off right in the middle of the escaped sequence, the bar would not show any output.