### PR TITLE
log: decouple py3status logging

### DIFF
--- a/py3status/command.py
+++ b/py3status/command.py
@@ -1,9 +1,12 @@
 import argparse
 import json
+import logging
 import os
 import socket
 import threading
 from pathlib import Path
+
+logger = logging.getLogger(__name__)
 
 SERVER_ADDRESS = "/tmp/py3status_uds"
 MAX_SIZE = 1024
@@ -156,7 +159,7 @@ class CommandRunner:
                     if requested_name == name.split(" ")[0]:
                         found_modules.add(module_name)
 
-        self.py3_wrapper.log(f"found {found_modules}", level="debug")
+        logger.debug("matched modules: %s", sorted(found_modules))
         return found_modules
 
     def refresh(self, data):
@@ -168,7 +171,7 @@ class CommandRunner:
         update_i3status = False
         for module_name in self.find_modules(modules):
             module = self.py3_wrapper.output_modules[module_name]
-            self.py3_wrapper.log(f"refresh {module}", level="debug")
+            logger.debug("refreshing module '%s'", module_name)
             if module["type"] == "py3status":
                 module["module"].force_update()
             else:
@@ -194,7 +197,7 @@ class CommandRunner:
             for name, message in CLICK_OPTIONS:
                 event[name] = data.get(name)
 
-            self.py3_wrapper.log(event, level="debug")
+            logger.debug("dispatching click event %s", event)
             # trigger the event
             self.py3_wrapper.events_thread.dispatch_event(event)
 
@@ -203,7 +206,7 @@ class CommandRunner:
         check the given command and send to the correct dispatcher
         """
         command = data.get("command")
-        self.py3_wrapper.log(f"Running remote command {command}", level="debug")
+        logger.debug("running command '%s'", command)
         if command == "refresh":
             self.refresh(data)
         elif command == "refresh_all":
@@ -237,8 +240,7 @@ class CommandServer(threading.Thread):
         # Create a UDS socket
         sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
         sock.bind(server_address.as_posix())
-
-        self.py3_wrapper.log(f"Unix domain socket at {server_address}", level="debug")
+        logger.debug("socket listening on %s", server_address)
 
         # Listen for incoming connections
         sock.listen(1)
@@ -262,25 +264,20 @@ class CommandServer(threading.Thread):
         while True:
             try:
                 data = None
-                # Wait for a connection
-                self.py3_wrapper.log("waiting for a connection", level="debug")
-
-                connection, client_address = self.sock.accept()
+                connection, _client_address = self.sock.accept()
+                logger.debug("connection accepted")
                 try:
-                    self.py3_wrapper.log("connection from", level="debug")
-
                     data = connection.recv(MAX_SIZE)
                     if data:
                         data = json.loads(data.decode("utf-8"))
-                        self.py3_wrapper.log(f"received {data}", level="debug")
+                        logger.debug("received payload %s", data)
                         self.command_runner.run_command(data)
                 finally:
                     # Clean up the connection
                     connection.close()
             except Exception:
                 if data:
-                    self.py3_wrapper.log("Command error")
-                    self.py3_wrapper.log(data)
+                    logger.error("payload: %s", data)
                 self.py3_wrapper.report_exception("command failed")
 
 

--- a/py3status/constants.py
+++ b/py3status/constants.py
@@ -13,24 +13,34 @@ GENERAL_DEFAULTS = {
 LOGGING_CONFIG = {
     "version": 1,
     "disable_existing_loggers": False,
+    "filters": {"shortname": {"()": "py3status.log.ShortnameFilter"}},
     "handlers": {
         "syslog": {
-            "formatter": "default",
+            "formatter": "syslog",
+            "filters": ["shortname"],
             "class": "logging.handlers.SysLogHandler",
             "address": "/dev/log",
         },
     },
     "formatters": {
-        "default": {
-            "format": "%(asctime)s %(levelname)s %(message)s",
+        "syslog": {
+            "format": "[%(shortname)s] %(message)s",
+        },
+        "logfile": {
+            "format": "%(asctime)s %(levelname)s [%(shortname)s] %(message)s",
             "datefmt": "%Y-%m-%d %H:%M:%S",
-        }
+        },
     },
     "root": {"handlers": ["syslog"], "level": "INFO"},
 }
 
 LOGGING_LOG_FILE_CONFIG = {
-    "__log_file": {"formatter": "default", "class": "logging.FileHandler", "filename": None}
+    "__log_file": {
+        "formatter": "logfile",
+        "filters": ["shortname"],
+        "class": "logging.FileHandler",
+        "filename": None,
+    }
 }
 
 LOGGING_LOG_LEVELS = {

--- a/py3status/core.py
+++ b/py3status/core.py
@@ -6,18 +6,18 @@ import sys
 import time
 from collections import deque
 from pathlib import Path
-from pprint import pformat
 from signal import SIGCONT, SIGTERM, SIGTSTP, SIGUSR1, Signals, signal
 from subprocess import Popen
 from threading import Event, Thread
 from traceback import extract_tb, format_stack, format_tb
 
 from py3status.command import CommandServer
-from py3status.constants import LOGGING_CONFIG, LOGGING_LOG_FILE_CONFIG, LOGGING_LOG_LEVELS
+from py3status.constants import LOGGING_CONFIG, LOGGING_LOG_FILE_CONFIG
 from py3status.events import Events
 from py3status.formatter import expand_color
 from py3status.helpers import print_stderr
 from py3status.i3status import I3status
+from py3status.log import module_logger_name, resolve_log_level
 from py3status.module import Module
 from py3status.output import OutputFormat
 from py3status.parse_config import process_config
@@ -39,6 +39,7 @@ CONFIG_SPECIAL_SECTIONS = [
 
 ENTRY_POINT_NAME = "py3status"
 ENTRY_POINT_KEY = "entry_point"
+logger = logging.getLogger(__name__)
 
 
 class Runner(Thread):
@@ -105,7 +106,7 @@ class CheckI3StatusThread(Task):
         if not self.i3status_thread.is_alive():
             err = self.i3status_thread.error
             if not err:
-                err = "I3status died horribly."
+                err = "i3status died horribly"
             self.notify_user(err)
         else:
             # check again in 5 seconds
@@ -165,7 +166,7 @@ class Common:
             param = expand_color(param.lower(), self.none_setting)
         return param
 
-    def report_exception(self, msg, notify_user=True, level="error", error_frame=None):
+    def report_exception(self, msg, notify_user=True, level="error", error_frame=None, name=None):
         """
         Report details of an exception to the user.
         This should only be called within an except: block Details of the
@@ -217,15 +218,16 @@ class Common:
                     if found:
                         break
             # all done!  create our message.
