### PR TITLE
core: improve performance by calculating f-string only when it is used

### DIFF
--- a/py3status/command.py
+++ b/py3status/command.py
@@ -156,7 +156,8 @@ class CommandRunner:
                     if requested_name == name.split(" ")[0]:
                         found_modules.add(module_name)
 
-        self.py3_wrapper.log(f"found {found_modules}", level="debug")
+        if self.py3_wrapper.log_enabled("debug"):
+            self.py3_wrapper.log(f"found {found_modules}", level="debug")
         return found_modules
 
     def refresh(self, data):
@@ -166,9 +167,11 @@ class CommandRunner:
         modules = data.get("module")
         # for i3status modules we have to refresh the whole i3status output.
         update_i3status = False
+        debug = self.py3_wrapper.log_enabled("debug")
         for module_name in self.find_modules(modules):
             module = self.py3_wrapper.output_modules[module_name]
-            self.py3_wrapper.log(f"refresh {module}", level="debug")
+            if debug:
+                self.py3_wrapper.log(f"refresh {module}", level="debug")
             if module["type"] == "py3status":
                 module["module"].force_update()
             else:
@@ -194,7 +197,8 @@ class CommandRunner:
             for name, message in CLICK_OPTIONS:
                 event[name] = data.get(name)
 
-            self.py3_wrapper.log(event, level="debug")
+            if self.py3_wrapper.log_enabled("debug"):
+                self.py3_wrapper.log(event, level="debug")
             # trigger the event
             self.py3_wrapper.events_thread.dispatch_event(event)
 
@@ -203,7 +207,8 @@ class CommandRunner:
         check the given command and send to the correct dispatcher
         """
         command = data.get("command")
-        self.py3_wrapper.log(f"Running remote command {command}", level="debug")
+        if self.py3_wrapper.log_enabled("debug"):
+            self.py3_wrapper.log(f"Running remote command {command}", level="debug")
         if command == "refresh":
             self.refresh(data)
         elif command == "refresh_all":
@@ -238,7 +243,8 @@ class CommandServer(threading.Thread):
         sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
         sock.bind(server_address.as_posix())
 
-        self.py3_wrapper.log(f"Unix domain socket at {server_address}", level="debug")
+        if self.py3_wrapper.log_enabled("debug"):
+            self.py3_wrapper.log(f"Unix domain socket at {server_address}", level="debug")
 
         # Listen for incoming connections
         sock.listen(1)
@@ -263,16 +269,20 @@ class CommandServer(threading.Thread):
             try:
                 data = None
                 # Wait for a connection
-                self.py3_wrapper.log("waiting for a connection", level="debug")
+                debug = self.py3_wrapper.log_enabled("debug")
+                if debug:
+                    self.py3_wrapper.log("waiting for a connection", level="debug")
 
                 connection, client_address = self.sock.accept()
                 try:
-                    self.py3_wrapper.log("connection from", level="debug")
+                    if debug:
+                        self.py3_wrapper.log("connection from", level="debug")
 
                     data = connection.recv(MAX_SIZE)
                     if data:
                         data = json.loads(data.decode("utf-8"))
-                        self.py3_wrapper.log(f"received {data}", level="debug")
+                        if debug:
+                            self.py3_wrapper.log(f"received {data}", level="debug")
                         self.command_runner.run_command(data)
                 finally:
                     # Clean up the connection

--- a/py3status/core.py
+++ b/py3status/core.py
@@ -865,6 +865,7 @@ class Py3statusWrapper:
                 # rate limiting
                 return
         update_i3status = False
+        debug = self.log_enabled("debug")
         for name, module in self.output_modules.items():
             if (
                 module_string is None
@@ -872,10 +873,12 @@ class Py3statusWrapper:
                 or (not exact and name.startswith(module_string))
             ):
                 if module["type"] == "py3status":
-                    self.log(f"refresh py3status module {name}", level="debug")
+                    if debug:
+                        self.log(f"refresh py3status module {name}", level="debug")
                     module["module"].force_update()
                 else:
-                    self.log(f"refresh i3status module {name}", level="debug")
+                    if debug:
+                        self.log(f"refresh i3status module {name}", level="debug")
                     update_i3status = True
         if update_i3status:
             self.i3status_thread.refresh_i3status()
@@ -950,6 +953,15 @@ class Py3statusWrapper:
         """
         log this information to syslog or user provided logfile.
         """
+        if not isinstance(level, int):
+            # logging.getLevelNamesMapping() is python 3.11+
+            # use local mapping instead to support python 3.9+
+            level = LOGGING_LOG_LEVELS.get(level.upper(), logging.DEBUG)
+
+        logger = logging.getLogger(name)
+        if not logger.isEnabledFor(level):
+            return
+
         # nice formatting of data structures using pretty print
         if isinstance(msg, (dict, list, set, tuple)):
             msg = pformat(msg)
@@ -958,13 +970,13 @@ class Py3statusWrapper:
             if "\n" in msg:
                 msg = "\n" + msg
 
-        if not isinstance(level, int):
-            # logging.getLevelNamesMapping() is python 3.11+
-            # use local mapping instead to support python 3.9+
-            level = LOGGING_LOG_LEVELS.get(level.upper(), logging.DEBUG)
-
-        logger = logging.getLogger(name)
         logger.log(level, msg)
+
+    def log_enabled(self, level, name=None):
+        """Return True if the given level would be logged for logger `name`."""
+        if not isinstance(level, int):
+            level = LOGGING_LOG_LEVELS.get(level.upper(), logging.DEBUG)
+        return logging.getLogger(name).isEnabledFor(level)
 
     def create_output_modules(self):
         """

--- a/py3status/py3.py
+++ b/py3status/py3.py
@@ -457,6 +457,11 @@ class Py3:
         Constants LOG_ERROR, LOG_INFO, and LOG_WARNING are also supported.
         Specifying `name` uses a logger with a given name or module_name if None.
         """
+        module_name = self._module.module_full_name
+        logger_name = name or module_name
+        if not self._py3_wrapper.log_enabled(level, logger_name):
+            return
+
         # nicely format logs if we can using pretty print
         if isinstance(message, (dict, list, set, tuple)):
             message = pformat(message)
@@ -466,9 +471,8 @@ class Py3:
                 message = "\n" + message
         except:  # noqa e722
             pass
-        module_name = self._module.module_full_name
         message = f"Module `{module_name}`: {message}"
-        self._py3_wrapper.log(message, level, name or module_name)
+        self._py3_wrapper.log(message, level, logger_name)
 
     def update(self, module_name=None):
         """


### PR DESCRIPTION
Additional suggestion is to fail fast when calling disallowed logging level

I encountered high memory usage for long period of time (some days of usage).
<img width="1915" height="286" alt="Image" src="https://github.com/user-attachments/assets/e00ea43c-acee-4645-b423-923b9476167f" />

Normal memory usage:
<img width="1672" height="332" alt="image" src="https://github.com/user-attachments/assets/06d60b4e-26fe-4e63-a75d-847ed781470b" />

I let claude code analyse standardized logging commit and found out some problems.
Main issue was related to f-strings which were calculated on every update and most likely never used (like debug level messages).

Claude code conclusion:
> The f-string is now evaluated on every update cycle — and inside log(), pformat() 
is unconditionally called on dicts/lists before any level check. In hot paths 
(every module update, every click event, every command-server connection), 
this creates continuous allocation pressure on the GC. Over long-running sessions 
this shows up as RSS growth that doesn't come back down (Python doesn't release arena
memory back to the OS easily — this is the "leak" you likely see on ps/htop).