### PR TITLE
py3: remove unused storage_items()

### DIFF
--- a/docs/dev-guide/the-py3-helper.md
+++ b/docs/dev-guide/the-py3-helper.md
@@ -451,14 +451,6 @@ If key is not supplied then all values for the module are removed.
 
 Retrieve a value for the module.
 
-### storage_items()
-
-Return key, value pairs of the stored data for the module.
-
-Keys will contain the following metadata entries:
-- '_ctime': storage creation timestamp
-- '_mtime': storage last modification timestamp
-
 ### storage_keys()
 
 Return a list of the keys for values stored for the module.

--- a/py3status/py3.py
+++ b/py3status/py3.py
@@ -1118,24 +1118,6 @@ class Py3:
         module_name = self._module.module_full_name
         return self._storage.storage_keys(module_name)
 
-    def storage_items(self):
-        """
-        Return key, value pairs of the stored data for the module.
-
-        Keys will contain the following metadata entries:
-        - '_ctime': storage creation timestamp
-        - '_mtime': storage last modification timestamp
-        """
-        if not self._module:
-            return {}.items()
-        self._storage_init()
-        items = []
-        module_name = self._module.module_full_name
-        for key in self._storage.storage_keys(module_name):
-            value = self._storage.storage_get(module_name, key)
-            items.append((key, value))
-        return items
-
     def play_sound(self, sound_file):
         """
         Plays sound_file if possible.


### PR DESCRIPTION
Codex found inconsistency bug. We should use `append`, not `add` with `items = []`.

This should raise an exception, but it didn't.... Why? It's because this code is not being used anywhere... so just remove it. ~~Also, Idk why modules would want access to other module storage. I mean, I could see some benefits in doing that, but~~ if it's not needed, go ahead and remove it instead of fixing it.

Consistency fix for dead code.
```diff
diff --git a/py3status/py3.py b/py3status/py3.py
--- a/py3status/py3.py
+++ b/py3status/py3.py
@@ -1130,13 +1130,13 @@ class Py3:
         - '_mtime': storage last modification timestamp
         """
         if not self._module:
-            return {}.items()
+            return []
         self._storage_init()
         items = []
         module_name = self._module.module_full_name
         for key in self._storage.storage_keys(module_name):
             value = self._storage.storage_get(module_name, key)
-            items.add((key, value))
+            items.append((key, value))
         return items
 
     def play_sound(self, sound_file):
     ```