-            msg = "{} ({}) {} line {}.".format(msg, exc_type.__name__, filename, line_no)
+            msg = "{} ({}) {} line {}".format(msg, exc_type.__name__, filename, line_no)
         except:  # noqa e722
-            # something went wrong report what we can.
-            msg = f"{msg}."
+            # something went wrong, report msg as-is.
+            pass
         finally:
             # delete tb!
             del tb
         # log the exception and notify user
-        self.py3_wrapper.log(msg, "warning")
+        tmp_logger = logging.getLogger(name) if name else logger
+        tmp_logger.log(resolve_log_level(level), msg)
         if traceback:
             # if debug is not in the config  then we are at an early stage of
             # running py3status and logging is not yet available so output the
@@ -233,7 +235,7 @@ class Common:
             if "debug" not in self.config:
                 print_stderr("\n".join(traceback))
             elif self.config.get("log_file"):
-                self.py3_wrapper.log("".join(["Traceback\n"] + traceback))
+                tmp_logger.info("traceback\n%s", "".join(traceback))
         if notify_user:
             self.py3_wrapper.notify_user(msg, level=level)
 
@@ -258,6 +260,7 @@ class Py3statusWrapper:
         self.options = options
         self.output_modules = {}
         self.py3_modules = []
+        self.loaded_entry_points = None
         self.running = True
         self.stop_signal = SIGTSTP
         self.update_queue = deque()
@@ -422,84 +425,110 @@ class Py3statusWrapper:
         if self.timeout_due is not None:
             return max(0, self.timeout_due - time.monotonic())
 
-    def get_user_modules(self):
+    def _get_default_modules(self):
+        modules_path = Path(__file__).resolve().parent / "modules"
+        return sorted(
+            p.stem for p in modules_path.iterdir() if p.suffix == ".py" and p.stem != "__init__"
+        )
+
+    def get_discoverable_modules(self):
         """Mapping from module name to relevant objects.
 
         There are two ways of discovery and storage:
         `include_paths` (no installation): include_path, f_name
         `entry_point` (from installed package): "entry_point", <Py3Status class>
 
-        Modules of the same name from entry points shadow all other modules.
+        Modules of the same name from entry-point packages shadow all other modules.
         """
-        user_modules = self._get_path_based_modules()
-        user_modules.update(self._get_entry_point_based_modules())
-        return user_modules
+        discoverable_modules = self._get_path_included_modules()
+        discoverable_modules.update(self._get_entry_point_based_modules())
+        return discoverable_modules
 
-    def _get_path_based_modules(self):
+    def _get_path_included_modules(self):
         """
         Search configured include directories for user provided modules.
 
-        user_modules: {
+        path_included_modules: {
             'weather_yahoo': ('~/i3/py3status/', 'weather_yahoo.py')
         }
         """
-        user_modules = {}
+        path_included_modules = {}
         for include_path in self.config["include_paths"]:
-            for f_name in sorted(include_path.iterdir()):
+            for f_name in include_path.iterdir():
                 if f_name.suffix != ".py":
                     continue
                 module_name = f_name.stem
                 # do not overwrite modules if already found
-                if module_name in user_modules:
+                if module_name in path_included_modules:
                     pass
-                user_modules[module_name] = (include_path, f_name)
-                self.log(f"available module from {include_path}: {module_name}")
-        return user_modules
+                path_included_modules[module_name] = (include_path, f_name)
+        return dict(sorted(path_included_modules.items()))
 
-    def _get_entry_point_based_modules(self):
-        classes_from_entry_points = {}
+    def _get_loaded_entry_points(self):
+        if self.loaded_entry_points is not None:
+            return self.loaded_entry_points
+
+        loaded_entry_points = []
         eps = importlib.metadata.entry_points(group=ENTRY_POINT_NAME)
 
         for entry_point in eps:
             try:
                 module = entry_point.load()
             except Exception as err:
-                self.log(f"entry_point '{entry_point}' error: {err}")
+                logger.error(
+                    "entry-point module '%s' (%s) %s",
+                    entry_point.name,
+                    entry_point.value,
+                    err,
+                )
                 continue
             klass = getattr(module, Module.EXPECTED_CLASS, None)
             if klass:
-                module_name = entry_point.name.split(".")[-1]
-                classes_from_entry_points[module_name] = (ENTRY_POINT_KEY, klass)
-                self.log(f"available module from entry point {ENTRY_POINT_KEY}: {module_name}")
+                loaded_entry_points.append(
+                    (entry_point.name.split(".")[-1], entry_point.value, klass)
+                )
+        self.loaded_entry_points = loaded_entry_points
+        return self.loaded_entry_points
+
+    def _get_entry_point_based_modules(self):
+        classes_from_entry_points = {}
+        for module_name, _value, klass in self._get_loaded_entry_points():
+            classes_from_entry_points[module_name] = (ENTRY_POINT_KEY, klass)
         return classes_from_entry_points
 
-    def get_user_configured_modules(self):
+    def _get_entry_point_debug_modules(self):
+        return sorted(
+            f"{module_name} ({value})"
+            for module_name, value, _klass in self._get_loaded_entry_points()
+        )
+
+    def get_configured_discoverable_modules(self):
         """
-        Get a dict of all available and configured py3status modules
+        Get a dict of all configured discoverable py3status modules
         in the user's i3status.conf.
 
         As we already have a convenient way of loading the module, we'll
         populate the map with the Py3Status class right away
         """
-        user_modules = {}
+        discoverable_modules = {}
         if not self.py3_modules:
-            return user_modules
-        for module_name, module_info in self.get_user_modules().items():
+            return discoverable_modules
+        for module_name, module_info in self.get_discoverable_modules().items():
             for module in self.py3_modules:
                 if module_name == module.split(" ")[0]:
                     source, item = module_info
-                    user_modules[module_name] = (source, item)
-        return user_modules
+                    discoverable_modules[module_name] = (source, item)
+        return discoverable_modules
 
-    def load_modules(self, modules_list, user_modules):
+    def load_modules(self, modules_list, discoverable_modules):
         """
         Load the given modules from the list (contains instance name) with
-        respect to the user provided modules dict.
+        respect to the discoverable modules dict.
 
         modules_list: ['weather_yahoo paris', 'pewpew', 'net_rate']
-        user_modules: {
+        discoverable_modules: {
             'weather_yahoo': ('/etc/py3status.d/', 'weather_yahoo.py'),
-            'pewpew': ('entry_point', <Py3Status class>),
+            'pewpew': ('entry_point', <Py3Status class>),  # entry-point module
         }
         """
         for module in modules_list:
@@ -508,20 +537,20 @@ class Py3statusWrapper:
                 continue
             try:
                 instance = None
-                payload = user_modules.get(module.split(" ")[0])
+                payload = discoverable_modules.get(module.split(" ")[0])
                 if payload:
                     kind, Klass = payload
                     if kind == ENTRY_POINT_KEY:
                         instance = Klass()
