### PR TITLE
parse_config: improve config loading

### DIFF
--- a/py3status/parse_config.py
+++ b/py3status/parse_config.py
@@ -685,36 +685,44 @@ def process_config(config_path, py3_wrapper=None):
         error_config = Template(ERROR_CONFIG).substitute(error=error)
         return parse_config(error_config)
 
-    config = {}
+    def load_config(encoding=None):
+        with config_path.open("r", encoding=encoding) as f:
+            try:
+                return parse_config(f)
+            except ParseException as e:
+                return parse_config_error(e, config_path)
+
+    def get_encoding(encoding):
+        if not encoding:
+            return None
+        encoding = encoding.lower()
+        if encoding in ["binary", "unknown-8bit"]:
+            return None
+        if encoding in ["utf-16le", "utf-16be", "utf-32le", "utf-32be"]:
+            return encoding[:-2]
+        return encoding
 
     # get the file encoding. this is important with multi-byte characters
     try:
-        encoding = check_output(
-            ["file", "-b", "--mime-encoding", "--dereference", config_path],
-            timeout=3,
-        )
-        encoding = encoding.strip().decode("utf-8")
-    except FileNotFoundError:
-        # can be missing on NixOS (see #1961)
-        notify_user("the 'file' command is missing, please install it.")
-        encoding = "utf-8"
-    except (CalledProcessError, TimeoutExpired):
-        # timeout can occur on some architectures where the magic
-        # database takes too long to load.
-        # bsd does not have the --mime-encoding so assume utf-8
-        encoding = "utf-8"
-    try:
-        with config_path.open("r", encoding=encoding) as f:
-            try:
-                config_info = parse_config(f)
-            except ParseException as e:
-                config_info = parse_config_error(e, config_path)
-    except (LookupError, UnicodeDecodeError):
-        with config_path.open() as f:
-            try:
-                config_info = parse_config(f)
-            except ParseException as e:
-                config_info = parse_config_error(e, config_path)
+        config_info = load_config("utf-8-sig")
+    except UnicodeDecodeError:
+        try:
+            # detect config encoding only if utf-8 decoding fails
+            cmd = ["file", "-b", "--mime-encoding", "--dereference", config_path]
+            encoding = get_encoding(check_output(cmd, timeout=3).strip().decode("utf-8"))
+        except FileNotFoundError:
+            # can be missing on NixOS (see #1961)
+            notify_user("the 'file' command is missing, please install it.")
+            encoding = None
+        except (CalledProcessError, TimeoutExpired):
+            encoding = None
+            # timeout can occur on some architectures where the magic
+            # database takes too long to load. and bsd does not have
+            # the --mime-encoding so we cannot determine the encoding.
+        config_info = load_config(encoding)
+
+    # the beginning of something beautiful
+    config = {}
 
     # update general section with defaults
     general_defaults = GENERAL_DEFAULTS.copy()

--- a/tests/test_parse_config.py
+++ b/tests/test_parse_config.py
@@ -1,0 +1,70 @@
+from codecs import BOM_UTF16_BE, BOM_UTF16_LE, BOM_UTF32_BE, BOM_UTF32_LE
+
+import pytest
+
+import py3status.parse_config as parse_config
+
+CONFIG = '''\
+order += "static_string"
+static_string {
+    format = "café"
+}
+'''
+
+DETECTED_CONFIGS = [
+    (CONFIG.encode("latin-1"), b"iso-8859-1"),
+    (BOM_UTF16_LE + CONFIG.encode("utf-16-le"), b"utf-16le"),
+    (BOM_UTF16_BE + CONFIG.encode("utf-16-be"), b"utf-16be"),
+    (BOM_UTF32_LE + CONFIG.encode("utf-32-le"), b"utf-32le"),
+    (BOM_UTF32_BE + CONFIG.encode("utf-32-be"), b"utf-32be"),
+]
+
+
+@pytest.mark.parametrize(
+    ("payload", "expected"),
+    [
+        (CONFIG.replace("café", "cafe").encode("ascii"), "cafe"),
+        (CONFIG.encode("utf-8"), "café"),
+        (CONFIG.encode("utf-8-sig"), "café"),
+    ],
+)
+def test_process_config_without_detection(tmp_path, monkeypatch, payload, expected):
+    def unexpected_file_call(*args, **kwargs):
+        raise AssertionError("file should not be called for ASCII or UTF-8 config")
+
+    monkeypatch.setattr(parse_config, "check_output", unexpected_file_call)
+    config_path = tmp_path / "py3status.conf"
+    config_path.write_bytes(payload)
+
+    config = parse_config.process_config(config_path)
+
+    assert config["static_string"]["format"] == expected
+
+
+@pytest.mark.parametrize(
+    ("payload", "detected_encoding"),
+    DETECTED_CONFIGS,
+)
+def test_process_config_detected_encoding(tmp_path, monkeypatch, payload, detected_encoding):
+    def detect_encoding(command, timeout):
+        assert command[:4] == ["file", "-b", "--mime-encoding", "--dereference"]
+        assert timeout == 3
+        return detected_encoding
+
+    monkeypatch.setattr(parse_config, "check_output", detect_encoding)
+    config_path = tmp_path / "py3status.conf"
+    config_path.write_bytes(payload)
+
+    config = parse_config.process_config(config_path)
+
+    assert config["static_string"]["format"] == "café"
+
+
+@pytest.mark.parametrize("payload", [payload for payload, _ in DETECTED_CONFIGS])
+def test_process_config_file_detection(tmp_path, payload):
+    config_path = tmp_path / "py3status.conf"
+    config_path.write_bytes(payload)
+
+    config = parse_config.process_config(config_path)
+
+    assert config["static_string"]["format"] == "café"


### PR DESCRIPTION
This attempts config loading `utf-8-sig` first (rather than `utf-8`) with fallback to command `file`.

It looks like py3status ~~switched from `utf-8` with no fallback to....~~ `file` with fallback `utf-8` ~~sometimes in the past to better handle files.~~ Why no `utf-8` first with `file` fallback?

However, because `file` is tried first, it introduced issues such as...

1) make  `file` a hard dependency.
2) bsd `file` doesn't have `--mime-encoding`
3) adding timeout to `file` subprocess call
4) slow

I'm suggesting that we try again with `utf-8-sig` first with `file` fallback rather than the other way around. The final, final fallback is default locale (instead of explicit `utf-8`, but we tried `utf-8-sig` first anyway).

---- 

Strategy Comparison.
```
case        | file first     | utf-8 first    | utf-8-sig first
------------+----------------+----------------+-----------------
ascii       | ok             | ok             | ok
utf-8       | ok             | ok             | ok
utf-8-sig   | parse_fail:bom | parse_fail:bom | ok
latin-1     | ok             | fallback->ok   | fallback->ok
utf-16      | ok             | fallback->ok   | fallback->ok
```

Benchmark.
```
branch                  | mean_seconds | vs_master
------------------------+--------------+----------------
master                  | 0.006011611  | baseline
parse_config_fallback   | 0.000251349  | 95.82% faster
```