### PR TITLE
clean up python2 leftovers

### DIFF
--- a/docs/dev-guide/the-py3-helper.md
+++ b/docs/dev-guide/the-py3-helper.md
@@ -71,7 +71,7 @@ If a string is passed then that command will be checked for.
 
 ### command_output(command, shell=False, capture_stderr=False, localized=False)
 
-Run a command and return its output as unicode.
+Run a command and return its output as text.
 The command can either be supplied as a sequence or string.
 
 :param command: command to run can be a str or list

--- a/docs/dev-guide/writing-modules.md
+++ b/docs/dev-guide/writing-modules.md
@@ -449,10 +449,10 @@ composite.
 Py3status allows modules to maintain state through the use of the
 storage functions of the Py3 helper.
 
-Currently bool, int, float, None, unicode, dicts, lists, datetimes etc
+Currently bool, int, float, None, strings, dicts, lists, datetimes etc
 are supported. Basically anything that can be pickled. We do our best to
-ensure that the resulting pickles are compatible with both python
-versions 2 and 3.
+ensure that the resulting pickles remain readable across py3status
+updates where practical.
 
 The following helper functions are defined in the modules py3.
 

--- a/py3status/events.py
+++ b/py3status/events.py
@@ -39,7 +39,7 @@ class IOPoller:
                 # skip first event line wrt issue #19
                 line = self.io.readline().strip()
             try:
-                # python3 compatibility code
+                # decode bytes input when needed
                 line = line.decode()
             except (AttributeError, UnicodeDecodeError):
                 pass

--- a/py3status/modules/rate_counter.py
+++ b/py3status/modules/rate_counter.py
@@ -66,7 +66,9 @@ class Py3status:
             # Use file to refer to the file object
             with self.config_file.open() as file:
                 self.saved_time = float(file.read())
-        except:  # noqa e722 // (IOError, FileNotFoundError):  # py2/py3
+        except (OSError, ValueError):
+            # start from zero if the saved state
+            # is missing or unreadable
             pass
 
     @property

--- a/py3status/modules/rt.py
+++ b/py3status/modules/rt.py
@@ -35,7 +35,7 @@ SAMPLE OUTPUT
 
 try:
     import pymysql as mysql
-except:  # noqa e722 // (ImportError, ModuleNotFoundError):  # py2/py3
+except ImportError:
     import MySQLdb as mysql
 
 

--- a/py3status/parse_config.py
+++ b/py3status/parse_config.py
@@ -283,10 +283,10 @@ class ConfigParser:
             return value[1:-1].replace("\\'", "'")
         return value
 
-    def unicode_escape_sequence_fix(self, value):
+    def escape_sequence_fix(self, value):
         """
-        It is possible to define unicode characters in the config either as the
-        actual utf-8 character or using escape sequences the following all will
+        It is possible to define Unicode characters in the config either as the
+        actual UTF-8 character or using escape sequences. The following all will
         show the Greek delta character.
         Δ \N{GREEK CAPITAL LETTER DELTA} \U00000394  \u0394
         """
@@ -303,8 +303,8 @@ class ConfigParser:
         """
         Converts to actual value, or remains as string.
         """
-        # ensure any escape sequences are converted to unicode
-        value = self.unicode_escape_sequence_fix(value)
+        # ensure any escape sequences are converted to text
+        value = self.escape_sequence_fix(value)
 
         if value and value[0] in ['"', "'"]:
             return self.remove_quotes(value)
@@ -395,7 +395,7 @@ class ConfigParser:
             if value_type == "bool":
                 value = True
             else:
-                # convert bytes to unicode
+                # convert bytes to text
                 value = value.decode("utf-8")
                 value = self.value_convert(value, value_type)
         return value
@@ -562,7 +562,7 @@ class ConfigParser:
             if module_name.split(" ")[0] in I3S_MODULE_NAMES + ["general"]:
                 self.error("Only py3status modules can use obfuscated")
 
-            if type(value).__name__ not in ["str", "unicode"]:
+            if not isinstance(value, str):
                 self.error("Only strings can be obfuscated")
 
             name, scheme = name.split(":")
@@ -687,7 +687,7 @@ def process_config(config_path, py3_wrapper=None):
 
     config = {}
 
