### PR TITLE
Implemented onecall 401 failure fallback

### DIFF
--- a/py3status/modules/weather_owm.py
+++ b/py3status/modules/weather_owm.py
@@ -262,6 +262,7 @@ diff
 
 import datetime
 import json
+
 from py3status.py3 import ModuleErrorException
 
 # API information


### PR DESCRIPTION
If a user has an OWM api token but no associated subscription with it, the onecall API will fail with a 401 error and no weather will be shown.

This commit will ignore the onecall api failure and will show just the current weather with the city name