-                my_m = Module(module, user_modules, self, instance=instance)
+                my_m = Module(module, discoverable_modules, self, instance=instance)
                 # only handle modules with available methods
                 if my_m.methods:
                     self.modules[module] = my_m
                 else:
-                    self.log(f'ignoring module "{module}" (no methods found)', level="debug")
+                    logger.debug("ignoring module '%s' (no methods found)", module)
             except Exception:
                 err = sys.exc_info()[1]
-                msg = f'Loading module "{module}" failed ({err}).'
+                msg = f'loading module "{module}" failed ({err})'
                 self.report_exception(msg, level="warning")
 
     def _setup_logging(self):
@@ -548,7 +577,11 @@ class Py3statusWrapper:
             handler_cfg = dict(handler_cfg)
             handler_cfg["filename"] = self.config["log_file"]
             init_logging_config["handlers"][handler_name] = handler_cfg
-            init_logging_config["root"]["handlers"].append(handler_name)
+            user_root_handlers = user_logging_config.get("root", {}).get("handlers")
+            if user_root_handlers is None:
+                init_logging_config["root"]["handlers"] = [handler_name]
+            elif handler_name not in init_logging_config["root"]["handlers"]:
+                init_logging_config["root"]["handlers"].append(handler_name)
 
         logging.config.dictConfig(init_logging_config)
 
@@ -564,7 +597,7 @@ class Py3statusWrapper:
         if not git_path.exists():
             return
 
-        self.log("Running within git repo")
+        logger.info("running within git repo")
 
         try:
             import git
@@ -581,24 +614,24 @@ class Py3statusWrapper:
                 with (git_path / "HEAD").open() as f:
                     out = f.readline()
             except OSError:
-                self.log(
-                    "Unable to read git HEAD. " "Use python git package for more repo information"
+                logger.warning(
+                    "unable to read git HEAD, use python git package for more repo information"
                 )
                 return
             branch = "/".join(out.strip().split("/")[2:])
-            self.log(f"git branch: {branch}")
+            logger.info("git branch: %s", branch)
             # last commit
             log_path = git_path / "logs" / "refs" / "heads" / branch
             with log_path.open() as f:
                 out = f.readlines()[-1]
             sha = out.split(" ")[1][:7]
             msg = ":".join(out.strip().split("\t")[-1].split(":")[1:])
-            self.log(f"git commit: {sha}{msg}")
+            logger.info("git commit: %s%s", sha, msg)
         else:
             commit = repo.head.commit
-            self.log(f"git branch: {repo.active_branch.name}")
-            self.log(f"git commit: {commit.hexsha[:7]} {commit.summary}")
-            self.log(f"git clean: {not repo.is_dirty()!s}")
+            logger.info("git branch: %s", repo.active_branch.name)
+            logger.info("git commit: %s %s", commit.hexsha[:7], commit.summary)
+            logger.info("git clean: %s", not repo.is_dirty())
 
     def setup(self):
         """
@@ -613,19 +646,17 @@ class Py3statusWrapper:
         self._setup_logging()
 
         # log py3status and python versions
-        self.log("=" * 8)
-        msg = "Starting py3status version {version} python {python_version}"
-        self.log(msg.format(**self.config))
+        logger.info("=" * 8)
+        msg = "starting py3status version {version} python {python_version}"
+        logger.info(msg.format(**self.config))
 
         # if running from git then log the branch and last commit
         self._log_gitversion()
 
-        # log window manager
-        self.log("window manager: {}".format(self.config["wm_name"]))
-
-        # log config
-        self.log(f"py3status started with config {self.config}", level="debug")
-        self.log(f"config file: {self.config['i3status_config_path']}")
+        # log config file and window manager
+        logger.info("config file: %s", self.config["i3status_config_path"])
+        logger.info("window manager: %s", self.config["wm_name"])
+        logger.debug("py3status started with config %s", self.config)
 
         # autodetect output_format
         output_format = self.config["py3_config"]["general"]["output_format"]
@@ -657,7 +688,7 @@ class Py3statusWrapper:
             i3s_mode = "mocked"
         else:
             for module in i3s_modules:
-                self.log(f"adding module {module}")
+                logger.info("adding i3status module '%s'", module)
             i3s_mode = "started"
             self.i3status_thread.start()
             while not self.i3status_thread.ready:
@@ -671,7 +702,7 @@ class Py3statusWrapper:
                     break
                 time.sleep(0.1)
 
-        self.log(f"i3status thread {i3s_mode} with config {py3_config}", level="debug")
+        logger.debug("i3status thread %s with config %s", i3s_mode, py3_config)
 
         # add i3status thread monitoring task
         if i3s_mode == "started":
@@ -682,13 +713,13 @@ class Py3statusWrapper:
         self.events_thread = Events(self)
         self.events_thread.daemon = True
         self.events_thread.start()
-        self.log("events thread started", level="debug")
+        logger.debug("events thread started")
 
         # initialise the command server
         self.commands_thread = CommandServer(self)
         self.commands_thread.daemon = True
         self.commands_thread.start()
-        self.log("commands thread started", level="debug")
+        logger.debug("commands thread started")
 
         # initialize the udev monitor (lazy)
         self.udev_monitor = UdevMonitor(self)
@@ -714,7 +745,7 @@ class Py3statusWrapper:
                     f"py3status.stop_signal '{custom_stop_signal}' is invalid "
                     f"and should be a number between 0 (disable) and 31"
                 )
-                self.log(error, level="error")
+                logger.error(error)
                 raise Exception(error)
 
         # SIGTSTP can be received and indicates that all output should
@@ -728,14 +759,17 @@ class Py3statusWrapper:
         # get the list of py3status configured modules
         self.py3_modules = self.config["py3_config"]["py3_modules"]
 
-        # get a dict of all user provided modules
-        self.log("modules include paths: {}".format(self.config["include_paths"]))
-        user_modules = self.get_user_configured_modules()
-        self.log(f"user_modules={user_modules}", level="debug")
+        # print available modules
+        # logger.debug("default modules: %s", self._get_default_modules())
+        logger.info("path-included module paths: %s", list(map(str, self.config["include_paths"])))
+        logger.debug("path-included modules: %s", list(self._get_path_included_modules()))
+        logger.debug("entry-point modules: %s", self._get_entry_point_debug_modules())
 
+        # get a dict of all configured discoverable modules
+        discoverable_modules = self.get_configured_discoverable_modules()
         if self.py3_modules:
             # load and spawn i3status.conf configured modules threads
-            self.load_modules(self.py3_modules, user_modules)
+            self.load_modules(self.py3_modules, discoverable_modules)
 
         # determine the target output format
         self.output_format = OutputFormat.instance_for(
@@ -795,11 +829,12 @@ class Py3statusWrapper:
         msg_hash = hash(f"{module_name}#{limit_key}#{msg}#{title}")
         if msg_hash in self.notified_messages:
             return
-        elif module_name:
-            log_msg = 'Module `{}` sent a notification. "{}: {}"'.format(module_name, title, msg)
-            self.log(log_msg, level)
+        log_level = resolve_log_level(level)
+        if module_name:
+            notification_logger = logging.getLogger(module_logger_name(module_name))
+            notification_logger.log(log_level, "notification: '%s: %s'", title, msg)
         else:
-            self.log(msg, level)
+            logger.log(log_level, msg)
         self.notified_messages.add(msg_hash)
 
         try:
@@ -826,7 +861,7 @@ class Py3statusWrapper:
                 stderr=Path("/dev/null").open("w"),
             )
         except Exception as err:
-            self.log(f"notify_user error: {err}")
+            logger.error("notify_user: %s", err)
 
     def stop(self):
         """
@@ -841,7 +876,7 @@ class Py3statusWrapper:
 
         try:
             self.lock.set()
-            self.log("lock set, exiting", level="debug")
+            logger.debug("lock set, exiting")
             # run kill() method on all py3status modules
             for module in self.modules.values():
                 module.kill()
@@ -872,10 +907,10 @@ class Py3statusWrapper:
                 or (not exact and name.startswith(module_string))
             ):
                 if module["type"] == "py3status":
