### PR TITLE
Fix: sysdata picks last matching temp sensor instead of the preferred

### DIFF
--- a/py3status/modules/sysdata.py
+++ b/py3status/modules/sysdata.py
@@ -305,6 +305,9 @@ class Py3status:
                                     "sensor": sensor,
                                 }
                                 break
+                        else:
+                            continue
+                        break
                     break
             else:
                 self.init["cpu_temp"] = []


### PR DESCRIPTION
In _init_cpu_temp, the chip-sensor lookup iterates `sensors` in priority order (e.g. ["Tdie", "Tctl"] for k10temp), but the inner `break` only exits the innermost `for temp_sensor` loop. The outer `for sensor` keeps iterating and `self.lm_sensors` gets overwritten by every subsequent match, so the *last* listed sensor wins instead of the first.

On Ryzen systems where k10temp exposes both Tdie and Tctl, this means Tctl (an offset control value, typically ~27 °C above the real die temp) is reported as the CPU temperature instead of Tdie.