### PR TITLE
conky: update ignored_conky_outputs

### DIFF
--- a/py3status/modules/conky.py
+++ b/py3status/modules/conky.py
@@ -386,7 +386,7 @@ class Py3status:
         self.ignored_conky_outputs = [
             "conky: invalid setting of type 'table'",
             "conky: FOUND:",
-            "x11 session running",
+            "session running",
         ]
 
         # thread


### PR DESCRIPTION
Ignore `x11 session running`... and `wayland session running`.

Closes https://github.com/ultrabug/py3status/issues/2297.