-                    self.log(f"refresh py3status module {name}", level="debug")
+                    logger.debug("refreshing py3status module '%s'", name)
                     module["module"].force_update()
                 else:
-                    self.log(f"refresh i3status module {name}", level="debug")
+                    logger.debug("refreshing i3status module '%s'", name)
                     update_i3status = True
         if update_i3status:
             self.i3status_thread.refresh_i3status()
@@ -884,14 +919,14 @@ class Py3statusWrapper:
         """
         SIGUSR1 was received, the user asks for an immediate refresh of the bar
         """
-        self.log("received USR1")
+        logger.info("received USR1")
         self.refresh_modules()
 
     def terminate(self, signum, frame):
         """
         Received request to terminate (SIGTERM), exit nicely.
         """
-        self.log("received SIGTERM")
+        logger.info("received SIGTERM")
         raise KeyboardInterrupt()
 
     def purge_module(self, module_name):
@@ -945,26 +980,6 @@ class Py3statusWrapper:
         # we need to update the output
         if self.update_queue:
             self.update_request.set()
-
-    def log(self, msg, level="info", name=None):
-        """
-        log this information to syslog or user provided logfile.
-        """
-        # nice formatting of data structures using pretty print
-        if isinstance(msg, (dict, list, set, tuple)):
-            msg = pformat(msg)
-            # if multiline then start the data output on a fresh line
-            # to aid readability.
-            if "\n" in msg:
-                msg = "\n" + msg
-
-        if not isinstance(level, int):
-            # logging.getLevelNamesMapping() is python 3.11+
-            # use local mapping instead to support python 3.9+
-            level = LOGGING_LOG_LEVELS.get(level.upper(), logging.DEBUG)
-
-        logger = logging.getLogger(name)
-        logger.log(level, msg)
 
     def create_output_modules(self):
         """
@@ -1037,24 +1052,24 @@ class Py3statusWrapper:
 
     def i3bar_stop(self, signum, frame):
         if self.next_allowed_signal == signum and time.monotonic() > self.inhibit_signal_ts:
-            self.log(f"received stop_signal {Signals(signum).name}")
+            logger.info("received stop_signal %s", Signals(signum).name)
             self.i3bar_running = False
             # i3status should be stopped
             self.i3status_thread.suspend_i3status()
             self.sleep_modules()
             self.next_allowed_signal = SIGCONT
         else:
-            self.log(f"inhibited stop_signal {Signals(signum).name}", level="warning")
+            logger.warning("inhibited stop_signal %s", Signals(signum).name)
             self.inhibit_signal_ts = time.monotonic() + 0.1
 
     def i3bar_start(self, signum, frame):
         if self.next_allowed_signal == signum and time.monotonic() > self.inhibit_signal_ts:
-            self.log(f"received resume signal {Signals(signum).name}")
+            logger.info("received resume signal %s", Signals(signum).name)
             self.i3bar_running = True
             self.wake_modules()
             self.next_allowed_signal = self.stop_signal
         else:
-            self.log(f"inhibited start_signal {Signals(signum).name}", level="warning")
+            logger.warning("inhibited start_signal %s", Signals(signum).name)
             self.inhibit_signal_ts = time.monotonic() + 0.1
 
     def sleep_modules(self):

--- a/py3status/events.py
+++ b/py3status/events.py
@@ -1,3 +1,4 @@
+import logging
 import select
 import sys
 from json import loads
@@ -6,6 +7,8 @@ from subprocess import PIPE, Popen
 from threading import Thread
 
 from py3status.profiling import profile
+
+logger = logging.getLogger(__name__)
 
 
 class IOPoller:
@@ -152,10 +155,12 @@ class Events(Thread):
         """
         wm_msg = self.config["wm"]["msg"]
         pipe = Popen([wm_msg, command], stdout=PIPE)
