### PR TITLE
sysdata: compile ZFS_SIZE_REGEX regex only once per module load

### DIFF
--- a/py3status/modules/sysdata.py
+++ b/py3status/modules/sysdata.py
@@ -111,6 +111,7 @@ from pathlib import Path
 
 INVALID_CPU_TEMP_UNIT = "invalid cpu_temp_unit"
 STRING_NOT_INSTALLED = "not installed"
+ZFS_SIZE_REGEX = re.compile(r"^size\s+\d+\s+(\d+)")
 
 
 class Py3status:
@@ -410,7 +411,6 @@ class Py3status:
 
     def _get_zfs_arc_size(self):
         """will raise OSError on failures"""
-        ZFS_SIZE_REGEX = re.compile(r"^size\s+\d+\s+(\d+)")
         try:
             with Path("/proc/spl/kstat/zfs/arcstats").open() as f:
                 for line in f.readlines():


### PR DESCRIPTION
During analysis of memory issue (#2328) I asked claude code to analyze module.
It pointed out that this regex is built in every cycle (or even twice when swap and memory monitor is enabled).