-    # get the file encoding this is important with multi-byte unicode chars
+    # get the file encoding. this is important with multi-byte characters
     try:
         encoding = check_output(
             ["file", "-b", "--mime-encoding", "--dereference", config_path],

--- a/py3status/private.py
+++ b/py3status/private.py
@@ -119,7 +119,7 @@ def catch_factory(attr):
     return _catch
 
 
-# We need to populate our base class with all the methods that unicode
+# We need to populate our base class with all the methods that str
 # has.  We will implement them using the _catch function created by out
 # factory.  We want to exclude a few select methods
 EXCLUDE = [

--- a/py3status/py3.py
+++ b/py3status/py3.py
@@ -1010,7 +1010,7 @@ class Py3:
 
     def command_output(self, command, shell=False, capture_stderr=False, localized=False):
         """
-        Run a command and return its output as unicode.
+        Run a command and return its output as text.
         The command can either be supplied as a sequence or string.
 
         :param command: command to run can be a str or list

--- a/py3status/request.py
+++ b/py3status/request.py
@@ -12,7 +12,7 @@ class HttpResponse:
     """
     Simple encapsulation of a http response for a url
 
-    The aim is to support both python 2 and 3 and be a simple as possible
+    The aim is to stay as simple as possible.
     """
 
     def __init__(self, url, params, data, headers, timeout, auth, cookiejar):
@@ -30,10 +30,9 @@ class HttpResponse:
             # rebuild the url
             url = urlunsplit(parts)
         if auth:
-            # we need to do the encode/decode to keep python 3 happy
-            # TODO: make this straight for python 3
-            auth_str = base64.b64encode(("%s:%s" % auth).encode("utf-8"))
-            headers["Authorization"] = "Basic %s" % auth_str.decode("utf-8")
+            userpass = ":".join(auth).encode("utf-8")
+            token = base64.b64encode(userpass).decode("utf-8")
+            headers["Authorization"] = f"Basic {token}"
         if data:
             data = urlencode(data).encode()
         if cookiejar is not None:

--- a/py3status/storage.py
+++ b/py3status/storage.py
@@ -71,8 +71,7 @@ class Storage:
         Save our data to disk. We want to always have a valid file.
         """
         with NamedTemporaryFile(dir=self.storage_path.parent, delete=False) as f:
-            # we use protocol=2 for python 2/3 compatibility
-            dump(self.data, f, protocol=2)
+            dump(self.data, f)
             f.flush()
             os.fsync(f.fileno())
             tmppath = Path(f.name)

--- a/tests/test_formatter.py
+++ b/tests/test_formatter.py
@@ -26,8 +26,6 @@ param_dict = {
     "?bad name": "evil",
     "☂ Very bad name ": "☂ extremely evil",
     "long_str": "I am a long string though not too long",
-    "python2_unicode": "Björk",
-    "python2_str": "Björk",
     "zero": 0,
     "zero_str": "0",
     "zero_float": 0.0,
@@ -165,10 +163,6 @@ def get_color_names(test_dict):
 
 
 def test_1():
-    run_formatter({"format": "hello ☂", "expected": "hello ☂"})
-
-
-def test_2():
     run_formatter({"format": "hello ☂", "expected": "hello ☂"})
 
 
@@ -353,27 +347,6 @@ def test_38():
     run_formatter({"format": "[{empty} ping] hello", "expected": " hello"})
 
 
-def test_39():
-    run_formatter(
-        # python 2 unicode
-        {"format": "Hello {python2_unicode}! ☂", "expected": "Hello Björk! ☂"}
-    )
-
-
-def test_40():
-    run_formatter(
-        {"format": "Hello {python2_unicode}! ☂", "expected": "Hello Björk! ☂"}
-    )
-
-
-def test_41():
-    run_formatter({"format": "Hello {python2_str}! ☂", "expected": "Hello Björk! ☂"})
-
-
-def test_42():
-    run_formatter({"format": "Hello {python2_str}! ☂", "expected": "Hello Björk! ☂"})
-
-
 def test_43():
     run_formatter(
         # formatting
@@ -386,8 +359,8 @@ def test_44():
 
 
 def test_45():
-    # the representation is different in python2 "u'Björk'"
-    run_formatter({"format": "{name!r}", "expected": "'Björk'", "py3only": True})
+    # repr formatting for strings
+    run_formatter({"format": "{name!r}", "expected": "'Björk'"})
 
 
 def test_46():

--- a/tests/test_module_doc.py
+++ b/tests/test_module_doc.py
@@ -103,7 +103,6 @@ def get_module_attributes(path):
     """
     names = {}
     attributes = OrderedDict()
-    python2_names = {"True": True, "False": False, "None": None}
 
     def get_values(source, dest, extra=None):
         """
@@ -128,10 +127,7 @@ def get_module_attributes(path):
                 elif class_name == "List":
                     attr_value = [get_value(e) for e in value.elts]
                 elif class_name == "Name":
-                    # in python 2 True, False, None are Names rather than
-                    # NameConstant so we use them for the default
-                    default = python2_names.get(value.id)
-                    attr_value = extra.get(value.id, default)
+                    attr_value = extra.get(value.id)
                 elif class_name == "Tuple":
                     attr_value = tuple(get_value(e) for e in value.elts)
                 elif class_name == "UnaryOp":


### PR DESCRIPTION
We got rid of python2.7 eons ago, but we still got few more... So I asked my buddy J.A.R.V.I.S. to seek and destroy any legacy python2 compatibility leftovers it can find in the repository except for... explicitly skipped files.
- py3status/i3status.py
- py3status/modules/i3pystatus.py
- py3status/modules/mpd_status.py

1) Got rid of python2-related unicde tests.
2) Dropped pickle 2/3 compatibility version (2) in favor of default version (4). The highest version is currently (5) and will not work with `python 3.10` anyway.
3) Skimmed through the diffs (comments, modifications) and they looked okay.
4) Python2 code still lives in `i3status.py` and I hope to replace this with `modules.i3status` module.