-        self.py3_wrapper.log(
-            '{} module="{}" command="{}" stdout={}'.format(
-                wm_msg, module_name, command, pipe.stdout.read()
-            )
+        logger.info(
+            '%s module="%s" command="%s" stdout=%s',
+            wm_msg,
+            module_name,
+            command,
+            pipe.stdout.read(),
         )
 
     def process_event(self, module_name, event, default_event=False):
@@ -171,9 +176,8 @@ class Events(Thread):
         # if module is a py3status one call it.
         if module_info["type"] == "py3status":
             module = module_info["module"]
+            logger.debug("dispatching event %s", event)
             module.click_event(event)
-            if self.config["debug"]:
-                self.py3_wrapper.log(f"dispatching event {event}")
 
             # to make the bar more responsive to users we refresh the module
             # unless the on_click event called py3.prevent_refresh()
@@ -183,8 +187,7 @@ class Events(Thread):
 
         if default_event:
             # default button 2 action is to clear this method's cache
-            if self.config["debug"]:
-                self.py3_wrapper.log(f"dispatching default event {event}")
+            logger.debug("dispatching default event %s", event)
             self.py3_wrapper.refresh_modules(module_name)
 
         # find container that holds the module and call its onclick
@@ -198,8 +201,7 @@ class Events(Thread):
         Takes an event dict.  Logs the event if needed and cleans up the dict
         such as setting the index needed for composits.
         """
-        if self.config["debug"]:
-            self.py3_wrapper.log(f"received event {event}")
+        logger.debug("received event %s", event)
 
         # usage variables
         event["index"] = event.get("index", "")
@@ -218,11 +220,6 @@ class Events(Thread):
                 pass
             event["index"] = index
             event["instance"] = instance
-
-        if self.config["debug"]:
-            self.py3_wrapper.log(
-                'trying to dispatch event to module "{}"'.format(f"{name} {instance}".strip())
-            )
 
         # guess the module config name
         module_name = f"{name} {instance}".strip()
@@ -272,8 +269,8 @@ class Events(Thread):
                     event = loads(event_str)
                     self.dispatch_event(event)
                 except Exception:
-                    self.py3_wrapper.report_exception("Event failed")
+                    self.py3_wrapper.report_exception("event failed")
         except:  # noqa e722
-            err = "Events thread died, click events are disabled."
+            err = "events thread died, click events are disabled"
             self.py3_wrapper.report_exception(err, notify_user=False)
             self.py3_wrapper.notify_user(err, level="warning")

--- a/py3status/i3status.py
+++ b/py3status/i3status.py
@@ -1,3 +1,4 @@
+import logging
 import sys
 import time
 from copy import deepcopy
@@ -18,6 +19,8 @@ from py3status.constants import (
 from py3status.events import IOPoller
 from py3status.profiling import profile
 from py3status.py3 import Py3
+
+logger = logging.getLogger(__name__)
 
 
 class I3statusModule:
@@ -344,8 +347,7 @@ class I3status(Thread):
     def refresh_i3status(self):
         # refresh i3status.  This is rate limited
         if time.monotonic() > (self.last_refresh_ts + 0.1):
-            if self.py3_wrapper.config["debug"]:
-                self.py3_wrapper.log("refreshing i3status")
+            logger.debug("refreshing i3status")
             if self.i3status_pipe:
                 self.i3status_pipe.send_signal(SIGUSR1)
             self.last_refresh_ts = time.monotonic()
@@ -380,7 +382,7 @@ class I3status(Thread):
                     preexec_fn=lambda: signal(SIGTSTP, SIG_IGN),
                 )
 
-                self.py3_wrapper.log(f"i3status spawned using config file {tmpfile.name}")
+                logger.info("started with config file: %s", tmpfile.name)
 
                 self.poller_inp = IOPoller(i3status_pipe.stdout)
                 self.poller_err = IOPoller(i3status_pipe.stderr)
@@ -406,16 +408,15 @@ class I3status(Thread):
                             err = self.poller_err.readline()
                             code = i3status_pipe.poll()
                             if code is not None:
-                                msg = "i3status died"
                                 if err:
-                                    msg += f" and said: {err}"
+                                    msg = err.split("i3status", 1)[-1].strip(" .:")
                                 else:
-                                    msg += f" with code {code}"
+                                    msg = f"exiting due to code {code}"
                                 raise OSError(msg)
                 except OSError:
                     err = sys.exc_info()[1]
                     self.error = err
-                    self.py3_wrapper.log(err, "error")
+                    logger.error(err)
         except OSError:
             self.error = "Problem starting i3status maybe it is not installed"
         except Exception:

--- a/py3status/log.py
+++ b/py3status/log.py
@@ -1,0 +1,55 @@
+import logging
+from pprint import pformat
+
+from py3status.constants import LOGGING_LOG_LEVELS
+
+PACKAGE_LOGGER_PREFIX = "py3status."
+MODULE_LOGGER_PREFIX = "py3status.modules."
+
+
+class ShortnameFilter(logging.Filter):
+    """
+    This lets logging formats use `%(shortname)s` instead
+    of `%(name)s` when shorter logger names are preferred.
+
+    Examples:
+        # shortname
+        `py3status.core` -> `core`
+        `py3status.events` -> `events`
+        `py3status.modules.sysdata` -> `modules.sysdata`
+    """
+
+    def filter(self, record):
+        if record.name.startswith(PACKAGE_LOGGER_PREFIX):
+            record.shortname = record.name[len(PACKAGE_LOGGER_PREFIX) :]
+        else:
+            record.shortname = record.name
+
+        return True
+
+
+def module_logger_name(name):
+    return f"{MODULE_LOGGER_PREFIX}{name}"
+
+
+def resolve_log_level(level):
+    if not isinstance(level, int):
+        # logging.getLevelNamesMapping() is python 3.11+
+        # use local mapping instead to support python 3.9+
+        level = LOGGING_LOG_LEVELS.get(level.upper(), logging.DEBUG)
+    return level
+
+
+def log_message(logger, message, level):
+    level = resolve_log_level(level)
+    if not logger.isEnabledFor(level):
+        return
+    # nicely format logs if we can use pretty print
+    if isinstance(message, (dict, list, set, tuple)):
+        message = pformat(message)
+    elif not isinstance(message, str):
+        message = str(message)
+    # start on new line if multi-line output
+    if "\n" in message:
+        message = "\n" + message
+    logger.log(level, message)

--- a/py3status/module.py
+++ b/py3status/module.py
@@ -1,4 +1,5 @@
 import inspect
+import logging
 import time
 from collections import OrderedDict
 from importlib.machinery import SourceFileLoader
@@ -9,6 +10,7 @@ from types import FunctionType
 from py3status.composite import Composite
 from py3status.constants import MARKUP_LANGUAGES, ON_ERROR_VALUES, POSITIONS
 from py3status.formatter import Formatter
+from py3status.log import module_logger_name
 from py3status.profiling import profile
 from py3status.py3 import ModuleErrorException, Py3
 
@@ -31,7 +33,7 @@ class Module:
     PARAMS_LEGACY = "legacy"
     EXPECTED_CLASS = "Py3status"
 
-    def __init__(self, module, user_modules, py3_wrapper, instance=None):
+    def __init__(self, module, discoverable_modules, py3_wrapper, instance=None):
         """
         We need quite some stuff to occupy ourselves don't we ?
         """
@@ -74,8 +76,12 @@ class Module:
         # should only use it on the understanding that it is not supported.
         self._py3_wrapper = py3_wrapper
 
+        # create namespaced module identity for consistent formatting/filtering
+        self.module_logger_name = module_logger_name(self.module_full_name)
+        self._logger = logging.getLogger(self.module_logger_name)
+
         try:
-            self.load_methods(module, user_modules)
+            self.load_methods(module, discoverable_modules)
         except Exception as e:
             # Import failed notify user in module error output
             self.disabled = True
@@ -87,15 +93,15 @@ class Module:
             ]
             self.error_output(self.error_messages[0])
             # log the error
-            msg = f"Module `{self.module_full_name}` could not be loaded ({e})"
             if isinstance(e, SyntaxError):
                 # provide full traceback
-                self._py3_wrapper.report_exception(msg, notify_user=False)
+                self._py3_wrapper.report_exception(
+                    "could not be loaded", notify_user=False, name=self.module_logger_name
+                )
             else:
                 # module import error we can just report the module that cannot
                 # be imported
-                self._py3_wrapper.log(msg)
-                self._py3_wrapper.log(str(e))
+                self._logger.error("could not be loaded (%s)", e)
 
         # check module/py3status config section
         if not self.disabled:
@@ -152,9 +158,10 @@ class Module:
                     f"{e}",
                 ]
                 self.runtime_error(self.error_messages[1], "post_config_hook")
-                msg = f"Exception in `{self.module_full_name}` post_config_hook() : {self.error_messages}"
-                self._py3_wrapper.report_exception(msg, notify_user=False)
-                self._py3_wrapper.log(f"terminating module {self.module_full_name}")
+                self._py3_wrapper.report_exception(
+                    "post_config_hook failed", notify_user=False, name=self.module_logger_name
+                )
+                self._logger.error("terminating module")
         self.enabled = True
 
     def runtime_error(self, msg, method):
@@ -229,7 +236,7 @@ class Module:
         self.prepare_module()
         if not (self.disabled or self.terminated):
             # Start the module and call its output method(s)
-            self._py3_wrapper.log(f"starting module {self.module_full_name}")
+            self._logger.info("starting module")
             self._py3_wrapper.timeout_queue_add(self)
 
     def force_update(self):
@@ -241,8 +248,10 @@ class Module:
         # clear cached_until for each method to allow update
         for meth, my_method in self.methods.items():
             my_method["cached_until"] = time.monotonic()
-            if self.config["debug"]:
-                self._py3_wrapper.log(f"clearing cache for method {meth}")
+            self._logger.debug(
+                "clearing cache for method '%s'",
+                meth,
+            )
         # set module to update
         self._py3_wrapper.timeout_queue_add(self)
 
@@ -255,7 +264,7 @@ class Module:
         # purge from any container modules
         self._py3_wrapper.purge_module(self.module_full_name)
         self.error_output("")
-        self._py3_wrapper.log(f"disabling module `{self.module_full_name}`")
+        self._logger.info("disabling module")
 
     def wake(self):
         self.sleeping = False
@@ -580,7 +589,7 @@ class Module:
         else:
             return self.PARAMS_LEGACY
 
-    def load_methods(self, module, user_modules):
+    def load_methods(self, module, discoverable_modules):
         """
         Read the given user-written py3status class file and store its methods.
         Those methods will be executed, so we will deliberately ignore:
@@ -591,17 +600,42 @@ class Module:
         """
         if not self.module_class:
             # user provided modules take precedence over py3status provided modules
-            if self.module_name in user_modules:
-                include_path, f_name = user_modules[self.module_name]
+            if self.module_name in discoverable_modules:
+                include_path, f_name = discoverable_modules[self.module_name]
                 module_path = Path(include_path) / f_name
-                self._py3_wrapper.log(f'loading module "{module}" from {module_path}')
+                self._logger.info(
+                    "loading module from path-included:%s",
+                    module_path,
+                )
                 self.module_class = self.load_from_file(module_path)
             # load from py3status provided modules
             else:
-                self._py3_wrapper.log(
-                    'loading module "{}" from py3status.modules.{}'.format(module, self.module_name)
+                try:
+                    self.module_class = self.load_from_namespace(self.module_name)
+                except ModuleNotFoundError as err:
+                    module_namespace = f"py3status.modules.{self.module_name}"
+                    if err.name == module_namespace:
+                        entry_point_modules = sorted(
+                            name
+                            for name, module_info in self._py3_wrapper.get_discoverable_modules().items()
+                            if module_info[0] == "entry_point"
+                        )
+                        if entry_point_modules:
+                            raise ModuleNotFoundError(
+                                f"module '{self.module_name}' not found"
+                            ) from err
+                    raise
+                self._logger.info(
+                    "loading module from py3status.modules.%s",
+                    self.module_name,
                 )
-                self.module_class = self.load_from_namespace(self.module_name)
+        elif self.module_name in discoverable_modules:
+            source, class_inst = discoverable_modules[self.module_name]
+            if source == "entry_point":
+                self._logger.info(
+                    "loading module from entry-point:%s",
+                    class_inst.__module__,
+                )
 
         class_inst = self.module_class
         if class_inst:
@@ -663,7 +697,7 @@ class Module:
                         if param:
                             msg = f"`{param}` {msg}"
                         msg = "DEPRECATION WARNING: {} {}".format(self.module_full_name, msg)
-                        self._py3_wrapper.log(msg)
+                        self._logger.info(msg)
 
                 if "rename" in deprecated:
                     # renamed parameters
@@ -864,12 +898,12 @@ class Module:
                             self.methods[method] = method_obj
 
         # done, log some debug info
-        if self.config["debug"]:
-            self._py3_wrapper.log(
-                'module "{}" click_events={} has_kill={} methods={}'.format(
-                    module, self.click_events, self.has_kill, list(self.methods)
-                )
-            )
+        self._logger.debug(
+            "click_events=%s has_kill=%s methods=%s",
+            self.click_events,
+            self.has_kill,
+            list(self.methods),
+        )
 
     def click_event(self, event):
         """
@@ -910,8 +944,10 @@ class Module:
                 # nothing has happened so no need for refresh
                 self.prevent_refresh = True
         except Exception:
-            msg = f"on_click event in `{self.module_full_name}` failed"
-            self._py3_wrapper.report_exception(msg)
+            self._py3_wrapper.report_exception(
+                "on_click event failed",
+                name=self.module_logger_name,
+            )
 
     @profile
     def run(self):
@@ -1008,8 +1044,11 @@ class Module:
                         my_method["last_output"] = result
 
                     # debug info
-                    if self.config["debug"]:
-                        self._py3_wrapper.log(f"method {meth} returned {result} ")
+                    self._logger.debug(
+                        "method '%s' returned %s",
+                        meth,
+                        result,
+                    )
                     # module working correctly so ensure module works as
                     # expected
                     self.allow_config_clicks = True
@@ -1035,10 +1074,12 @@ class Module:
                         )
 
                 except Exception as e:
