### PR TITLE
Adding New Cycles feature in pomodoro.py file

### DIFF
--- a/py3status/modules/pomodoro.py
+++ b/py3status/modules/pomodoro.py
@@ -20,6 +20,7 @@ Configuration parameters:
         (default 'Pomodoro ({format})')
     num_progress_bars: number of progress bars (default 5)
     pomodoros: specify a number of pomodoros (intervals) (default 4)
+    cycles: number of full pomodoro cycles before stopping (default None = infinite)-----1
     sound_break_end: break end sound (file path) (default None)
     sound_pomodoro_end: pomodoro end sound (file path) (default None)
     sound_pomodoro_start: pomodoro start sound (file path) (default None)
@@ -30,6 +31,7 @@ Configuration parameters:
 Format placeholders:
     {bar} display time in bars
     {breakno} current break number
+    {CycleNumber} = current cycle in progress (1-based)
     {ss} display time in total seconds (1500)
     {mm} display time in total minutes (25)
     {mmss} display time in (hh-)mm-ss (25:00)
@@ -74,13 +76,15 @@ class Py3status:
     format_separator = ":"
     format_stopped = "Pomodoro ({format})"
     num_progress_bars = 5
-    pomodoros = 4
+    pomodoros = 2
+    cycles = None  # NEW: optional cycle limit------------2
     sound_break_end = None
     sound_pomodoro_end = None
     sound_pomodoro_start = None
     timer_break = 5 * 60
     timer_long_break = 15 * 60
     timer_pomodoro = 25 * 60
