### PR TITLE
module battery_level: apply color_good on good discharge

### DIFF
--- a/py3status/modules/battery_level.py
+++ b/py3status/modules/battery_level.py
@@ -524,6 +524,7 @@ class Py3status:
             self.response["color"] = self.py3.COLOR_GOOD
             battery_status = "full"
         else:
+            self.response["color"] = self.py3.COLOR_GOOD
             battery_status = "good"
 
         if notify_msg and self.notify_low_level and self.last_known_status != battery_status:


### PR DESCRIPTION
No color is currently set when battery is discharging and good threshold is met. This patch fixes it, applying `color_good` in this case.