-                    msg = "Instance `{}`, user method `{}` failed"
-                    msg = msg.format(self.module_full_name, meth)
                     if not self.testing:
-                        self._py3_wrapper.report_exception(msg, notify_user=False)
+                        self._py3_wrapper.report_exception(
+                            f"user method '{meth}' failed",
+                            notify_user=False,
+                            name=self.module_logger_name,
+                        )
                     # added error
                     self.runtime_error(str(e) or e.__class__.__name__, meth)
                     cache_time = time.monotonic() + getattr(

--- a/py3status/module_test.py
+++ b/py3status/module_test.py
@@ -1,9 +1,33 @@
+import logging
 import time
 from ast import literal_eval
 from sys import argv
 from threading import Event
 
 from py3status.core import Common, Module
+from py3status.log import log_message, resolve_log_level
+
+
+class ExcludeModuleFilter(logging.Filter):
+    """Suppress module.py framework logs during module_test runs."""
+
+    def __init__(self, path):
+        self.path = path
+
+    def filter(self, record):
+        return record.pathname != self.path
+
+
+def setup_logging(level="INFO"):
+    level = resolve_log_level(level)
+    logging.basicConfig(
+        level=level,
+        format="%(levelname)s [%(name)s] %(message)s",
+    )
+    module_path = __file__.replace("_test.py", ".py")
+    module_filter = ExcludeModuleFilter(module_path)
+    for handler in logging.getLogger().handlers:
+        handler.addFilter(module_filter)
 
 
 class MockPy3statusWrapper:
@@ -18,10 +42,11 @@ class MockPy3statusWrapper:
             pass
 
     def __init__(self, config):
+        self.logger = logging.getLogger(__name__)
+
         self.config = {
             "py3_config": config,
             "include_paths": [],
-            "debug": False,
             "cache_timeout": 1,
             "minimum_interval": 0.1,
             "testing": True,
@@ -54,27 +79,43 @@ class MockPy3statusWrapper:
     def clear_timeout_due(self, *arg, **kw):
         pass
 
-    def log(self, *arg, **kw):
-        print(arg[0])
+    def log(self, message, level="info"):
+        log_message(self.logger, message=message, level=level)
 
 
 def module_test(module_class, config=None):
     if not config:
         config = {}
 
-    # config cli arguments
-    arguments, term = argv[1:], False
-    for index, arg in enumerate(arguments):
-        if "--term" in arg:
+    # user cli arguments
+    log_level = "INFO"
+    term = False
+
+    arguments = argv[1:]
+    index = 0
+    while index < len(arguments):
+        arg = arguments[index]
+        if arg == "--term":
             term = True
-        elif arg[0:2] == "--":
-            key = arguments[index][2:]
+            index += 1
+            continue
+        if arg == "--log-level" and index + 1 < len(arguments):
+            log_level = arguments[index + 1]
+            index += 2
+            continue
+        if arg[0:2] == "--" and index + 1 < len(arguments):
+            key = arg[2:]
             value = arguments[index + 1]
             try:
                 value = literal_eval(value)
             except (SyntaxError, ValueError):
                 pass
             config[key] = value
+            index += 2
+            continue
+        index += 1
+
+    setup_logging(log_level)
 
     py3_config = {
         "general": {

--- a/py3status/py3.py
+++ b/py3status/py3.py
@@ -1,3 +1,4 @@
+import logging
 import os
 import re
 import shlex
@@ -8,7 +9,6 @@ from copy import deepcopy
 from fnmatch import fnmatch
 from math import log10
 from pathlib import Path
-from pprint import pformat
 from shutil import which
 from subprocess import PIPE, STDOUT, Popen
 from time import sleep
@@ -16,6 +16,7 @@ from uuid import uuid4
 
 from py3status import exceptions
 from py3status.formatter import Composite, Formatter, expand_color
+from py3status.log import log_message, module_logger_name
 from py3status.request import HttpResponse
 from py3status.storage import Storage
 from py3status.util import Gradients
@@ -102,6 +103,7 @@ class Py3:
         self._format_color_names = {}
         self._format_placeholders = {}
         self._format_placeholders_cache = {}
+        self._logger = None
         self._module = module
         self._replacements = None
         self._report_exception_cache = set()
@@ -457,18 +459,14 @@ class Py3:
         Constants LOG_ERROR, LOG_INFO, and LOG_WARNING are also supported.
         Specifying `name` uses a logger with a given name or module_name if None.
         """
-        # nicely format logs if we can using pretty print
-        if isinstance(message, (dict, list, set, tuple)):
-            message = pformat(message)
-        # start on new line if multi-line output
-        try:
-            if "\n" in message:
-                message = "\n" + message
-        except:  # noqa e722
-            pass
-        module_name = self._module.module_full_name
-        message = f"Module `{module_name}`: {message}"
-        self._py3_wrapper.log(message, level, name or module_name)
+        if name:
+            logger = logging.getLogger(name)
+        else:
+            logger = self._logger
+            if logger is None:
+                logger = logging.getLogger(module_logger_name(self._module.module_full_name))
+                self._logger = logger
+        log_message(logger, message, level)
 
     def update(self, module_name=None):
         """
@@ -1135,7 +1133,7 @@ class Py3:
         module_name = self._module.module_full_name
         for key in self._storage.storage_keys(module_name):
             value = self._storage.storage_get(module_name, key)
-            items.add((key, value))
+            items.append((key, value))
         return items
 
     def play_sound(self, sound_file):

--- a/py3status/storage.py
+++ b/py3status/storage.py
@@ -1,8 +1,11 @@
+import logging
 import os
 import time
 from pathlib import Path
 from pickle import dump, load
 from tempfile import NamedTemporaryFile
+
+logger = logging.getLogger(__name__)
 
 
 class Storage:
@@ -35,9 +38,7 @@ class Storage:
 
         # move legacy storage cache to new desired / default location
         if legacy_storage_path:
-            self.py3_wrapper.log(
-                "moving legacy storage_path {} to {}".format(legacy_storage_path, self.storage_path)
-            )
+            logger.info("moving legacy path %s to %s", legacy_storage_path, self.storage_path)
             legacy_storage_path.rename(self.storage_path)
 
         try:
@@ -46,9 +47,12 @@ class Storage:
         except OSError:
             pass
 
-        self.py3_wrapper.log(f"storage_path: {self.storage_path}")
+        logger.info("path: %s", self.storage_path)
         if self.data:
-            self.py3_wrapper.log(f"storage_data: {self.data}")
+            logger.debug(
+                "keys: %s",
+                {module_name: list(module_data) for module_name, module_data in self.data.items()},
+            )
         self.initialized = True
 
     def get_legacy_storage_path(self):

--- a/py3status/udev_monitor.py
+++ b/py3status/udev_monitor.py
@@ -1,3 +1,4 @@
+import logging
 from collections import Counter, defaultdict
 from datetime import datetime
 from time import sleep
@@ -8,6 +9,8 @@ try:
     import pyudev
 except ImportError:
     pyudev = None
+
+logger = logging.getLogger(__name__)
 
 
 class UdevMonitor:
@@ -33,14 +36,16 @@ class UdevMonitor:
         monitor = pyudev.Monitor.from_netlink(context)
         self.udev_observer = pyudev.MonitorObserver(monitor, self._udev_event)
         self.udev_observer.start()
-        self.py3_wrapper.log("udev monitoring enabled")
+        logger.info("enabled")
 
     def _udev_event(self, action, device):
         """
         This is a callback method that will trigger a refresh on subscribers.
         """
-        # self.py3_wrapper.log(
-        #     f"detected udev action '{action}' on subsystem '{device.subsystem}'"
+        # logger.info(
+        #     "detected action '%s' on subsystem '%s'",
+        #     action,
+        #     device.subsystem,
         # )
         if not self.py3_wrapper.i3bar_running:
             return
@@ -58,20 +63,21 @@ class UdevMonitor:
             if self.udev_observer is None:
                 self._setup_pyudev_monitoring()
             if trigger_action not in ON_TRIGGER_ACTIONS:
-                self.py3_wrapper.log(
-                    f"module {py3_module.module_full_name}: invalid action "
-                    f"{trigger_action} on udev events subscription"
+                py3_module._logger.info(
+                    "invalid action '%s' on events subscription",
+                    trigger_action,
                 )
                 return False
             self.udev_consumers[subsystem].append((py3_module, trigger_action))
-            self.py3_wrapper.log(
-                f"module {py3_module.module_full_name} subscribed to udev events on {subsystem}"
+            py3_module._logger.info(
+                "subscribed to events on %s",
+                subsystem,
             )
             return True
         else:
-            self.py3_wrapper.log(
-                f"pyudev module not installed: module {py3_module.module_full_name} "
-                f"not subscribed to events on {subsystem}"
+            py3_module._logger.info(
+                "pyudev module not installed; not subscribed to events on %s",
+                subsystem,
             )
             return False
 
@@ -86,13 +92,15 @@ class UdevMonitor:
                 occurences = self.throttle[event_key][resolution]
                 # we allow at most 5 events per 10 seconds window
                 if occurences >= 5:
-                    self.py3_wrapper.log(
-                        f"udev event {event_key}: throttled after {occurences} occurences",
-                        level="warning",
+                    py3_module._logger.warning(
+                        "event '%s' throttled after %s occurrences",
+                        event_key,
+                        occurences,
                     )
                     continue
-                self.py3_wrapper.log(
-                    f"{event_key} udev event: refresh consumer {py3_module.module_full_name}"
+                py3_module._logger.info(
+                    "event '%s' refreshing consumer",
+                    event_key,
                 )
                 sleep(0.1)
                 py3_module.force_update()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -110,6 +110,7 @@ line_length = 100
 [tool.ruff]
 line-length = 100
 lint.ignore = ["E501"]
+lint.extend-select = ["G004"]
 
 [tool.hatch.envs.docs]
 dependencies = [

--- a/tests/test_modules.py
+++ b/tests/test_modules.py
@@ -15,13 +15,13 @@ def make_status_wrapper():
     return status_wrapper
 
 
-def test__get_path_based_modules(status_wrapper):
+def test__get_path_included_modules(status_wrapper):
     """Use the list of inbuilt modules as reference to check against."""
-    included_modules_path = Path(py3status.__file__).resolve().parent / "modules"
-    status_wrapper.options.__dict__["include_paths"] = [included_modules_path]
-    assert included_modules_path.exists()
-    expected_keys = [n.stem for n in included_modules_path.iterdir() if n.suffix == ".py"]
-    modules = status_wrapper._get_path_based_modules()
+    path_included_modules_path = Path(py3status.__file__).resolve().parent / "modules"
+    status_wrapper.options.__dict__["include_paths"] = [path_included_modules_path]
+    assert path_included_modules_path.exists()
+    expected_keys = [n.stem for n in path_included_modules_path.iterdir() if n.suffix == ".py"]
+    modules = status_wrapper._get_path_included_modules()
     assert sorted(modules) == sorted(expected_keys)
 
 
@@ -32,7 +32,7 @@ def test__get_entry_point_based_modules(status_wrapper, monkeypatch):
 
             def __init__(self, name):
                 self.name = name
-                self.module_name = "module_name_" + self.name
+                self.value = f"{name}.module"
 
             @staticmethod
             def load():
@@ -44,9 +44,9 @@ def test__get_entry_point_based_modules(status_wrapper, monkeypatch):
 
     monkeypatch.setattr(importlib.metadata, "entry_points", return_fake_entry_points)
 
-    user_modules = status_wrapper._get_entry_point_based_modules()
-    assert len(user_modules) == 2
-    for name, info in user_modules.items():
+    discoverable_modules = status_wrapper._get_entry_point_based_modules()
+    assert len(discoverable_modules) == 2
+    for name, info in discoverable_modules.items():
         assert any(n in name for n in ["spam", "eggs"])
         kind, klass = info
         assert kind == ENTRY_POINT_KEY


### PR DESCRIPTION
Working with codex off this https://github.com/ultrabug/py3status/pull/2327#issuecomment-4351974940 

> It's certainly terrible to look at those added if debug.

Direct logging avoids this.

> Original logging PR called for using the logging module directly everywhere plus using lazy %s strings. One can look into adding ruff rule to prevent f-strings logging to reduce wasted f-string calculation.

Addressed.
Lint ruled added -- https://docs.astral.sh/ruff/rules/logging-f-string/ 

> I think the real issue is that we're logging everything through a busy self.log instead of breaking up into either using logging functions directly or create additional py3 logging (ie self.py3.debug pass if disabled, self.py3.info). I looked at how we logged debug/warn code... we just print plain strings most times, so no need to check for arrays/lists/sets/etc and other functions. Those should be just for user-facing logging.

See above. `self.py3.log()` is now for user-facing module logging. We also could remove `self.py3_wrapper.log()` in favor of direct logging... for performance reasons since we don't really need wrapper / additional checks.

> And to really improve performance, we should be able to disable logs completely too, no syslog, no info log, for most runs, which your proposal PR currently doesn't cover. This issue is acknowledged too.

I haven't looked into this.

> @valdur55 Additional suggestion is to fail fast when calling disallowed logging level

Added in `self.py3.log()`.

1) I still have to review more. I just want to toss this PR out and see how you think/feel about this...  
2) I think core code should stick with direct logging and user-facing modules can stick with `self.py3.log()`
3) This changed lot of things. For instance, we now can see logging names (via `__name__`) rather than piping everything through `self.py3.log()` / `self.py3_wrapper.log()` functions.

Here's the benchmarks.

```
Summary (median µs/call)

benchmark                      | master | logging-memory-leak | logging-split
-------------------------------+--------+---------------------+--------------
internal_debug_disabled_simple | 0.96   | 0.70                | 0.18
internal_debug_disabled_dict   | 10.68  | 0.70                | 0.18
internal_info_enabled_simple   | 5.81   | 6.37                | 4.92
py3_debug_disabled_simple      | 1.20   | 0.78                | 0.35
py3_debug_disabled_dict        | 10.88  | 0.78                | 0.35
py3_info_enabled_simple        | 6.21   | 7.13                | 5.79
```

Replaces / Closes https://github.com/ultrabug/py3status/pull/2327 