+   
 
     class Meta:
         deprecated = {
@@ -105,6 +109,10 @@ class Py3status:
         self._timer = None
         self._end_time = None
         self._alert = False
+        # NEW: cycle tracking (additive, does not affect defaults)------------3
+        self._cycle_count = 0
+        self._long_break_active = False
+        self._cycle_message = None
         if self.display_bar is True:
             self.format = "{bar}"
         self._initialized = True
@@ -126,14 +134,41 @@ class Py3status:
             self._time_left = self.timer_break
             self._section_time = self.timer_break
             self._break_number += 1
+            self._long_break_active = False  #----------4
             if self._break_number >= self.pomodoros:
                 self._time_left = self.timer_long_break
                 self._section_time = self.timer_long_break
                 self._break_number = 0
+                self._long_break_active = True#-------------5
             self._active = False
         else:
             if not user_action:
                 self.py3.play_sound(self.sound_break_end)
+             # NEW: increment cycle only after long break completion--------------6
+        
+            if self._long_break_active:
+                self._cycle_count += 1
+                self._alert = True
+
+                if self.cycles is not None and self._cycle_count == self.cycles:
+                     final_cycle = self._cycle_count  # capture before reset
+
+                    # FINAL cycle message ONLY
+                     self._cycle_message = f"All {final_cycle} cycles completed — reset"
+                    self.py3.notify_user("Pomodoro cycles completed")
+                    # reset for next batch
+                    self._cycle_count = 0
+                    self._break_number = 0
+                    self._long_break_active = False
+                    self._time_left = self.timer_pomodoro
+                    self._section_time = self.timer_pomodoro
+                    self._active = True
+                    self._running = False
+                    return
+                else:
+                    # NORMAL per-cycle message
+                    self._cycle_message = f"Cycle {self._cycle_count} completed"
+
             self._time_left = self.timer_pomodoro
             self._section_time = self.timer_pomodoro
             self._active = True
@@ -210,7 +245,7 @@ class Py3status:
         else:
             time_left = ceil(self._time_left)
 
-        vals = {"ss": int(time_left), "mm": ceil(time_left / 60)}
+        vals = {"ss": int(time_left), "mm": ceil(time_left / 60), "CycleNumber": self._cycle_count + 1}
 
         if self.py3.format_contains(self.format, "mmss"):
             hours, rest = divmod(time_left, 3600)
@@ -228,6 +263,11 @@ class Py3status:
             vals["bar"] = self._setup_bar()
 
         formatted = self.format.format(**vals)
+
+         # show cycle message once if present
+        if self._cycle_message:
+            formatted = self._cycle_message
+            self._cycle_message = None
 
         if self._running:
             if self._active:
@@ -268,3 +308,5 @@ if __name__ == "__main__":
     from py3status.module_test import module_test
 
     module_test(Py3status)
+
+

--- a/py3status/modules/pomodoro.py
+++ b/py3status/modules/pomodoro.py
@@ -163,9 +163,9 @@ class Py3status:
                     self._active = True
                     self._running = False
                     return
-                else:
-                    # NORMAL per-cycle message
-                    self._cycle_message = f"Cycle {self._cycle_count} completed"
+
+                # NORMAL per-cycle message
+                self._cycle_message = f"Cycle {self._cycle_count} completed"
 
             self._time_left = self.timer_pomodoro
             self._section_time = self.timer_pomodoro

--- a/py3status/modules/pomodoro.py
+++ b/py3status/modules/pomodoro.py
@@ -31,7 +31,7 @@ Configuration parameters:
 Format placeholders:
     {bar} display time in bars
     {breakno} current break number
-    {CycleNumber} = current cycle in progress (1-based)
+    {cycleno} = current cycle in progress (1-based)
     {ss} display time in total seconds (1500)
     {mm} display time in total minutes (25)
     {mmss} display time in (hh-)mm-ss (25:00)
@@ -84,7 +84,6 @@ class Py3status:
     timer_break = 5 * 60
     timer_long_break = 15 * 60
     timer_pomodoro = 25 * 60
-   
 
     class Meta:
         deprecated = {
@@ -134,7 +133,7 @@ class Py3status:
             self._time_left = self.timer_break
             self._section_time = self.timer_break
             self._break_number += 1
-            self._long_break_active = False  
+            self._long_break_active = False
             if self._break_number >= self.pomodoros:
                 self._time_left = self.timer_long_break
                 self._section_time = self.timer_long_break
@@ -144,17 +143,16 @@ class Py3status:
         else:
             if not user_action:
                 self.py3.play_sound(self.sound_break_end)
-             # NEW: increment cycle only after long break completion
-        
+            # NEW: increment cycle only after long break completion
+
             if self._long_break_active:
                 self._cycle_count += 1
                 self._alert = True
 
                 if self.cycles is not None and self._cycle_count == self.cycles:
-                     final_cycle = self._cycle_count  # capture before reset
-
+                    final_cycle = self._cycle_count  # capture before reset
                     # FINAL cycle message ONLY
-                     self._cycle_message = f"All {final_cycle} cycles completed — reset"
+                    self._cycle_message = f"All {final_cycle} cycles completed — reset"
                     self.py3.notify_user("Pomodoro cycles completed")
                     # reset for next batch
                     self._cycle_count = 0
@@ -245,7 +243,7 @@ class Py3status:
         else:
             time_left = ceil(self._time_left)
 
-        vals = {"ss": int(time_left), "mm": ceil(time_left / 60), "CycleNumber": self._cycle_count + 1}
+        vals = {"ss": int(time_left), "mm": ceil(time_left / 60), "cycleno": self._cycle_count + 1}
 
         if self.py3.format_contains(self.format, "mmss"):
             hours, rest = divmod(time_left, 3600)
@@ -264,9 +262,9 @@ class Py3status:
 
         formatted = self.format.format(**vals)
 
-         # show cycle message once if present
+        # show cycle message once if present
         if self._cycle_message:
-            formatted = self._cycle_message
+            formatted = f"{formatted} | {self._cycle_message}"
             self._cycle_message = None
 
         if self._running:
@@ -308,5 +306,3 @@ if __name__ == "__main__":
     from py3status.module_test import module_test
 
     module_test(Py3status)
-
-

--- a/py3status/modules/pomodoro.py
+++ b/py3status/modules/pomodoro.py
@@ -20,7 +20,7 @@ Configuration parameters:
         (default 'Pomodoro ({format})')
     num_progress_bars: number of progress bars (default 5)
     pomodoros: specify a number of pomodoros (intervals) (default 4)
-    cycles: number of full pomodoro cycles before stopping (default None = infinite)-----1
+    cycles: number of full pomodoro cycles before stopping (default None = infinite)
     sound_break_end: break end sound (file path) (default None)
     sound_pomodoro_end: pomodoro end sound (file path) (default None)
     sound_pomodoro_start: pomodoro start sound (file path) (default None)
@@ -76,8 +76,8 @@ class Py3status:
     format_separator = ":"
     format_stopped = "Pomodoro ({format})"
     num_progress_bars = 5
-    pomodoros = 2
-    cycles = None  # NEW: optional cycle limit------------2
+    pomodoros = 4
+    cycles = None  # NEW: optional cycle limit
     sound_break_end = None
     sound_pomodoro_end = None
     sound_pomodoro_start = None
@@ -109,7 +109,7 @@ class Py3status:
         self._timer = None
         self._end_time = None
         self._alert = False
-        # NEW: cycle tracking (additive, does not affect defaults)------------3
+        # NEW: cycle tracking (additive, does not affect defaults)
         self._cycle_count = 0
         self._long_break_active = False
         self._cycle_message = None
@@ -134,17 +134,17 @@ class Py3status:
             self._time_left = self.timer_break
             self._section_time = self.timer_break
             self._break_number += 1
-            self._long_break_active = False  #----------4
+            self._long_break_active = False  
             if self._break_number >= self.pomodoros:
                 self._time_left = self.timer_long_break
                 self._section_time = self.timer_long_break
                 self._break_number = 0
-                self._long_break_active = True#-------------5
+                self._long_break_active = True
             self._active = False
         else:
             if not user_action:
                 self.py3.play_sound(self.sound_break_end)
-             # NEW: increment cycle only after long break completion--------------6
+             # NEW: increment cycle only after long break completion
         
             if self._long_break_active:
                 self._cycle_count += 1

--- a/py3status/modules/pomodoro.py
+++ b/py3status/modules/pomodoro.py
@@ -6,6 +6,7 @@ Button 2 switch Pomodoro/Break.
 Button 3 resets timer.
 
 Configuration parameters:
+    cycles: number of full pomodoro cycles before stopping (default None)
     display_bar: display time in bars when True, otherwise in seconds
         (default False)
     format: define custom time format. See placeholders below (default '{ss}')
@@ -20,7 +21,6 @@ Configuration parameters:
         (default 'Pomodoro ({format})')
     num_progress_bars: number of progress bars (default 5)
     pomodoros: specify a number of pomodoros (intervals) (default 4)
-    cycles: number of full pomodoro cycles before stopping (default None = infinite)
     sound_break_end: break end sound (file path) (default None)
     sound_pomodoro_end: pomodoro end sound (file path) (default None)
     sound_pomodoro_start: pomodoro start sound (file path) (default None)
@@ -68,6 +68,7 @@ class Py3status:
     """ """
 
     # available configuration parameters
+    cycles = None
     display_bar = False
     format = "{ss}"
     format_active = "Pomodoro [{format}]"
@@ -77,7 +78,6 @@ class Py3status:
     format_stopped = "Pomodoro ({format})"
     num_progress_bars = 5
     pomodoros = 4
-    cycles = None  # NEW: optional cycle limit
     sound_break_end = None
     sound_pomodoro_end = None
     sound_pomodoro_start = None


### PR DESCRIPTION
### Summary
This PR adds an **optional `cycles` configuration** to the `pomodoro` module, allowing users to group multiple pomodoro sessions into higher-level cycles.

Existing users who do not configure `cycles` see **no change** and **module behaves exactly as before.**
This PR introduces an optional `cycles` parameter to support that use case without altering existing behavior.

Testing and resutls snapshot-: Attached as a pdf document.
---

**About the changes done-:** 
### What’s included
- New optional `cycles` parameter (`None` by default)
- Cycle counting triggered **only after a long break completes**
- Automatic reset after the final cycle completes
- Optional cycle number placeholder (`{CycleNumber}`) for display formats
- User notification when all configured cycles are completed
- No changes to defaults or existing configuration
---
### Behavior overview
- A **cycle** is defined as one full pomodoro block ending with a long break
- After each long break:
  - the cycle counter increments
- When the configured cycle count is reached:
  - the state resets cleanly
  - the next pomodoro starts fresh (waiting for user interaction)
- Existing users who do not configure `cycles` see **no change**
---

### Note-:
Any feedback and suggestions are welcomed.


[config_n_testing_resutls_pomodoro_cycles.pdf](https://github.com/user-attachments/files/24460013/config_n_testing_resutls_pomodoro_cycles.pdf)

