### PR TITLE
py3, modules: add static threshold_update helper

### DIFF
--- a/docs/dev-guide/the-py3-helper.md
+++ b/docs/dev-guide/the-py3-helper.md
@@ -481,6 +481,16 @@ thresholds we will use a gradient between the color values.
     accepts 3-tuples to allow name with different
     values eg ('name', 'key', 'thresholds')
 
+### threshold_update(thresholds, format_string)
+
+Convenience helper for static threshold updates.
+
+This checks threshold names from the format string against
+values in the thresholds dict and updates matching threshold colors.
+
+- thresholds: dict containing threshold values
+- format_string: format string to check
+
 ### time_in(seconds=None, sync_to=None, offset=0)
 
 Returns the time a given number of seconds into the future.  Helpful

--- a/py3status/modules/air_quality.py
+++ b/py3status/modules/air_quality.py
@@ -150,8 +150,6 @@ class Py3status:
                 aqi = [(x[0], x[1]) for x in self.quality_thresholds]
                 self.thresholds["aqi"] = aqi
 
-        self.thresholds_init = self.py3.get_color_names_list(self.format)
-
     def _get_aqi_data(self):
         try:
             return self.py3.request(self.url, params=self.auth_token).json()
@@ -169,9 +167,7 @@ class Py3status:
             if data["aqi"] >= index_aqi:
                 data["category"] = index_category
 
-        for x in self.thresholds_init:
-            if x in data:
-                self.py3.threshold_get_color(data[x], x)
+        self.py3.threshold_update(data, self.format)
 
         for k in self.init_datetimes:
             if k in data:

--- a/py3status/modules/apt_updates.py
+++ b/py3status/modules/apt_updates.py
@@ -39,6 +39,16 @@ class Py3status:
         if not self.py3.check_commands("apt"):
             raise Exception(STRING_NOT_INSTALLED)
 
+    def _check_apt_updates(self):
+        """
+        This method will use the 'checkupdates' command line utility
+        to determine how many updates are waiting to be installed via
+        'apt list --upgradeable'.
+        """
+        output = str(subprocess.check_output(["apt", "list", "--upgradeable"]))
+        output = output.split(LINE_SEPARATOR)
+        return len(output[1:-1])
+
     def apt_updates(self):
         apt_updates = self._check_apt_updates()
 
@@ -51,16 +61,6 @@ class Py3status:
             "cached_until": self.py3.time_in(self.cache_timeout),
             "full_text": full_text,
         }
-
-    def _check_apt_updates(self):
-        """
-        This method will use the 'checkupdates' command line utility
-        to determine how many updates are waiting to be installed via
-        'apt list --upgradeable'.
-        """
-        output = str(subprocess.check_output(["apt", "list", "--upgradeable"]))
-        output = output.split(LINE_SEPARATOR)
-        return len(output[1:-1])
 
 
 if __name__ == "__main__":

--- a/py3status/modules/async_script.py
+++ b/py3status/modules/async_script.py
@@ -59,24 +59,6 @@ class Py3status:
         if not self.script_path:
             self.py3.error("script_path is mandatory")
 
-    def async_script(self):
-        response = {}
-        response["cached_until"] = self.py3.CACHE_FOREVER
-
-        if self.command_error is not None:
-            self.py3.log(self.command_error, level=self.py3.LOG_ERROR)
-            self.py3.error(self.command_error, timeout=self.py3.CACHE_FOREVER)
-        if not self.command_thread.is_alive():
-            self.command_thread = Thread(target=self._command_start)
-            self.command_thread.daemon = True
-            self.command_thread.start()
-
-        if self.command_color is not None:
-            response["color"] = self.command_color
-
-        response["full_text"] = self.py3.safe_format(self.format, {"output": self.command_output})
-        return response
-
     def _command_start(self):
         try:
             command = Popen(shlex.split(self.script_path), stdout=PIPE)
@@ -95,6 +77,24 @@ class Py3status:
         except Exception as e:
             self.command_error = str(e)
             self.py3.update()
+
+    def async_script(self):
+        response = {}
+        response["cached_until"] = self.py3.CACHE_FOREVER
+
+        if self.command_error is not None:
+            self.py3.log(self.command_error, level=self.py3.LOG_ERROR)
+            self.py3.error(self.command_error, timeout=self.py3.CACHE_FOREVER)
+        if not self.command_thread.is_alive():
+            self.command_thread = Thread(target=self._command_start)
+            self.command_thread.daemon = True
+            self.command_thread.start()
+
+        if self.command_color is not None:
+            response["color"] = self.command_color
+
+        response["full_text"] = self.py3.safe_format(self.format, {"output": self.command_output})
+        return response
 
 
 if __name__ == "__main__":

--- a/py3status/modules/backlight.py
+++ b/py3status/modules/backlight.py
@@ -141,22 +141,6 @@ class Py3status:
         if self.brightness_initial:
             self._set_backlight_level(self.brightness_initial)
 
-    def on_click(self, event):
-        level = self._get_backlight_level()
-        button = event["button"]
-        if button == self.button_up:
-            delta = self.brightness_delta if level >= self.low_tune_threshold else 1
-            level += delta
-            if level > 100:
-                level = 100
-            self._set_backlight_level(level)
-        elif button == self.button_down:
-            delta = self.brightness_delta if level > self.low_tune_threshold else 1
-            level -= delta
-            if level < self.brightness_minimal:
-                level = self.brightness_minimal
-            self._set_backlight_level(level)
-
     def _set_backlight_level(self, level):
         if self.command_available:
             self.py3.command_run(self._command_set(level))
@@ -197,6 +181,22 @@ class Py3status:
             "full_text": full_text,
         }
         return response
+
+    def on_click(self, event):
+        level = self._get_backlight_level()
+        button = event["button"]
+        if button == self.button_up:
+            delta = self.brightness_delta if level >= self.low_tune_threshold else 1
+            level += delta
+            if level > 100:
+                level = 100
+            self._set_backlight_level(level)
+        elif button == self.button_down:
+            delta = self.brightness_delta if level > self.low_tune_threshold else 1
+            level -= delta
+            if level < self.brightness_minimal:
+                level = self.brightness_minimal
+            self._set_backlight_level(level)
 
 
 if __name__ == "__main__":

--- a/py3status/modules/battery_level.py
+++ b/py3status/modules/battery_level.py
@@ -191,47 +191,6 @@ class Py3status:
             raise NameError(f"invalid {msg}")
         self.py3.log(f"selected {msg}")
 
-    def battery_level(self):
-        battery_list = self.get_battery_info()
-        if not battery_list:
-            return {
-                "full_text": "",
-                "cached_until": self.py3.time_in(self.cache_timeout),
-            }
-
-        self._refresh_battery_info(battery_list)
-        self._update_icon()
-        self._update_ascii_bar()
-        self._update_status()
-        self._update_full_text()
-
-        return self._build_response()
-
-    def on_click(self, event):
-        """
-        Display a notification following the specified format
-        """
-        if not self.notification:
-            return
-
-        if self.charging:
-            format = self.format_notify_charging
-        else:
-            format = self.format_notify_discharging
-
-        message = self.py3.safe_format(
-            format,
-            dict(
-                ascii_bar=self.ascii_bar,
-                icon=self.icon,
-                percent=self.percent_charged,
-                time_remaining=self.time_remaining,
-            ),
-        )
-
-        if message:
-            self.py3.notify_user(message, "info")
-
     def _extract_battery_info_from_acpi(self):
         """
         Get the battery info from acpi
@@ -535,6 +494,47 @@ class Py3status:
 
     def _set_cache_timeout(self):
         self.response["cached_until"] = self.py3.time_in(self.cache_timeout)
+
+    def battery_level(self):
+        battery_list = self.get_battery_info()
+        if not battery_list:
+            return {
+                "full_text": "",
+                "cached_until": self.py3.time_in(self.cache_timeout),
+            }
+
+        self._refresh_battery_info(battery_list)
+        self._update_icon()
+        self._update_ascii_bar()
+        self._update_status()
+        self._update_full_text()
+
+        return self._build_response()
+
+    def on_click(self, event):
+        """
+        Display a notification following the specified format
+        """
+        if not self.notification:
+            return
+
+        if self.charging:
+            format = self.format_notify_charging
+        else:
+            format = self.format_notify_discharging
+
+        message = self.py3.safe_format(
+            format,
+            dict(
+                ascii_bar=self.ascii_bar,
+                icon=self.icon,
+                percent=self.percent_charged,
+                time_remaining=self.time_remaining,
+            ),
+        )
+
+        if message:
+            self.py3.notify_user(message, "info")
 
 
 if __name__ == "__main__":

--- a/py3status/modules/bluetooth.py
+++ b/py3status/modules/bluetooth.py
@@ -111,10 +111,6 @@ class Py3status:
             ("devices", "org.bluez.Device1"),
         ]
 
-        self.thresholds_init = {}
-        for name in ["format", "format_adapter", "format_device"]:
-            self.thresholds_init[name] = self.py3.get_color_names_list(getattr(self, name))
-
     def _dbus_init(self):
         bus = Gio.bus_get_sync(Gio.BusType.SYSTEM, None)
         iface = "org.freedesktop.DBus.ObjectManager"
@@ -162,9 +158,7 @@ class Py3status:
             new_device = []
 
             for device in devices:
-                for x in self.thresholds_init["format_device"]:
-                    if x in device:
-                        self.py3.threshold_get_color(device[x], x)
+                self.py3.threshold_update(device, self.format_device)
 
                 new_device.append(self.py3.safe_format(self.format_device, device))
 
@@ -173,9 +167,7 @@ class Py3status:
 
             adapter.update({"format_device": format_device, "device": len(devices)})
 
-            for x in self.thresholds_init["format_adapter"]:
-                if x in adapter:
-                    self.py3.threshold_get_color(adapter[x], x)
+            self.py3.threshold_update(adapter, self.format_adapter)
 
             new_adapter.append(self.py3.safe_format(self.format_adapter, adapter))
 
@@ -184,9 +176,7 @@ class Py3status:
 
         bluetooth_data = {"format_adapter": format_adapter, "adapter": len(adapters)}
 
-        for x in self.thresholds_init["format"]:
-            if x in bluetooth_data:
-                self.py3.threshold_get_color(bluetooth_data[x], x)
+        self.py3.threshold_update(bluetooth_data, self.format)
 
         return {
             "cached_until": self.py3.time_in(self.cache_timeout),

--- a/py3status/modules/clock.py
+++ b/py3status/modules/clock.py
@@ -205,22 +205,6 @@ class Py3status:
         timezone = self.format[self.active]
         self.py3.storage_set("timezone", timezone)
 
-    def on_click(self, event):
-        """
-        Switch the displayed module or pass the event on to the active module
-        """
-        if event["button"] == self.button_reset:
-            self._change_active(0)
-        elif event["button"] == self.button_change_time_format:
-            self.active_time_format += 1
-            if self.active_time_format >= len(self.format_time):
-                self.active_time_format = 0
-            # save the active format_time
-            time_format = self.format_time[self.active_time_format]
-            self.py3.storage_set("time_format", time_format)
-        elif event["button"] == self.button_change_format:
-            self._change_active(1)
-
     def clock(self):
         # cycling
         if self.cycle and time.time() >= self._cycle_time:
@@ -292,6 +276,22 @@ class Py3status:
             "full_text": self.py3.safe_format(self.format[self.active], times),
             "cached_until": timeout,
         }
+
+    def on_click(self, event):
+        """
+        Switch the displayed module or pass the event on to the active module
+        """
+        if event["button"] == self.button_reset:
+            self._change_active(0)
+        elif event["button"] == self.button_change_time_format:
+            self.active_time_format += 1
+            if self.active_time_format >= len(self.format_time):
+                self.active_time_format = 0
+            # save the active format_time
+            time_format = self.format_time[self.active_time_format]
+            self.py3.storage_set("time_format", time_format)
+        elif event["button"] == self.button_change_format:
+            self._change_active(1)
 
 
 if __name__ == "__main__":

--- a/py3status/modules/coin_balance.py
+++ b/py3status/modules/coin_balance.py
@@ -128,19 +128,6 @@ class Py3status:
         self._config = None
         self._credential_cache = {}
 
-    def coin_balance(self, outputs, config):
-        self._config = config
-
-        self._active_coins = [e[1] for e in Formatter().parse(self.format)]
-        balances = {}
-        for coin in self._active_coins:
-            balances[coin] = self._get_balance(coin)
-
-        return {
-            "full_text": self.py3.safe_format(self.format, balances),
-            "cached_until": self.py3.time_in(self.cache_timeout),
-        }
-
     def _get_daemon_config_value(self, coin, key):
         try:
             with (Path.home() / f".{coin}" / coin).open() as cfg:
@@ -196,6 +183,19 @@ class Py3status:
                 return "Request Error"
         except:  # noqa e722
             return "Connection to '" + url + "' failed"
+
+    def coin_balance(self, outputs, config):
+        self._config = config
+
+        self._active_coins = [e[1] for e in Formatter().parse(self.format)]
+        balances = {}
+        for coin in self._active_coins:
+            balances[coin] = self._get_balance(coin)
+
+        return {
+            "full_text": self.py3.safe_format(self.format, balances),
+            "cached_until": self.py3.time_in(self.cache_timeout),
+        }
 
 
 if __name__ == "__main__":

--- a/py3status/modules/coin_market.py
+++ b/py3status/modules/coin_market.py
@@ -146,8 +146,6 @@ class Py3status:
         self.url = "https://pro-api.coinmarketcap.com/v1/cryptocurrency/quotes"
         self.url += f"/latest?convert={convert}&symbol={markets}"
 
-        self.thresholds_init = self.py3.get_color_names_list(self.format_coin)
-
     def _get_coin_data(self):
         try:
             response = self.py3.request(self.url, headers=self.headers)
@@ -174,9 +172,7 @@ class Py3status:
         new_coin = []
 
         for market in coin_data:
-            for x in self.thresholds_init:
-                if x in market:
-                    self.py3.threshold_get_color(market[x], x)
+            self.py3.threshold_update(market, self.format_coin)
 
             new_coin.append(self.py3.safe_format(self.format_coin, market))
 

--- a/py3status/modules/conky.py
+++ b/py3status/modules/conky.py
@@ -434,9 +434,7 @@ class Py3status:
                     self.cache_names[k] = k.replace(" ", ".")
                     conky_data[self.cache_names[k]] = conky_data[k]
 
-            for x in self.thresholds_init:
-                if x in conky_data:
-                    self.py3.threshold_get_color(conky_data[x], x)
+            self.py3.threshold_update(conky_data, self.format)
 
         return {
             "cached_until": self.py3.CACHE_FOREVER,

--- a/py3status/modules/dexcom.py
+++ b/py3status/modules/dexcom.py
@@ -105,7 +105,6 @@ class Py3status:
         self.seconds = CACHE_TIMEOUT + getattr(self, "cached_delay", 10)
         self.placeholders = ["value", "datetime", "mg_dl", "mmol_l", "trend"]
         self.placeholders += ["trend_arrow", "trend_description", "trend_direction"]
-        self.thresholds_init = self.py3.get_color_names_list(self.format)
         self.dexcom_class = Dexcom(self.username, self.password, ous=self.ous)
 
     def _get_glucose_data(self):
@@ -132,9 +131,7 @@ class Py3status:
                 date_format = datetime.strftime(obj, self.format_datetime[x])
                 glucose_data[x] = self.py3.safe_format(date_format)
 
-        for x in self.thresholds_init:
-            if x in glucose_data:
-                self.py3.threshold_get_color(glucose_data[x], x)
+        self.py3.threshold_update(glucose_data, self.format)
 
         return {
             "cached_until": self.py3.time_in(cached_until),

--- a/py3status/modules/diskdata.py
+++ b/py3status/modules/diskdata.py
@@ -96,8 +96,6 @@ class Py3status:
             except Exception:
                 self.init["diskstats"] = {}
 
-        self.thresholds_init = self.py3.get_color_names_list(self.format)
-
     def _get_df_usages(self, disk):
         try:
             df_usages = self.py3.command_output(["df", "-k"])
@@ -185,9 +183,7 @@ class Py3status:
                     self.format_rate, {"value": value, "unit": unit}
                 )
 
-        for x in self.thresholds_init:
-            if x in threshold_data:
-                self.py3.threshold_get_color(threshold_data[x], x)
+        self.py3.threshold_update(threshold_data, self.format)
 
         return {
             "cached_until": self.py3.time_in(self.cache_timeout),

--- a/py3status/modules/dnf_updates.py
+++ b/py3status/modules/dnf_updates.py
@@ -66,9 +66,6 @@ class Py3status:
     format = "DNF [\?if=security&color=bad {available}|\?color=available {available}]"
     thresholds = [(0, "good"), (1, "degraded")]
 
-    def post_config_hook(self):
-        self.thresholds_init = self.py3.get_color_names_list(self.format, ADVISORIES)
-
     def _get_dnf_data(self):
         try:
             updates = loads(self.py3.command_output("dnf updateinfo list --json"))
@@ -87,8 +84,7 @@ class Py3status:
     def dnf_updates(self):
         dnf_data, cached_until = self._get_dnf_data()
 
-        for x in self.thresholds_init:
-            self.py3.threshold_get_color(dnf_data[x], x)
+        self.py3.threshold_update(dnf_data, self.format)
 
         return {
             "cached_until": self.py3.time_in(cached_until),

--- a/py3status/modules/do_not_disturb.py
+++ b/py3status/modules/do_not_disturb.py
@@ -216,15 +216,12 @@ class Py3status:
             raise Exception(STRING_INVALID_STATE.format(self.state))
 
         self.name = self.server.capitalize()
-        self.thresholds_init = self.py3.get_color_names_list(self.format)
 
     def do_not_disturb(self):
         self.state = self.backend.get_state()
         dnd_data = {"state": int(self.state), "name": self.name}
 
-        for x in self.thresholds_init:
-            if x in dnd_data:
-                self.py3.threshold_get_color(dnd_data[x], x)
+        self.py3.threshold_update(dnd_data, self.format)
 
         return {
             "cached_until": self.py3.time_in(self.cache_timeout),

--- a/py3status/modules/emerge_status.py
+++ b/py3status/modules/emerge_status.py
@@ -65,17 +65,6 @@ class Py3status:
     )
     prefix = "emrg"
 
-    def _emerge_running(self):
-        """
-        Check if emerge is running.
-        Returns true if at least one instance of emerge is running.
-        """
-        try:
-            self.py3.command_output(["pgrep", "emerge"])
-            return True
-        except Exception:
-            return False
-
     def post_config_hook(self):
         if not self.py3.check_commands("emerge"):
             raise Exception(STRING_NOT_INSTALLED)
@@ -87,6 +76,17 @@ class Py3status:
             "pkg": "",
             "total": 0,
         }
+
+    def _emerge_running(self):
+        """
+        Check if emerge is running.
+        Returns true if at least one instance of emerge is running.
+        """
+        try:
+            self.py3.command_output(["pgrep", "emerge"])
+            return True
+        except Exception:
+            return False
 
     def _get_progress(self):
         """

--- a/py3status/modules/gitlab.py
+++ b/py3status/modules/gitlab.py
@@ -102,7 +102,7 @@ class Py3status:
             self.url["single_project"] += "/?statistics=true"
 
         # init placeholders
-        self.init = {"thresholds": self.py3.get_color_names_list(self.format)}
+        self.init = {}
         placeholders = self.py3.get_placeholders_list(self.format)
         for x in ["open_merge_requests_count", "todos_count", "pipelines_status"]:
             self.init[x] = x in placeholders
@@ -139,9 +139,7 @@ class Py3status:
             if data:
                 gitlab_data["pipelines_status"] = data.json()[0]["status"]
 
-        for x in self.init["thresholds"]:
-            if x in gitlab_data:
-                self.py3.threshold_get_color(gitlab_data[x], x)
+        self.py3.threshold_update(gitlab_data, self.format)
 
         return {
             "cached_until": self.py3.time_in(self.cache_timeout),

--- a/py3status/modules/hddtemp.py
+++ b/py3status/modules/hddtemp.py
@@ -140,7 +140,6 @@ class Py3status:
 
         self.keys = ["path", "name", "temperature", "unit"]
         self.cache_names = {}
-        self.thresholds_init = self.py3.get_color_names_list(self.format_hdd)
 
     def hddtemp(self):
         line = self.py3.command_output("nc localhost 7634")
@@ -157,9 +156,7 @@ class Py3status:
                     key = "GB".join(key.rsplit("G B", 1))
                 hdd["name"] = self.cache_names[hdd["name"]] = key
 
-            for x in self.thresholds_init:
-                if x in hdd:
-                    self.py3.threshold_get_color(hdd[x], x)
+            self.py3.threshold_update(hdd, self.format_hdd)
 
             new_data.append(self.py3.safe_format(self.format_hdd, hdd))
 

--- a/py3status/modules/hueshift.py
+++ b/py3status/modules/hueshift.py
@@ -121,8 +121,6 @@ class Py3status:
         if not self.is_color_setter_running:
             self._set_color_temperature(delta=0)
 
-        self.thresholds_init = self.py3.get_color_names_list(self.format)
-
     def _set_color_setter_boolean(self):
         # to improve user experience, we prevent users from shifting color
         # temperature when there are running processes that can also shift
@@ -161,9 +159,7 @@ class Py3status:
             "enabled": self.is_color_setter_running,
         }
 
-        for x in self.thresholds_init:
-            if x in hue_data:
-                self.py3.threshold_get_color(hue_data[x], x)
+        self.py3.threshold_update(hue_data, self.format)
 
         return {
             "cached_until": self.py3.CACHE_FOREVER,

--- a/py3status/modules/icinga2.py
+++ b/py3status/modules/icinga2.py
@@ -63,6 +63,17 @@ class Py3status:
         if not self.base_url:
             raise Exception(STRING_NOT_CONFIGURED)
 
+    def _query_service_count(self, state):
+        url_parameters = self.url_parameters
+        if self.disable_acknowledge:
+            url_parameters = url_parameters + "&service_handled=0"
+        result = requests.get(
+            self.base_url + url_parameters.format(service_state=state),
+            auth=(self.user, self.password),
+            verify=self.ca,
+        )
+        return len(result.json())
+
     def icinga2(self):
         response = {
             "cached_until": self.py3.time_in(self.cache_timeout),
@@ -75,17 +86,6 @@ class Py3status:
             ),
         }
         return response
-
-    def _query_service_count(self, state):
-        url_parameters = self.url_parameters
-        if self.disable_acknowledge:
-            url_parameters = url_parameters + "&service_handled=0"
-        result = requests.get(
-            self.base_url + url_parameters.format(service_state=state),
-            auth=(self.user, self.password),
-            verify=self.ca,
-        )
-        return len(result.json())
 
 
 if __name__ == "__main__":

--- a/py3status/modules/imap.py
+++ b/py3status/modules/imap.py
@@ -129,42 +129,6 @@ class Py3status:
         if self.security not in ["ssl", "starttls"]:
             raise ValueError("Unknown security protocol")
 
-    def imap(self):
-        # I -- acquire mail_count
-        if self.use_idle is not False:
-            if not self.idle_thread.is_alive():
-                sleep(self.read_timeout)  # rate-limit thread-restarting (when network is offline)
-                self.idle_thread = Thread(target=self._get_mail_count)
-                self.idle_thread.daemon = True
-                self.idle_thread.start()
-        else:
-            self._get_mail_count()
-        response = {"cached_until": self.py3.time_in(self.cache_timeout)}
-        if self.mail_error is not None:
-            self.py3.log(self.mail_error, level=self.py3.LOG_ERROR)
-            self.py3.error(self.mail_error)
-            self.mail_error = None
-
-        # II -- format response
-        response["full_text"] = self.py3.safe_format(self.format, {"unseen": self.mail_count})
-
-        if self.mail_count is None:
-            response["color"] = (self.py3.COLOR_BAD,)
-            response["full_text"] = self.py3.safe_format(
-                self.format, {"unseen": STRING_UNAVAILABLE}
-            )
-        elif self.mail_count == NO_DATA_YET:
-            response["full_text"] = ""
-        elif self.mail_count == 0 and self.hide_if_zero:
-            response["full_text"] = ""
-        elif self.mail_count > 0:
-            response["color"] = self.py3.COLOR_NEW_MAIL or self.py3.COLOR_GOOD
-            response["urgent"] = self.allow_urgent
-        if self.network_error is not None and self.degraded_when_stale:
-            response["color"] = self.py3.COLOR_DEGRADED
-
-        return response
-
     def _check_if_idle(self, connection):
         supports_idle = "IDLE" in connection.capabilities
 
@@ -382,6 +346,42 @@ class Py3status:
                 break
             finally:
                 self.py3.update()  # to propagate mail_error
+
+    def imap(self):
+        # I -- acquire mail_count
+        if self.use_idle is not False:
+            if not self.idle_thread.is_alive():
+                sleep(self.read_timeout)  # rate-limit thread-restarting (when network is offline)
+                self.idle_thread = Thread(target=self._get_mail_count)
+                self.idle_thread.daemon = True
+                self.idle_thread.start()
+        else:
+            self._get_mail_count()
+        response = {"cached_until": self.py3.time_in(self.cache_timeout)}
+        if self.mail_error is not None:
+            self.py3.log(self.mail_error, level=self.py3.LOG_ERROR)
+            self.py3.error(self.mail_error)
+            self.mail_error = None
+
+        # II -- format response
+        response["full_text"] = self.py3.safe_format(self.format, {"unseen": self.mail_count})
+
+        if self.mail_count is None:
+            response["color"] = (self.py3.COLOR_BAD,)
+            response["full_text"] = self.py3.safe_format(
+                self.format, {"unseen": STRING_UNAVAILABLE}
+            )
+        elif self.mail_count == NO_DATA_YET:
+            response["full_text"] = ""
+        elif self.mail_count == 0 and self.hide_if_zero:
+            response["full_text"] = ""
+        elif self.mail_count > 0:
+            response["color"] = self.py3.COLOR_NEW_MAIL or self.py3.COLOR_GOOD
+            response["urgent"] = self.allow_urgent
+        if self.network_error is not None and self.degraded_when_stale:
+            response["color"] = self.py3.COLOR_DEGRADED
+
+        return response
 
 
 if __name__ == "__main__":

--- a/py3status/modules/kdeconnector.py
+++ b/py3status/modules/kdeconnector.py
@@ -524,20 +524,6 @@ class Py3status:
         battery = self._get_battery()
         self._set_battery_status(isCharging=battery["isCharging"], charge=battery["charge"])
 
-    def kill(self):
-        self._kill = True
-        if self._signal_reachable_changed:
-            self._signal_reachable_changed.remove()
-
-        if self._signal_battery:
-            self._signal_battery.remove()
-
-        if self._signal_notifications:
-            self._signal_notifications.remove()
-
-        if self._signal_conn_report:
-            self._signal_conn_report.remove()
-
     def kdeconnector(self):
         """
         Get the current state and return it.
@@ -566,6 +552,20 @@ class Py3status:
             "color": color,
         }
         return response
+
+    def kill(self):
+        self._kill = True
+        if self._signal_reachable_changed:
+            self._signal_reachable_changed.remove()
+
+        if self._signal_battery:
+            self._signal_battery.remove()
+
+        if self._signal_notifications:
+            self._signal_notifications.remove()
+
+        if self._signal_conn_report:
+            self._signal_conn_report.remove()
 
 
 if __name__ == "__main__":

--- a/py3status/modules/keyboard_layout.py
+++ b/py3status/modules/keyboard_layout.py
@@ -91,45 +91,6 @@ class Py3status:
             "us": "#729FCF",
         }
 
-    def keyboard_layout(self):
-        layout, variant = self._get_command()
-        # If the current layout is not in our layouts list we need to add it
-        if layout not in self._layouts:
-            self._layouts = [layout] + self.layouts
-            self._active = 0
-        # show new layout if it has been changed externally
-        if layout != self._last_layout:
-            self._active = self._layouts.index(layout)
-            self._last_layout = layout
-        lang = self._layouts[self._active]
-
-        response = {
-            "cached_until": self.py3.time_in(self.cache_timeout),
-            "full_text": self.py3.safe_format(self.format, {"layout": lang, "variant": variant}),
-        }
-
-        if self.colors and not self.colors_dict:
-            self.colors_dict = {
-                k.strip(): v.strip()
-                for k, v in (layout.split("=") for layout in self.colors.split(","))
-            }
-
-        # colorize languages containing spaces and/or dashes too
-        language = lang.upper()
-        for character in " -":
-            if character in language:
-                language = language.replace(character, "_")
-
-        lang_color = getattr(self.py3, f"COLOR_{language}")
-        if not lang_color:
-            lang_color = self.colors_dict.get(lang)
-        if not lang_color:  # old compatibility: try default value
-            lang_color = self.defaults.get(lang)
-        if lang_color:
-            response["color"] = lang_color
-
-        return response
-
     def _get_xkblayout(self):
         layout, variant = [
             x.strip()
@@ -171,6 +132,45 @@ class Py3status:
         self._active += delta
         self._active = self._active % len(self._layouts)
         self._set_command()
+
+    def keyboard_layout(self):
+        layout, variant = self._get_command()
+        # If the current layout is not in our layouts list we need to add it
+        if layout not in self._layouts:
+            self._layouts = [layout] + self.layouts
+            self._active = 0
+        # show new layout if it has been changed externally
+        if layout != self._last_layout:
+            self._active = self._layouts.index(layout)
+            self._last_layout = layout
+        lang = self._layouts[self._active]
+
+        response = {
+            "cached_until": self.py3.time_in(self.cache_timeout),
+            "full_text": self.py3.safe_format(self.format, {"layout": lang, "variant": variant}),
+        }
+
+        if self.colors and not self.colors_dict:
+            self.colors_dict = {
+                k.strip(): v.strip()
+                for k, v in (layout.split("=") for layout in self.colors.split(","))
+            }
+
+        # colorize languages containing spaces and/or dashes too
+        language = lang.upper()
+        for character in " -":
+            if character in language:
+                language = language.replace(character, "_")
+
+        lang_color = getattr(self.py3, f"COLOR_{language}")
+        if not lang_color:
+            lang_color = self.colors_dict.get(lang)
+        if not lang_color:  # old compatibility: try default value
+            lang_color = self.defaults.get(lang)
+        if lang_color:
+            response["color"] = lang_color
+
+        return response
 
     def on_click(self, event):
         button = event["button"]

--- a/py3status/modules/librelinkup.py
+++ b/py3status/modules/librelinkup.py
@@ -131,10 +131,7 @@ class Py3status:
             if not getattr(self, x):
                 raise Exception(f"missing `{x}`")
 
-        self.init = {
-            "datetimes": [],
-            "thresholds": self.py3.get_color_names_list(self.format_patient),
-        }
+        self.init = {"datetimes": []}
         for x in ["timestamp", "factory_timestamp"]:
             if self.py3.format_contains(self.format_patient, x) and x in self.format_datetime:
                 self.init["datetimes"].append(x)
@@ -181,9 +178,7 @@ class Py3status:
                 date_format = obj.strftime(self.format_datetime[x])
                 patient_data[x] = self.py3.safe_format(date_format)
 
-            for x in self.init["thresholds"]:
-                if x in patient_data:
-                    self.py3.threshold_get_color(patient_data[x], x)
+            self.py3.threshold_update(patient_data, self.format_patient)
 
             new_patient.append(self.py3.safe_format(self.format_patient, patient_data))
 

--- a/py3status/modules/loadavg.py
+++ b/py3status/modules/loadavg.py
@@ -235,7 +235,6 @@ class Py3status:
 
     def post_config_hook(self):
         self.load_data = {}
-        self.thresholds_init = self.py3.get_color_names_list(self.format)
 
     def loadavg(self):
         cpu = float(cpu_count())
@@ -244,9 +243,7 @@ class Py3status:
             self.load_data[key + "min"] = value
             self.load_data[key + "avg"] = value / cpu * 100
 
-        for x in self.thresholds_init:
-            if x in self.load_data:
-                self.py3.threshold_get_color(self.load_data[x], x)
+        self.py3.threshold_update(self.load_data, self.format)
 
         return {
             "cached_until": self.py3.time_in(self.cache_timeout),

--- a/py3status/modules/mail.py
+++ b/py3status/modules/mail.py
@@ -224,8 +224,6 @@ class Py3status:
                             self.mailboxes[mail].append(account)
                             break
 
-        self.thresholds_init = self.py3.get_color_names_list(self.format)
-
     def mail(self):
         mail_data = {"mail": 0, "urgent": False}
         for k, v in self.mailboxes.items():
@@ -288,9 +286,7 @@ class Py3status:
                 mail_data["mail"] += count_mail
                 mail_data[k] += count_mail
 
-        for x in self.thresholds_init:
-            if x in mail_data:
-                self.py3.threshold_get_color(mail_data[x], x)
+        self.py3.threshold_update(mail_data, self.format)
 
         self.first_run = False
 

--- a/py3status/modules/mpd_status.py
+++ b/py3status/modules/mpd_status.py
@@ -165,41 +165,6 @@ class Py3status:
             return self.state_stop
         return "?"
 
-    def mpd_status(self):
-        # I - get current mpd status (or wait until it changes)
-        # this writes into self.current_status
-        if self.use_idle is not False:
-            if not self.idle_thread.is_alive():
-                sleep(self.cache_timeout)  # rate limit thread restarting
-                self.idle_thread = Thread(target=self._get_status)
-                self.idle_thread.daemon = True
-                self.idle_thread.start()
-        else:
-            self._get_status()
-
-        # II - format response
-        text, state = ("", "")
-        if self.current_status is not None:
-            text, state = self.current_status
-
-        if len(text) > self.max_width:
-            text = "{}...".format(text[: self.max_width - 3])
-
-        response = {
-            "cached_until": self.py3.time_in(self.cache_timeout),
-            "full_text": text if state or not self.hide_on_error else "",
-        }
-
-        if state:
-            if state == "play":
-                response["color"] = self.py3.COLOR_PLAY or self.py3.COLOR_GOOD
-            elif state == "pause":
-                response["color"] = self.py3.COLOR_PAUSE or self.py3.COLOR_DEGRADED
-            elif state == "stop":
-                response["color"] = self.py3.COLOR_STOP or self.py3.COLOR_BAD
-
-        return response
-
     def _get_status(self):
         while True:
             try:
@@ -262,6 +227,41 @@ class Py3status:
                 return
             finally:
                 self.py3.update()  # to propagate error message
+
+    def mpd_status(self):
+        # I - get current mpd status (or wait until it changes)
+        # this writes into self.current_status
+        if self.use_idle is not False:
+            if not self.idle_thread.is_alive():
+                sleep(self.cache_timeout)  # rate limit thread restarting
+                self.idle_thread = Thread(target=self._get_status)
+                self.idle_thread.daemon = True
+                self.idle_thread.start()
+        else:
+            self._get_status()
+
+        # II - format response
+        text, state = ("", "")
+        if self.current_status is not None:
+            text, state = self.current_status
+
+        if len(text) > self.max_width:
+            text = "{}...".format(text[: self.max_width - 3])
+
+        response = {
+            "cached_until": self.py3.time_in(self.cache_timeout),
+            "full_text": text if state or not self.hide_on_error else "",
+        }
+
+        if state:
+            if state == "play":
+                response["color"] = self.py3.COLOR_PLAY or self.py3.COLOR_GOOD
+            elif state == "pause":
+                response["color"] = self.py3.COLOR_PAUSE or self.py3.COLOR_DEGRADED
+            elif state == "stop":
+                response["color"] = self.py3.COLOR_STOP or self.py3.COLOR_BAD
+
+        return response
 
     def kill(self):
         if self.idle_thread.is_alive():

--- a/py3status/modules/mpris.py
+++ b/py3status/modules/mpris.py
@@ -678,11 +678,6 @@ class Py3status:
         if update:
             self.py3.update()
 
-    def kill(self):
-        self._kill = True
-        if self._name_owner_change_match:
-            self._dbus._clean_up_signal_match(self._name_owner_change_match)
-
     def mpris(self):
         """
         Get the current output format and return it.
@@ -746,6 +741,11 @@ class Py3status:
             "composite": composite,
         }
         return response
+
+    def kill(self):
+        self._kill = True
+        if self._name_owner_change_match:
+            self._dbus._clean_up_signal_match(self._name_owner_change_match)
 
     def on_click(self, event):
         """

--- a/py3status/modules/net_iplist.py
+++ b/py3status/modules/net_iplist.py
@@ -78,6 +78,36 @@ class Py3status:
         self.ip_re = re.compile(r"\s+inet (?P<ip4>[\d.]+)(?:/| )")
         self.ip6_re = re.compile(r"\s+inet6 (?P<ip6>[\da-f:]+)(?:/\d{1,3}| ) scope global dynamic")
 
+    def _get_data(self):
+        txt = self.py3.command_output(["ip", "address", "show"]).splitlines()
+
+        data = {}
+        for line in txt:
+            iface = self.iface_re.match(line)
+            if iface:
+                cur_iface = iface.group("iface")
+                if not self.remove_empty:
+                    data[cur_iface] = {}
+                continue
+
+            ip4 = self.ip_re.match(line)
+            if ip4:
+                data.setdefault(cur_iface, {}).setdefault("ip4", []).append(ip4.group("ip4"))
+                continue
+
+            ip6 = self.ip6_re.match(line)
+            if ip6:
+                data.setdefault(cur_iface, {}).setdefault("ip6", []).append(ip6.group("ip6"))
+                continue
+
+        return data
+
+    def _check_blacklist(self, string, blacklist):
+        for ignore in blacklist:
+            if fnmatch(string, ignore):
+                return False
+        return True
+
     def net_iplist(self):
         response = {
             "cached_until": self.py3.time_in(seconds=self.cache_timeout),
@@ -125,36 +155,6 @@ class Py3status:
             response["color"] = self.py3.COLOR_GOOD
 
         return response
-
-    def _get_data(self):
-        txt = self.py3.command_output(["ip", "address", "show"]).splitlines()
-
-        data = {}
-        for line in txt:
-            iface = self.iface_re.match(line)
-            if iface:
-                cur_iface = iface.group("iface")
-                if not self.remove_empty:
-                    data[cur_iface] = {}
-                continue
-
-            ip4 = self.ip_re.match(line)
-            if ip4:
-                data.setdefault(cur_iface, {}).setdefault("ip4", []).append(ip4.group("ip4"))
-                continue
-
-            ip6 = self.ip6_re.match(line)
-            if ip6:
-                data.setdefault(cur_iface, {}).setdefault("ip6", []).append(ip6.group("ip6"))
-                continue
-
-        return data
-
-    def _check_blacklist(self, string, blacklist):
-        for ignore in blacklist:
-            if fnmatch(string, ignore):
-                return False
-        return True
 
 
 if __name__ == "__main__":

--- a/py3status/modules/net_rate.py
+++ b/py3status/modules/net_rate.py
@@ -104,6 +104,43 @@ class Py3status:
 
         self.thresholds_init = self.py3.get_color_names_list(self.format)
 
+    def _get_stat(self):
+        """
+        Get statistics from devfile in list of lists of words
+        """
+
+        def dev_filter(x):
+            # get first word and remove trailing interface number
+            x = x.strip().split(" ")[0][:-1]
+
+            if x in self.interfaces_blacklist:
+                return False
+
+            if self.all_interfaces:
+                return True
+
+            if x in self.interfaces:
+                return True
+
+            return False
+
+        # read devfile, skip two header files
+        x = filter(dev_filter, open(self.devfile).readlines()[2:])
+
+        try:
+            # split info into words
+            return [_x.split() for _x in x]
+
+        except StopIteration:
+            return None
+
+    def _format_value(self, value):
+        """
+        Return formatted string
+        """
+        value, unit = self.py3.format_units(value, unit=self.unit, si=self.si_units)
+        return self.py3.safe_format(self.format_value, {"value": value, "unit": unit})
+
     def net_rate(self):
         network_stat = self._get_stat()
         deltas = {}
@@ -182,43 +219,6 @@ class Py3status:
             )
 
         return response
-
-    def _get_stat(self):
-        """
-        Get statistics from devfile in list of lists of words
-        """
-
-        def dev_filter(x):
-            # get first word and remove trailing interface number
-            x = x.strip().split(" ")[0][:-1]
-
-            if x in self.interfaces_blacklist:
-                return False
-
-            if self.all_interfaces:
-                return True
-
-            if x in self.interfaces:
-                return True
-
-            return False
-
-        # read devfile, skip two header files
-        x = filter(dev_filter, open(self.devfile).readlines()[2:])
-
-        try:
-            # split info into words
-            return [_x.split() for _x in x]
-
-        except StopIteration:
-            return None
-
-    def _format_value(self, value):
-        """
-        Return formatted string
-        """
-        value, unit = self.py3.format_units(value, unit=self.unit, si=self.si_units)
-        return self.py3.safe_format(self.format_value, {"value": value, "unit": unit})
 
 
 if __name__ == "__main__":

--- a/py3status/modules/net_rate.py
+++ b/py3status/modules/net_rate.py
@@ -102,8 +102,6 @@ class Py3status:
         self.last_stat = self._get_stat()
         self.last_time = time.monotonic()
 
-        self.thresholds_init = self.py3.get_color_names_list(self.format)
-
     def _get_stat(self):
         """
         Get statistics from devfile in list of lists of words
@@ -204,9 +202,7 @@ class Py3status:
         elif not interface:
             response["full_text"] = self.format_no_connection
         else:
-            for x in self.thresholds_init:
-                if x in delta:
-                    self.py3.threshold_get_color(delta[x], x)
+            self.py3.threshold_update(delta, self.format)
 
             response["full_text"] = self.py3.safe_format(
                 self.format,

--- a/py3status/modules/netdata.py
+++ b/py3status/modules/netdata.py
@@ -118,7 +118,6 @@ class Py3status:
                 self.nic = "lo"
             self.py3.log(f"selected nic: {self.nic}")
 
-        self.thresholds_init = self.py3.get_color_names_list(self.format)
         self.last_received_bytes, self.last_transmitted_bytes = self._get_bytes()
         self.last_time = time.monotonic()
 
@@ -155,9 +154,7 @@ class Py3status:
             "nic": self.nic,
         }
 
-        for x in self.thresholds_init:
-            if x in net_data:
-                self.py3.threshold_get_color(net_data[x], x)
+        self.py3.threshold_update(net_data, self.format)
 
         return {
             "cached_until": self.py3.time_in(self.cache_timeout),

--- a/py3status/modules/networkmanager.py
+++ b/py3status/modules/networkmanager.py
@@ -101,7 +101,6 @@ class Py3status:
         ).split()
         self.caches = {"lines": {}, "devices": {}}
         self.devices = {"list": [], "devices": self.devices}
-        self.thresholds_init = self.py3.get_color_names_list(self.format_device)
 
     def _update_key(self, key):
         for old, new in [("[", ""), ("]", ""), (".", "_"), ("-", "_")]:
@@ -161,9 +160,7 @@ class Py3status:
                         current_ap[key.replace(used_ap + "_", "ap_")] = device[key]
                 device.update(current_ap)
 
-            for x in self.thresholds_init:
-                if x in device:
-                    self.py3.threshold_get_color(device[x], x)
+            self.py3.threshold_update(device, self.format_device)
 
             new_device.append(self.py3.safe_format(self.format_device, device))
 

--- a/py3status/modules/nvidia_smi.py
+++ b/py3status/modules/nvidia_smi.py
@@ -116,8 +116,6 @@ class Py3status:
         self.memory_unit = self.memory_unit or "B"
         self.nvidia_command = command + ",".join(self.properties)
 
-        self.thresholds_init = self.py3.get_color_names_list(self.format_gpu)
-
     def _get_nvidia_data(self):
         return self.py3.command_output(self.nvidia_command)
 
@@ -136,9 +134,7 @@ class Py3status:
                 value, unit_value = self.py3.format_units(value, self.memory_unit)
                 gpu.update({key: value, unit_key: unit_value})
 
-            for x in self.thresholds_init:
-                if x in gpu:
-                    self.py3.threshold_get_color(gpu[x], x)
+            self.py3.threshold_update(gpu, self.format_gpu)
 
             new_gpu.append(self.py3.safe_format(self.format_gpu, gpu))
 

--- a/py3status/modules/playerctl.py
+++ b/py3status/modules/playerctl.py
@@ -130,7 +130,6 @@ class Py3status:
     def post_config_hook(self):
         # Initialize module settings
         self._setup_buttons()
-        self.thresholds_init = self.py3.get_color_names_list(self.format_player)
         self.replacements_init = self.py3.get_replacements_list(self.format_player)
         self.position = self.py3.format_contains(self.format_player, "position")
         self.cache_timeout = getattr(self, "cache_timeout", 1)
@@ -340,9 +339,7 @@ class Py3status:
                     player_data[x] = self.py3.replace(player_data[x], x)
 
             # Set the color of a player
-            for key in self.thresholds_init:
-                if key in player_data:
-                    self.py3.threshold_get_color(player_data[key], key)
+            self.py3.threshold_update(player_data, self.format_player)
 
             format_player = self.py3.safe_format(self.format_player, player_data)
             self.py3.composite_update(format_player, {"index": player_data["player"]})

--- a/py3status/modules/pomodoro.py
+++ b/py3status/modules/pomodoro.py
@@ -171,49 +171,6 @@ class Py3status:
             self._section_time = self.timer_pomodoro
             self._active = True
 
-    def kill(self):
-        """
-        cancel any timer
-        """
-        if self._timer:
-            self._timer.cancel()
-
-    def on_click(self, event):
-        """
-        Handles click events:
-            - left click starts an inactive counter and pauses a running
-              Pomodoro
-            - middle click resets everything
-            - right click starts (and ends, if needed) a break
-        """
-        if event["button"] == 1:
-            if self._running:
-                self._running = False
-                self._time_left = self._end_time - time.monotonic()
-                if self._timer:
-                    self._timer.cancel()
-            else:
-                self._running = True
-                self._end_time = time.monotonic() + self._time_left
-                if self._timer:
-                    self._timer.cancel()
-                self._timer = Timer(self._time_left, self._time_up)
-                self._timer.start()
-                if self._active:
-                    self.py3.play_sound(self.sound_pomodoro_start)
-
-        elif event["button"] == 2:
-            # reset
-            self._init()
-            if self._timer:
-                self._timer.cancel()
-
-        elif event["button"] == 3:
-            # advance
-            self._advance(user_action=True)
-            if self._timer:
-                self._timer.cancel()
-
     def _setup_bar(self):
         """
         Setup the process bar.
@@ -297,6 +254,47 @@ class Py3status:
                 response["color"] = self.py3.COLOR_DEGRADED
 
         return response
+
+    def kill(self):
+        """
+        cancel any timer
+        """
+        if self._timer:
+            self._timer.cancel()
+
+    def on_click(self, event):
+        """
+        Left click starts an inactive counter and pauses a running Pomodoro
+        Middle click resets everything
+        Right click starts (and ends, if needed) a break
+        """
+        if event["button"] == 1:
+            if self._running:
+                self._running = False
+                self._time_left = self._end_time - time.monotonic()
+                if self._timer:
+                    self._timer.cancel()
+            else:
+                self._running = True
+                self._end_time = time.monotonic() + self._time_left
+                if self._timer:
+                    self._timer.cancel()
+                self._timer = Timer(self._time_left, self._time_up)
+                self._timer.start()
+                if self._active:
+                    self.py3.play_sound(self.sound_pomodoro_start)
+
+        elif event["button"] == 2:
+            # reset
+            self._init()
+            if self._timer:
+                self._timer.cancel()
+
+        elif event["button"] == 3:
+            # advance
+            self._advance(user_action=True)
+            if self._timer:
+                self._timer.cancel()
 
 
 if __name__ == "__main__":

--- a/py3status/modules/prometheus.py
+++ b/py3status/modules/prometheus.py
@@ -59,6 +59,15 @@ class Py3status:
     server = None
     units = None
 
+    def _query(self, query):
+        r = self.py3.request(self.server + "/api/v1/query", params={"query": query})
+        if r.status_code != 200:
+            return []
+        r = r.json()
+        if r["status"] != "success" or r["data"]["resultType"] != "vector":
+            return []
+        return r["data"]["result"]
+
     def prometheus(self):
         self._rows = []
         self._rownum = 0
@@ -92,15 +101,6 @@ class Py3status:
                 if getattr(self.py3, entry):
                     ret["color"] = getattr(self.py3, entry)
         return ret
-
-    def _query(self, query):
-        r = self.py3.request(self.server + "/api/v1/query", params={"query": query})
-        if r.status_code != 200:
-            return []
-        r = r.json()
-        if r["status"] != "success" or r["data"]["resultType"] != "vector":
-            return []
-        return r["data"]["result"]
 
 
 if __name__ == "__main__":

--- a/py3status/modules/rate_counter.py
+++ b/py3status/modules/rate_counter.py
@@ -61,7 +61,7 @@ class Py3status:
         self.config_file = Path(self.config_file).expanduser()
         self.running = False
         self.saved_time = 0
-        self.start_time = self.current_time
+        self.start_time = self._current_time
         try:
             # Use file to refer to the file object
             with self.config_file.open() as file:
@@ -72,7 +72,7 @@ class Py3status:
             pass
 
     @property
-    def current_time(self):
+    def _current_time(self):
         """Get the current time.
 
         Using a helper property to make it easy to keep consistency.
@@ -80,7 +80,7 @@ class Py3status:
         return time.monotonic()
 
     @staticmethod
-    def secs_to_dhms(time_in_secs):
+    def _secs_to_dhms(time_in_secs):
         """Convert seconds to days, hours, minutes, seconds.
 
         Using days as the largest unit of time.  Blindly using the days in
@@ -93,12 +93,12 @@ class Py3status:
 
     def _start_timer(self):
         if not self.running:
-            self.start_time = self.current_time - self.saved_time
+            self.start_time = self._current_time - self.saved_time
             self.running = True
 
     def _stop_timer(self):
         if self.running:
-            self.saved_time = self.current_time - self.start_time
+            self.saved_time = self._current_time - self.start_time
             self.running = False
 
     def _toggle_timer(self):
@@ -106,17 +106,6 @@ class Py3status:
             self._stop_timer()
         else:
             self._start_timer()
-
-    def kill(self):
-        self._stop_timer()
-        with self.config_file.open("w") as f:
-            f.write(str(self.saved_time))
-
-    def on_click(self, event):
-        if event["button"] == 1:
-            self._toggle_timer()
-        elif event["button"] == 3:
-            self._reset()
 
     def _reset(self):
         if not self.running:
@@ -128,12 +117,12 @@ class Py3status:
         running_time = 0.0
         if self.running:
             color = self.py3.COLOR_RUNNING or self.py3.COLOR_GOOD
-            running_time = self.current_time - self.start_time
+            running_time = self._current_time - self.start_time
         else:
             color = self.py3.COLOR_STOPPED or self.py3.COLOR_BAD
             running_time = self.saved_time
 
-        days, hours, mins, secs = self.secs_to_dhms(running_time)
+        days, hours, mins, secs = self._secs_to_dhms(running_time)
         subtotal = self.hour_price * running_time / SECS_IN_HOUR
         total = subtotal * float(self.tax)
         subtotal_cost = self.py3.safe_format(self.format_money, {"price": f"{subtotal:.2f}"})
@@ -158,6 +147,17 @@ class Py3status:
             ),
         }
         return response
+
+    def kill(self):
+        self._stop_timer()
+        with self.config_file.open("w") as f:
+            f.write(str(self.saved_time))
+
+    def on_click(self, event):
+        if event["button"] == 1:
+            self._toggle_timer()
+        elif event["button"] == 3:
+            self._reset()
 
 
 if __name__ == "__main__":

--- a/py3status/modules/rss_aggregator.py
+++ b/py3status/modules/rss_aggregator.py
@@ -74,26 +74,6 @@ class Py3status:
         if self.user is None or self.password is None:
             raise ValueError("user and password must be provided")
 
-    def rss_aggregator(self):
-        if self.aggregator == "owncloud":
-            rss_count = self._get_count_owncloud()
-        elif self.aggregator == "ttrss":
-            rss_count = self._get_count_ttrss()
-
-        self._cached = self._cached if rss_count is None else rss_count
-
-        response = {
-            "cached_until": self.py3.time_in(self.cache_timeout),
-            "full_text": self.py3.safe_format(self.format, {"unseen": self._cached}),
-        }
-
-        if rss_count is None:
-            response["color"] = self.py3.COLOR_ERROR or self.py3.COLOR_BAD
-        elif rss_count != 0:
-            response["color"] = self.py3.COLOR_NEW_ITEMS or self.py3.COLOR_GOOD
-
-        return response
-
     def _get_count_owncloud(self):
         try:
             rss_count = 0
@@ -153,6 +133,27 @@ class Py3status:
 
         except:  # noqa e722
             return None
+
+    def rss_aggregator(self):
+        rss_count = None
+        if self.aggregator == "owncloud":
+            rss_count = self._get_count_owncloud()
+        elif self.aggregator == "ttrss":
+            rss_count = self._get_count_ttrss()
+
+        self._cached = self._cached if rss_count is None else rss_count
+
+        response = {
+            "cached_until": self.py3.time_in(self.cache_timeout),
+            "full_text": self.py3.safe_format(self.format, {"unseen": self._cached}),
+        }
+
+        if rss_count is None:
+            response["color"] = self.py3.COLOR_ERROR or self.py3.COLOR_BAD
+        elif rss_count != 0:
+            response["color"] = self.py3.COLOR_NEW_ITEMS or self.py3.COLOR_GOOD
+
+        return response
 
 
 if __name__ == "__main__":

--- a/py3status/modules/scratchpad.py
+++ b/py3status/modules/scratchpad.py
@@ -173,14 +173,10 @@ class Py3status:
         else:
             raise Exception(STRING_ERROR.format(self.ipc))
 
-        self.thresholds_init = self.py3.get_color_names_list(self.format)
-
     def scratchpad(self):
         scratchpad_data = self.backend.get_scratchpad_data()
 
-        for x in self.thresholds_init:
-            if x in scratchpad_data:
-                self.py3.threshold_get_color(scratchpad_data[x], x)
+        self.py3.threshold_update(scratchpad_data, self.format)
 
         response = {
             "cached_until": self.py3.time_in(self.cache_timeout),

--- a/py3status/modules/speedtest.py
+++ b/py3status/modules/speedtest.py
@@ -178,7 +178,6 @@ class Py3status:
         self.placeholders = self.py3.get_placeholders_list(self.format)
         self.speedtest_data = self.py3.storage_get("speedtest_data") or {}
         self.thread = None
-        self.thresholds_init = self.py3.get_color_names_list(self.format)
 
         # remove elapsed_time
         if "elapsed_time" in self.placeholders:
@@ -228,9 +227,7 @@ class Py3status:
             self.py3.storage_set("speedtest_data", self.speedtest_data)
 
         # thresholds
-        for x in self.thresholds_init:
-            if x in self.speedtest_data:
-                self.py3.threshold_get_color(self.speedtest_data[x], x)
+        self.py3.threshold_update(self.speedtest_data, self.format)
 
         return {
             "cached_until": self.py3.time_in(cached_until),

--- a/py3status/modules/spotify.py
+++ b/py3status/modules/spotify.py
@@ -86,6 +86,9 @@ class Py3status:
     format_stopped = "Spotify stopped"
     replacements = None
 
+    def post_config_hook(self):
+        self.replacements_init = self.py3.get_replacements_list(self.format)
+
     def _spotify_cmd(self, action):
         return SPOTIFY_CMD.format(dbus_client=self.dbus_client, cmd=action)
 
@@ -137,9 +140,6 @@ class Py3status:
             return (self.py3.safe_format(self.format, spotify_data), color)
         except Exception:
             return (self.format_down, self.py3.COLOR_OFFLINE or self.py3.COLOR_BAD)
-
-    def post_config_hook(self):
-        self.replacements_init = self.py3.get_replacements_list(self.format)
 
     def spotify(self):
         """

--- a/py3status/modules/sql.py
+++ b/py3status/modules/sql.py
@@ -123,10 +123,6 @@ class Py3status:
         if not self.is_parameters_a_dict:
             self.parameters = Path(self.parameters).expanduser()
 
-        self.thresholds_init = {}
-        for name in ("format", "format_row"):
-            self.thresholds_init[name] = self.py3.get_color_names_list(getattr(self, name))
-
     def _get_sql_data(self):
         if self.is_parameters_a_dict:
             connection = self.connect(**self.parameters)
@@ -153,9 +149,7 @@ class Py3status:
             new_data = []
             count_row = len(data)
             for row in data:
-                for x in self.thresholds_init["format_row"]:
-                    if x in row:
-                        self.py3.threshold_get_color(row[x], x)
+                self.py3.threshold_update(row, self.format_row)
 
                 new_data.append(self.py3.safe_format(self.format_row, row))
 
@@ -163,9 +157,7 @@ class Py3status:
             format_row = self.py3.composite_join(format_separator, new_data)
             sql_data.update({"row": count_row, "format_row": format_row})
 
-            for x in self.thresholds_init["format"]:
-                if x in sql_data:
-                    self.py3.threshold_get_color(sql_data[x], x)
+            self.py3.threshold_update(sql_data, self.format)
 
         return {
             "cached_until": self.py3.time_in(self.cache_timeout),

--- a/py3status/modules/sysdata.py
+++ b/py3status/modules/sysdata.py
@@ -261,7 +261,6 @@ class Py3status:
 
         self.thresholds_init = {
             "format": self.py3.get_color_names_list(self.format),
-            "format_cpu": self.py3.get_color_names_list(self.format_cpu),
             "legacy": {
                 "cpu": "cpu_used_percent",
                 "temp": "cpu_temp",
@@ -479,9 +478,7 @@ class Py3status:
                 new_cpu = []
                 for cpu in self._filter_stat(stat):
                     cpu = dict(zip(cpu_keys, [cpu[0], self._calc_cpu_percent(cpu)]))
-                    for x in self.thresholds_init["format_cpu"]:
-                        if x in cpu:
-                            self.py3.threshold_get_color(cpu[x], x)
+                    self.py3.threshold_update(cpu, self.format_cpu)
                     new_cpu.append(self.py3.safe_format(self.format_cpu, cpu))
 
                 format_cpu_separator = self.py3.safe_format(self.format_cpu_separator)
@@ -532,10 +529,11 @@ class Py3status:
             [perc for name, perc in sys.items() if "used_percent" in name]
         )
 
+        self.py3.threshold_update(sys, self.format)
         for x in self.thresholds_init["format"]:
             if x in sys:
-                self.py3.threshold_get_color(sys[x], x)
-            elif x in self.thresholds_init["legacy"]:
+                continue
+            if x in self.thresholds_init["legacy"]:
                 y = self.thresholds_init["legacy"][x]
                 if y in sys:
                     self.py3.threshold_get_color(sys[y], x)

--- a/py3status/modules/systemd_suspend_inhibitor.py
+++ b/py3status/modules/systemd_suspend_inhibitor.py
@@ -51,14 +51,11 @@ class Py3status:
             raise Exception(STRING_DBUS_EXCEPTION)
         self.lock = None
         self.lock_types = ":".join(self.lock_types)
-        self.thresholds_init = self.py3.get_color_names_list(self.format)
 
     def systemd_suspend_inhibitor(self):
         suspend_data = {"state": bool(self.lock)}
 
-        for x in self.thresholds_init:
-            if x in suspend_data:
-                self.py3.threshold_get_color(suspend_data[x], x)
+        self.py3.threshold_update(suspend_data, self.format)
 
         return {
             "cached_until": self.py3.CACHE_FOREVER,

--- a/py3status/modules/taskwarrior.py
+++ b/py3status/modules/taskwarrior.py
@@ -58,19 +58,19 @@ class Py3status:
             self.taskwarrior_command += " " + self.report
 
     @staticmethod
-    def descriptions(tasks_json):
+    def _descriptions(tasks_json):
         return ", ".join(f"{t['id']} {t['description']}" for t in tasks_json)
 
     @staticmethod
-    def tasks(tasks_json):
+    def _tasks(tasks_json):
         return len(tasks_json)
 
     def taskwarrior(self):
         tasks_json = json.loads(self.py3.command_output(self.taskwarrior_command))
         taskwarrior_data = {}
         for ph in self.placeholders:
-            if hasattr(self, ph):
-                ph_func = getattr(self, ph)
+            ph_func = getattr(self, f"_{ph}", None)
+            if ph_func:
                 taskwarrior_data[ph] = ph_func(tasks_json)
         return {
             "cached_until": self.py3.time_in(self.cache_timeout),

--- a/py3status/modules/thunderbird_todos.py
+++ b/py3status/modules/thunderbird_todos.py
@@ -1,0 +1,259 @@
+"""
+Display number of todos and more for Thunderbird.
+
+Configuration parameters:
+    cache_timeout: refresh interval for this module (default 60)
+    format: display format for this module (default '{format_todo}')
+    format_datetime: specify strftime formatting to use (default {})
+    format_separator: show separator if more than one (default ' ')
+    format_todo: display format for todos
+        (default '\\?if=!todo_completed {title}')
+    profile: specify a profile path, otherwise first available profile
+        eg '~/.thunderbird/abcd1234.default' (default None)
+    sort: specify a tuple, eg ('placeholder_name', reverse_boolean)
+        to sort by; excluding placeholder indexes (default ())
+    thresholds: specify color thresholds to use (default [])
+
+Format placeholders:
+    {todo_total}        eg 5
+    {todo_completed}    eg 2
+    {todo_incompleted}  eg 3
+    {format_todo}       format for todos
+
+format_todo placeholders:
+    {index_total}       eg 1, 2, 3
+    {index_completed}   eg 1, 2, 3
+    {index_incompleted} eg 1, 2, 3
+    {alarm_last_ack}    eg None, 1513291952000000
+    {cal_id}            eg 966bd855-5e71-4168-8072-c98f244ed825
+    {flags}             eg 4, 276
+    {ical_status}       eg None, IN-PROCESS, COMPLETED
+    {id}                eg 87e9bfc9-eaad-4aa6-ad5f-adbf6d7a11a5
+    {last_modified}     eg 1513276147000000
+    {offline_journal}   eg None
+    {priority}          eg None, # None=None, 0=None, 1=High, 5=Normal, 9=Low
+    {privacy}           eg None, CONFIDENTIAL
+    {recurrence_id}     eg None
+    {recurrence_id_tz}  eg None, UTC
+    {time_created}      eg 1513276147000000
+    {title}             eg New Task
+    {todo_complete}     eg None
+    {todo_completed}    eg None, 1513281528000000
+    {todo_completed_tz} eg None, UTC
+    {todo_due}          eg None, 1513292400000000
+    {todo_due_tz}       eg None, America/Chicago
+    {todo_entry}        eg None, 1513292400000000
+    {todo_entry_tz}     eg None, America/Chicago
+    {todo_stamp}        eg 1513276147000000
+
+format_datetime placeholders:
+    KEY: alarm_last_ack, last_modified, time_created, todo,
+        todo_completed, todo_entry, todo_stamp
+    VALUE: % strftime characters to be translated, eg '%b %d' ----> 'Dec 14'
+    SEE EXAMPLE BELOW: "show incompleted titles with last modified time"
+
+Color thresholds:
+    xxx: print a color based on the value of `xxx` placeholder
+
+Requires:
+    thunderbird: standalone mail and news reader
+
+Examples:
+```
+# show number of incompleted titles
+thunderbird_todos {
+    format = '{todo_incompleted} incompleted todos'
+}
+
+# show rainbow number of incompleted titles
+thunderbird_todos {
+    format = '\\?color=todo_incompleted {todo_incompleted} todos'
+    thresholds = [
+        (1, '#bababa'), (2, '#ffb3ba'), (3, '#ffdfba'), (4, '#ffffba'),
+        (5, '#baefba'), (6, '#baffc9'), (7, '#bae1ff'), (8, '#bab3ff')
+    ]
+}
+
+# show rainbow incompleted titles
+thunderbird_todos {
+    format_todo = '\\?if=!todo_completed&color=index_incompleted {title}'
+    thresholds = [
+        (1, '#bababa'), (2, '#ffb3ba'), (3, '#ffdfba'), (4, '#ffffba'),
+        (5, '#baefba'), (6, '#baffc9'), (7, '#bae1ff'), (8, '#bab3ff')
+    ]
+}
+
+# show incompleted titles with last modified time
+thunderbird_todos {
+    format_todo = '\\?if=!todo_completed {title} {last_modified}'
+    format_datetime = {
+        'last_modified': '\\?color=degraded last modified %-I:%M%P'
+    }
+}
+
+# show 'No todos'
+thunderbird_todos {
+    format = '{format_todo}|No todos'
+}
+
+# show completed titles and incompleted titles
+thunderbird_todos {
+    format_todo = '\\?if=todo_completed&color=good {title}|\\?color=bad {title}'
+}
+
+# make todo blocks
+thunderbird_todos {
+    format = 'TODO {format_todo}'
+    format_todo = '\\?if=todo_completed&color=good \u25b0|\\?color=bad \u25b0'
+    format_separator = ''
+}
+
+# display incompleted titles with any priority
+thunderbird_todos {
+    format_todo = '\\?if=!todo_completed [\\?if=priority>0 {title}]'
+}
+
+# colorize titles based on priorities
+thunderbird_todos {
+    format_todo = '\\?if=!todo_completed [\\?color=priority {title}]'
+    thresholds = [(0, None), (1, 'red'), (5, None), (9, 'deepskyblue')]
+}
+
+# sort todos
+thunderbird_todos {
+    sort = ('last_modified', True) # sort by modified time: recent first
+    sort = ('priority', True)      # sort by priority: high to low
+    sort = ('title', False)        # sort by title: ABC to abc
+}
+
+# add your snippets here
+thunderbird_todos {
+    format = '...'
+}
+```
+
+@author mrt-prodz, lasers
+
+SAMPLE OUTPUT
+{'full_text': 'New Task 1, New Task 2'}
+"""
+
+from datetime import datetime
+from pathlib import Path
+from sqlite3 import connect
+
+STRING_NO_PROFILE = "missing profile"
+STRING_NOT_INSTALLED = "not installed"
+
+
+class Py3status:
+    """ """
+
+    # available configuration parameters
+    cache_timeout = 60
+    format = "{format_todo}"
+    format_datetime = {}
+    format_separator = " "
+    format_todo = r"\?if=!todo_completed {title}"
+    profile = None
+    sort = ()
+    thresholds = []
+
+    def post_config_hook(self):
+        if not self.py3.check_commands("thunderbird"):
+            raise Exception(STRING_NOT_INSTALLED)
+
+        # first profile, please.
+        if not self.profile:
+            directory = Path("~/.thunderbird").expanduser()
+            profile_ini = directory / "profiles.ini"
+            profile = []
+            with profile_ini.open() as f:
+                for line in f:
+                    if line.startswith("Path="):
+                        profile.append("{}/{}".format(directory, line.split("Path=")[-1].strip()))
+            if not len(profile):
+                raise Exception(STRING_NO_PROFILE)
+            self.profile = profile[0]
+
+        self.profile = Path(self.profile).expanduser()
+        self.path = self.profile / "calendar-data/local.sqlite"
+
+        self.init_datetimes = []
+        for word in self.format_datetime:
+            if (self.py3.format_contains(self.format_todo, word)) and (
+                word in self.format_datetime
+            ):
+                self.init_datetimes.append(word)
+
+    def _get_thunderbird_todos_data(self):
+        connection = connect(self.path)
+        cursor = connection.cursor()
+        cursor.execute("SELECT * FROM cal_todos")
+        keys = [desc[0] for desc in cursor.description]
+        todos_data = cursor.fetchall()
+        cursor.close()
+        connection.close()
+        return [dict(zip(keys, values)) for values in todos_data]
+
+    def _organize(self, data):
+        # sort?
+        if self.sort:
+            data = sorted(data, key=lambda k: k[self.sort[0]], reverse=self.sort[1])
+        # counts and indexes
+        count = {"todo_total": 0, "todo_completed": 0, "todo_incompleted": 0}
+        for todo_index, todo in enumerate(data, 1):
+            count["todo_total"] += 1
+            todo["index_total"] = todo_index
+            todo["index_completed"] = todo["index_incompleted"] = None
+            if todo["todo_completed"]:
+                count["todo_completed"] += 1
+                todo["index_completed"] = count["todo_completed"]
+            else:
+                count["todo_incompleted"] += 1
+                todo["index_incompleted"] = count["todo_incompleted"]
+
+        return data, count
+
+    def _manipulate(self, data, count):
+        new_data = []
+        for todo in data:
+            # datetimes
+            for k in self.init_datetimes:
+                if k in todo:
+                    todo[k] = self.py3.safe_format(
+                        datetime.strftime(
+                            datetime.fromtimestamp(float(str(todo[k])[:-6])),
+                            self.format_datetime[k],
+                        )
+                    )
+            # thresholds
+            self.py3.threshold_update(todo, self.format_todo)
+
+            new_data.append(self.py3.safe_format(self.format_todo, todo))
+
+        self.py3.threshold_update(count, self.format)
+
+        format_separator = self.py3.safe_format(self.format_separator)
+        format_todo = self.py3.composite_join(format_separator, new_data)
+
+        return format_todo
+
+    def thunderbird_todos(self):
+        todo_data = self._get_thunderbird_todos_data()
+        data, count = self._organize(todo_data)
+        format_todo = self._manipulate(data, count)
+
+        return {
+            "cached_until": self.py3.time_in(self.cache_timeout),
+            "full_text": self.py3.safe_format(self.format, dict(format_todo=format_todo, **count)),
+        }
+
+
+if __name__ == "__main__":
+    """
+    Run module in test mode.
+    """
+    from py3status.module_test import module_test
+
+    module_test(Py3status)

--- a/py3status/modules/timer.py
+++ b/py3status/modules/timer.py
@@ -128,6 +128,11 @@ class Py3status:
             response["urgent"] = True
         return response
 
+    def kill(self):
+        # remove any timer
+        if self.alarm_timer:
+            self.alarm_timer.cancel()
+
     def on_click(self, event):
         deltas = {"hours": 3600, "minutes": 60, "seconds": 1}
         index = event["index"]
@@ -190,11 +195,6 @@ class Py3status:
                 self.time_left = t
             else:
                 self.time = t
-
-    def kill(self):
-        # remove any timer
-        if self.alarm_timer:
-            self.alarm_timer.cancel()
 
 
 if __name__ == "__main__":

--- a/py3status/modules/timewarrior.py
+++ b/py3status/modules/timewarrior.py
@@ -202,9 +202,6 @@ class Py3status:
                 self.init["datetimes"].append(word)
 
         self.tracking = None
-        self.thresholds_init = {}
-        for name in ("format", "format_tag", "format_time"):
-            self.thresholds_init[name] = self.py3.get_color_names_list(getattr(self, name))
 
     def _get_timewarrior_data(self):
         return json_loads(self.py3.command_output(self.timewarrior_command))
@@ -222,9 +219,7 @@ class Py3status:
             time["tags"] = time.get("tags", [])
             for tag_name in time["tags"]:
                 tag_data = {"name": tag_name, "state_tag": time["state_time"]}
-                for x in self.thresholds_init["format_tag"]:
-                    if x in tag_data:
-                        self.py3.threshold_get_color(tag_data[x], x)
+                self.py3.threshold_update(tag_data, self.format_tag)
                 new_tag.append(self.py3.safe_format(self.format_tag, tag_data))
 
             format_tag_separator = self.py3.safe_format(self.format_tag_separator)
@@ -264,9 +259,7 @@ class Py3status:
                     )
 
             # time
-            for x in self.thresholds_init["format_time"]:
-                if x in time:
-                    self.py3.threshold_get_color(time[x], x)
+            self.py3.threshold_update(time, self.format_time)
 
             new_time.append(self.py3.safe_format(self.format_time, time))
 
@@ -285,9 +278,7 @@ class Py3status:
 
         timew_data = {"format_time": format_time, "tracking": self.tracking}
 
-        for x in self.thresholds_init["format"]:
-            if x in timew_data:
-                self.py3.threshold_get_color(timew_data[x], x)
+        self.py3.threshold_update(timew_data, self.format)
 
         return {
             "cached_until": self.py3.time_in(cached_until),

--- a/py3status/modules/tor_rate.py
+++ b/py3status/modules/tor_rate.py
@@ -79,6 +79,25 @@ class Py3status:
         self._handler_active = False
         self._up = 0
 
+    def _get_rates(self):
+        up, up_unit = self.py3.format_units(self._up, unit=self.rate_unit, si=self.si_units)
+        down, down_unit = self.py3.format_units(self._down, unit=self.rate_unit, si=self.si_units)
+        return {
+            "up": self.py3.safe_format(self.format_value, {"rate": up, "unit": up_unit}),
+            "down": self.py3.safe_format(self.format_value, {"rate": down, "unit": down_unit}),
+        }
+
+    def _handle_event(self, event):
+        self._down = event.read
+        self._up = event.written
+
+    def _register_event_handler(self):
+        self._control = Controller.from_port(address=self.control_address, port=self.control_port)
+        if self.control_password:
+            self._control.authenticate(password=self.control_password)
+        self._control.add_event_listener(lambda e: self._handle_event(e), EventType.BW)
+        self._handler_active = True
+
     def tor_rate(self, outputs, config):
         text = ""
         if not self._handler_active and not self._auth_failure:
@@ -98,25 +117,6 @@ class Py3status:
             text = self.py3.safe_format(self.format, self._get_rates())
 
         return {"cached_until": self.py3.time_in(self.cache_timeout), "full_text": text}
-
-    def _get_rates(self):
-        up, up_unit = self.py3.format_units(self._up, unit=self.rate_unit, si=self.si_units)
-        down, down_unit = self.py3.format_units(self._down, unit=self.rate_unit, si=self.si_units)
-        return {
-            "up": self.py3.safe_format(self.format_value, {"rate": up, "unit": up_unit}),
-            "down": self.py3.safe_format(self.format_value, {"rate": down, "unit": down_unit}),
-        }
-
-    def _handle_event(self, event):
-        self._down = event.read
-        self._up = event.written
-
-    def _register_event_handler(self):
-        self._control = Controller.from_port(address=self.control_address, port=self.control_port)
-        if self.control_password:
-            self._control.authenticate(password=self.control_password)
-        self._control.add_event_listener(lambda e: self._handle_event(e), EventType.BW)
-        self._handler_active = True
 
 
 if __name__ == "__main__":

--- a/py3status/modules/transmission.py
+++ b/py3status/modules/transmission.py
@@ -1,0 +1,296 @@
+r"""
+Display number of torrents and more.
+
+Configuration parameters:
+    arguments: additional arguments for the transmission-remote (default None)
+    button_next: mouse button to switch next torrent (default None)
+    button_previous: mouse button to switch previous torrent (default None)
+    button_run: mouse button to run the command on current torrent
+        (default [(1, '--start'), (2, '--verify'), (3, '--stop')])
+    cache_timeout: refresh interval for this module (default 20)
+    format: display format for this module (default '{format_torrent}')
+    format_separator: show separator if more than one (default ' ')
+    format_torrent: display format for torrents
+        (default '[\?if=is_focused&color=bad X] {status} {id} {name} {done}%')
+    thresholds: specify color thresholds to use (default [])
+
+Format placeholders:
+    {torrent} number of torrents
+    {format_torrent} format for torrents
+    {up} summary up traffic
+    {down} summary down traffic
+    {have} summary download
+
+format_torrent placeholders:
+    {index} torrent index, eg 1
+    {id} torrent id, eg 2
+    {done} torrent percent, eg 100%
+    {have} torrent download, 253 KB
+    {eta} torrent estimated time, eg Done, 1 min, etc
+    {up} torrent up traffic
+    {down} torrent down traffic
+    {ratio} torrent seed ratio
+    {status} torrent status, eg Idle, Downloading, Stopped, Verifying, etc
+    {name} torrent name, eg py3status-3.8.tar.gz
+
+Color options:
+    color_bad: current torrent
+
+Color thresholds:
+    xxx: print a color based on the value of `xxx` placeholder
+
+Requires:
+    transmission-cli:
+        fast, easy, and free bittorrent client (cli tools, daemon, web client)
+
+Examples:
+```
+# add arguments
+transmission {
+    # We use 'transmission-remote --list'
+    # See `transmission-remote --help' for more information.
+    # Not all of the arguments will work here.
+    arguments = '--auth username:password --port 9091'
+}
+# see 'man transmission-remote' for more buttons
+transmission {
+    button_run = [
+        (1, '--start'),
+        (2, '--verify'),
+        (3, '--stop'),
+        (8, '--remove'),
+        (9, '--exit'),
+    ]
+}
+
+# open web-based transmission client
+transmission {
+    on_click 1 = 'exec xdg-open http://username:password@localhost:9091'
+}
+
+# add buttons
+transmission {
+    button_next = 5
+    button_previous = 4
+}
+
+# see 'man transmission-remote' for more buttons
+transmission {
+    # specify a script to run when a torrent finishes
+    on_click 9 = 'exec transmission-remote --torrent-done-script ~/file'
+
+    # use the alternate limits?
+    on_click 9 = 'exec transmission-remote --alt-speed'
+    on_click 10 = 'exec transmission-remote --no-alt-speed'
+}
+
+# show summary statistcs - up, down, have
+transmission {
+    format = '{format_torrent}'
+    format += '[\?color=#ffccff [\?not_zero  Up:{up}]'
+    format += '[\?not_zero  Down:{down}][\?not_zero  Have:{have}]]'
+}
+
+# add a format that sucks less than the default plain format
+transmission {
+    format_torrent = '[\?if=is_focused&color=bad X ]'
+    format_torrent += '[[\?if=status=Idle&color=degraded {status}]'
+    format_torrent += '|[\?if=status=Stopped&color=bad {status}]'
+    format_torrent += '|[\?if=status=Downloading&color=good {status}]'
+    format_torrent += '|[\?if=status=Verifying&color=good {status}]'
+    format_torrent += '|\?color=degraded {status}]'
+    format_torrent += ' {name} [\?color=done {done}]'
+}
+
+# show percent thresholds
+transmission {
+    format_torrent = '{name} [\?color=done {done}]'
+    thresholds = [(0, 'bad'), (1, 'degraded'), (100, 'good')]
+}
+
+# download the rainbow
+transmission {
+    format_torrent = '[\?if=is_focused&color=bad X ]'
+    format_torrent += '{status} [\?color=index {name}] [\?color=done {done}%]'
+    thresholds = {
+        'done': [(0, '#ffb3ba'), (1, '#ffffba'), (100, '#baefba')],
+        'index': [
+            (1, '#ffb3ba'), (2, '#ffdfba'), (3, '#ffffba'),
+            (4, '#baefba'), (5, '#baffc9'), (6, '#bae1ff'),
+            (7, '#bab3ff')
+        ]
+    }
+}
+```
+
+@author lasers
+
+SAMPLE OUTPUT
+{'full_text': 'Downloading py3status-3.8.tar.gz 89%'}
+
+verifying
+{'full_text': 'Verifying py3status-3.8.tar.gz 100%'}
+
+stopped
+{'full_text': 'Stopped py3status-3.8.tar.gz 100%'}
+
+idle
+{'full_text': 'Idle py3status-3.8.tar.gz 100%'}
+
+"""
+
+import time
+
+STRING_NOT_INSTALLED = "transmission-remote not installed"
+
+
+class Py3status:
+    """ """
+
+    # available configuration parameters
+    arguments = None
+    button_next = None
+    button_previous = None
+    button_run = [(1, "--start"), (2, "--verify"), (3, "--stop")]
+    cache_timeout = 20
+    format = "{format_torrent}"
+    format_separator = " "
+    format_torrent = r"[\?if=is_focused&color=bad X] {status} {id} {name} {done}%"
+    thresholds = []
+
+    def post_config_hook(self):
+        self.command = "transmission-remote --list"
+        if not self.py3.check_commands(self.command):
+            raise Exception(STRING_NOT_INSTALLED)
+        if self.arguments:
+            self.command = f"{self.command} {self.arguments}"
+        self.init_summary = self.py3.format_contains(self.format, ["up", "down", "have"])
+        self.id = 0
+        self.state = None
+        self.reset_id = self.id
+        self.torrent_data = None
+        self.is_scrolling = False
+        self.count_torrent = 0
+        self.summary_data = {}
+
+    def _scroll(self, direction=0):
+        self.is_scrolling = True
+        data = self.shared
+        if direction == 0:
+            self.id = self.reset_id
+            self.state = None
+            self.is_scrolling = False
+            for d in data:
+                d["is_focused"] = False
+        else:
+            if data and not any(d for d in data if d["is_focused"]):
+                data[0]["is_focused"] = True
+
+            length = len(data)
+            for index, d in enumerate(data):
+                if d.get("is_focused"):
+                    data[index]["is_focused"] = False
+                    if direction < 0:  # switch previous
+                        if index > 0:
+                            data[index - 1]["is_focused"] = True
+                        else:
+                            data[index]["is_focused"] = True
+                    elif direction > 0:  # switch next
+                        if index < (length - 1):
+                            data[index + 1]["is_focused"] = True
+                        else:
+                            data[length - 1]["is_focused"] = True
+                    break
+
+            for d in data:
+                if d["is_focused"]:
+                    self.id = d["id"]
+                    self.state = d["status"]
+                    break
+
+        self._manipulate(data)
+
+    def _organize(self, data):
+        self.id = self.reset_id
+        new_data = []
+        for line in data:
+            new_data.append(
+                {
+                    "is_focused": None,
+                    "id": line[0:6].strip(),
+                    "done": line[7:12].strip().strip("%"),
+                    "have": line[13:23].strip(),
+                    "eta": line[24:33].strip(),
+                    "up": line[34:41].strip(),
+                    "down": line[42:49].strip(),
+                    "ratio": line[50:56].strip(),
+                    "status": line[57:69].strip(),
+                    "name": line[70:].strip(),
+                }
+            )
+        return new_data
+
+    def _manipulate(self, data):
+        self.shared = data
+        new_data = []
+        for index, t in enumerate(data, 1):
+            t["index"] = index
+            if not self.is_scrolling:
+                t["is_focused"] = False
+            self.py3.threshold_update(t, self.format_torrent)
+
+            new_data.append(self.py3.safe_format(self.format_torrent, t))
+        return new_data
+
+    def transmission(self):
+        data = self.torrent_data
+        summary_data = self.summary_data
+
+        if not self.is_scrolling:
+            data = self.py3.command_output(self.command).splitlines()
+            if self.init_summary:
+                summary_line = data[-1]
+                summary_data["have"] = summary_line[13:23].strip()
+                summary_data["up"] = summary_line[34:41].strip()
+                summary_data["down"] = summary_line[42:49].strip()
+            data = data[1:-1]
+            self.count_torrent = len(data)
+            data = self.torrent_data = self._organize(data)
+
+        data = self._manipulate(data)
+        format_separator = self.py3.safe_format(self.format_separator)
+        format_torrent = self.py3.composite_join(format_separator, data)
+
+        summary_data.update({"torrent": self.count_torrent, "format_torrent": format_torrent})
+
+        self.py3.threshold_update(summary_data, self.format)
+
+        self.is_scrolling = False
+        return {
+            "cached_until": self.py3.time_in(self.cache_timeout),
+            "full_text": self.py3.safe_format(self.format, summary_data),
+        }
+
+    def on_click(self, event):
+        button = event["button"]
+        self.id = str(self.id).strip("*")
+        if button == self.button_next and self.torrent_data:
+            self._scroll(+1)
+        elif button == self.button_previous and self.torrent_data:
+            self._scroll(-1)
+        elif self.id:
+            for x in self.button_run:
+                if button == x[0]:
+                    cmd = "transmission-remote -t {} {}".format(self.id, x[1])
+                    self.py3.command_run(cmd)
+                    time.sleep(0.75)
+                    break
+
+
+if __name__ == "__main__":
+    """
+    Run module in test mode.
+    """
+    from py3status.module_test import module_test
+
+    module_test(Py3status)

--- a/py3status/modules/twitch.py
+++ b/py3status/modules/twitch.py
@@ -119,46 +119,6 @@ class Py3status:
             ],
         }
 
-    def _trace(self, msg):
-        if not self.trace:
-            return
-        self.py3.log(msg, self.py3.LOG_INFO)
-
-    def _refresh_token(self):
-        if self._token and self._token["expires"] > time.time():
-            return
-
-        self._trace("refreshing twitch oauth token")
-        auth_endpoint = "https://id.twitch.tv/oauth2/token"
-        auth_request = {
-            "client_id": self.client_id,
-            "client_secret": self.client_secret,
-            "grant_type": "client_credentials",
-        }
-
-        try:
-            response = self.py3.request(auth_endpoint, data=auth_request)
-        except self.py3.RequestException:
-            return {}
-
-        data = response.json()
-        if not data:
-            data = vars(response)
-            error = data.get("_error_message")
-            if error:
-                self.py3.error("{} {}".format(error, data["_status_code"]))
-
-        self._token = data
-        self._token["expires"] = time.time() + self._token["expires_in"] - 60
-        self.py3.storage_set("oauth_token", self._token)
-
-    def _headers(self):
-        self._refresh_token()
-        return {
-            "Authorization": "Bearer " + self._token["access_token"],
-            "Client-ID": self.client_id,
-        }
-
     def post_config_hook(self):
         for config_name in ["client_id", "client_secret", "stream_name"]:
             if not getattr(self, config_name, None):
@@ -201,6 +161,46 @@ class Py3status:
 
         if "en-us" not in self.locales:
             self.locales.append("en-us")
+
+    def _trace(self, msg):
+        if not self.trace:
+            return
+        self.py3.log(msg, self.py3.LOG_INFO)
+
+    def _refresh_token(self):
+        if self._token and self._token["expires"] > time.time():
+            return
+
+        self._trace("refreshing twitch oauth token")
+        auth_endpoint = "https://id.twitch.tv/oauth2/token"
+        auth_request = {
+            "client_id": self.client_id,
+            "client_secret": self.client_secret,
+            "grant_type": "client_credentials",
+        }
+
+        try:
+            response = self.py3.request(auth_endpoint, data=auth_request)
+        except self.py3.RequestException:
+            return {}
+
+        data = response.json()
+        if not data:
+            data = vars(response)
+            error = data.get("_error_message")
+            if error:
+                self.py3.error("{} {}".format(error, data["_status_code"]))
+
+        self._token = data
+        self._token["expires"] = time.time() + self._token["expires_in"] - 60
+        self.py3.storage_set("oauth_token", self._token)
+
+    def _headers(self):
+        self._refresh_token()
+        return {
+            "Authorization": "Bearer " + self._token["access_token"],
+            "Client-ID": self.client_id,
+        }
 
     def _get_twitch_data(self, url, first=True):
         try:

--- a/py3status/modules/vnstat.py
+++ b/py3status/modules/vnstat.py
@@ -86,8 +86,6 @@ class Py3status:
         if self.coloring and not self.thresholds:
             self.thresholds = [(num * 1024**2, col) for num, col in self.coloring.items()]
 
-        self.thresholds_init = self.py3.get_color_names_list(self.format)
-
     def _divide_and_format(self, value):
         # Divide a value and return formatted string
         value /= self.initial_multi
@@ -107,9 +105,7 @@ class Py3status:
         if self.coloring:
             response["color"] = self.py3.threshold_get_color(stat["total"])
 
-        for x in self.thresholds_init:
-            if x in stat:
-                self.py3.threshold_get_color(stat[x], x)
+        self.py3.threshold_update(stat, self.format)
 
         response["full_text"] = self.py3.safe_format(
             self.format,

--- a/py3status/modules/watson.py
+++ b/py3status/modules/watson.py
@@ -39,6 +39,25 @@ class Py3status:
     def post_config_hook(self):
         self.state_file = Path(self.state_file).expanduser()
 
+    def _format_output(self, session_data: Dict[str, Union[str, int, List[str]]]) -> Dict[str, str]:
+        if not session_data:
+            return {"full_text": "No project started", "color": self.py3.COLOR_BAD}
+
+        project = session_data["project"]
+        tags = session_data["tags"]
+
+        if tags:
+            tag_str = " [{}]".format(", ".join(tags))
+        else:
+            tag_str = " "
+
+        return {
+            "full_text": self.py3.safe_format(
+                self.format, {"project": project, "tag_str": tag_str}
+            ),
+            "color": self.py3.COLOR_GOOD,
+        }
+
     def watson(self) -> Dict[str, str]:
         if not self.state_file.is_file():
             return {
@@ -65,25 +84,6 @@ class Py3status:
                 "color": self.py3.COLOR_BAD,
                 "cached_until": self.py3.time_in(seconds=self.cache_timeout),
             }
-
-    def _format_output(self, session_data: Dict[str, Union[str, int, List[str]]]) -> Dict[str, str]:
-        if not session_data:
-            return {"full_text": "No project started", "color": self.py3.COLOR_BAD}
-
-        project = session_data["project"]
-        tags = session_data["tags"]
-
-        if tags:
-            tag_str = " [{}]".format(", ".join(tags))
-        else:
-            tag_str = " "
-
-        return {
-            "full_text": self.py3.safe_format(
-                self.format, {"project": project, "tag_str": tag_str}
-            ),
-            "color": self.py3.COLOR_GOOD,
-        }
 
 
 if __name__ == "__main__":

--- a/py3status/modules/weather_owm.py
+++ b/py3status/modules/weather_owm.py
@@ -444,11 +444,6 @@ class Py3status:
                 if name not in self.thresholds:
                     self.thresholds[name] = self.thresholds[THRESHOLDS_ALL]
 
-        # Initialize per-format thresholds
-        self.thresholds_init = {}
-        for name in ("format_humidity",):
-            self.thresholds_init[name] = self.py3.get_color_names_list(getattr(self, name))
-
     def _get_icons(self):
         if self.icons is None:
             self.icons = {}
@@ -713,9 +708,7 @@ class Py3status:
             "humidity": self._jpath(wthr, OWM_HUMIDITY, self._jpath(wthr, OWM_CURRENT_HUMIDITY, 0)),
         }
 
-        for x in self.thresholds_init["format_humidity"]:
-            if x in humidity_data:
-                self.py3.threshold_get_color(humidity_data[x], x)
+        self.py3.threshold_update(humidity_data, self.format_humidity)
 
         return self.py3.safe_format(self.format_humidity, humidity_data)
 

--- a/py3status/modules/weather_owm.py
+++ b/py3status/modules/weather_owm.py
@@ -400,45 +400,6 @@ class Py3status:
             ],
         }
 
-    def _get_icons(self):
-        if self.icons is None:
-            self.icons = {}
-
-        # Defaults for weather ranges
-        defaults = {
-            "200_299": self.icon_thunderstorm,
-            "300_399": self.icon_rain,
-            "500_599": self.icon_rain,
-            "600_699": self.icon_snow,
-            "700_799": self.icon_atmosphere,
-            "800": self.icon_sun,
-            "801_809": self.icon_cloud,
-            "900_909": self.icon_extreme,
-            "950_959": self.icon_wind,
-            "960_999": self.icon_extreme,
-        }
-
-        # Handling ranges from OpenWeatherMap
-        data = {}
-        for source in (defaults, self.icons):
-            for key in source:
-                if not key.replace("_", "").isdigit():
-                    raise Exception(f"Invalid icon id: ({key})")
-
-                if "_" in key:
-                    if key.count("_") != 1:
-                        raise Exception("fInvalid icon range: {key}")
-
-                    # Populate each code
-                    start, _, end = key.partition("_")
-                    for code in range(int(start), int(end) + 1):
-                        data[code] = source[key]
-
-                else:
-                    data[int(key)] = source[key]
-
-        return data
-
     def post_config_hook(self):
         # Verify the API key
         if self.api_key is None:
@@ -487,6 +448,45 @@ class Py3status:
         self.thresholds_init = {}
         for name in ("format_humidity",):
             self.thresholds_init[name] = self.py3.get_color_names_list(getattr(self, name))
+
+    def _get_icons(self):
+        if self.icons is None:
+            self.icons = {}
+
+        # Defaults for weather ranges
+        defaults = {
+            "200_299": self.icon_thunderstorm,
+            "300_399": self.icon_rain,
+            "500_599": self.icon_rain,
+            "600_699": self.icon_snow,
+            "700_799": self.icon_atmosphere,
+            "800": self.icon_sun,
+            "801_809": self.icon_cloud,
+            "900_909": self.icon_extreme,
+            "950_959": self.icon_wind,
+            "960_999": self.icon_extreme,
+        }
+
+        # Handling ranges from OpenWeatherMap
+        data = {}
+        for source in (defaults, self.icons):
+            for key in source:
+                if not key.replace("_", "").isdigit():
+                    raise Exception(f"Invalid icon id: ({key})")
+
+                if "_" in key:
+                    if key.count("_") != 1:
+                        raise Exception("fInvalid icon range: {key}")
+
+                    # Populate each code
+                    start, _, end = key.partition("_")
+                    for code in range(int(start), int(end) + 1):
+                        data[code] = source[key]
+
+                else:
+                    data[int(key)] = source[key]
+
+        return data
 
     def _make_req(self, url, params=None):
         # Make a request expecting a JSON response

--- a/py3status/modules/wifi.py
+++ b/py3status/modules/wifi.py
@@ -254,9 +254,7 @@ class Py3status:
             "ssid": ssid,
         }
 
-        for x in self.thresholds_init:
-            if x in wifi_data:
-                self.py3.threshold_get_color(wifi_data[x], x)
+        self.py3.threshold_update(wifi_data, self.format)
 
         response = {
             "cached_until": self.py3.time_in(self.cache_timeout),

--- a/py3status/modules/wwan.py
+++ b/py3status/modules/wwan.py
@@ -332,11 +332,7 @@ class Py3status:
         }
 
         self._dbus = SystemBus()
-        self.init = {
-            "ip": [],
-            "sms_message": [],
-            "thresholds": self.py3.get_color_names_list(self.format),
-        }
+        self.init = {"ip": [], "sms_message": []}
         self.last_messages = 0
         self.last_notification = self.py3.storage_get("notification")
 
@@ -565,9 +561,7 @@ class Py3status:
                     wwan_data["format_message"] = self._manipulate_message(message_data)
 
         # thresholds
-        for x in self.init["thresholds"]:
-            if x in wwan_data:
-                self.py3.threshold_get_color(wwan_data[x], x)
+        self.py3.threshold_update(wwan_data, self.format)
 
         # notifications
         if self.format_notification:

--- a/py3status/modules/wwan_status.py
+++ b/py3status/modules/wwan_status.py
@@ -77,6 +77,17 @@ class Py3status:
     modem = "/dev/ttyUSB1"
     modem_timeout = 0.4
 
+    def _get_ip(self, interface):
+        """
+        Returns the interface's IPv4 address if device exists and has a valid
+        ip address. Otherwise, returns an empty string
+        """
+        if interface in ni.interfaces():
+            addresses = ni.ifaddresses(interface)
+            if ni.AF_INET in addresses:
+                return addresses[ni.AF_INET][0]["addr"]
+        return ""
+
     def wwan_status(self):
         query = "AT^SYSINFOEX"
         target_line = "^SYSINFOEX"
@@ -163,17 +174,6 @@ class Py3status:
             response["color"] = self.py3.COLOR_BAD
             response["full_text"] = self.format_down
         return response
-
-    def _get_ip(self, interface):
-        """
-        Returns the interface's IPv4 address if device exists and has a valid
-        ip address. Otherwise, returns an empty string
-        """
-        if interface in ni.interfaces():
-            addresses = ni.ifaddresses(interface)
-            if ni.AF_INET in addresses:
-                return addresses[ni.AF_INET][0]["addr"]
-        return ""
 
 
 if __name__ == "__main__":

--- a/py3status/modules/xkb_input.py
+++ b/py3status/modules/xkb_input.py
@@ -426,10 +426,6 @@ class Py3status:
         if getattr(self, "listener", True):
             self.listener_backend = Listener(self)
 
-        self.thresholds_init = {}
-        for name in ["format", "format_input"]:
-            self.thresholds_init[name] = self.py3.get_color_names_list(getattr(self, name))
-
     def _stop_on_errors(self):
         if self.error:
             self.kill()
@@ -442,9 +438,7 @@ class Py3status:
 
         for _input in xkb_inputs:
             _input = self.input_backend.add_libinput(_input) or _input
-            for x in self.thresholds_init["format_input"]:
-                if x in _input:
-                    self.py3.threshold_get_color(_input[x], x)
+            self.py3.threshold_update(_input, self.format_input)
             new_input.append(self.py3.safe_format(self.format_input, _input))
 
         format_input_separator = self.py3.safe_format(self.format_input_separator)
@@ -456,9 +450,7 @@ class Py3status:
             "switcher": self.switcher,
         }
 
-        for x in self.thresholds_init["format"]:
-            if x in input_data:
-                self.py3.threshold_get_color(input_data[x], x)
+        self.py3.threshold_update(input_data, self.format)
 
         return {
             "cached_until": self.py3.time_in(self.cache_timeout),

--- a/py3status/modules/xkb_input.py
+++ b/py3status/modules/xkb_input.py
@@ -168,6 +168,7 @@ class Listener:
         try:
             self.process.kill()
         except AttributeError:
+            # kill the process
             pass
 
 

--- a/py3status/modules/xrandr.py
+++ b/py3status/modules/xrandr.py
@@ -440,24 +440,6 @@ class Py3status:
                 else:
                     break
 
-    def on_click(self, event):
-        """
-        Click events
-            - left click & scroll up/down: switch between modes
-            - right click: apply selected mode
-            - middle click: force refresh of available modes
-        """
-        self._no_force_on_change = True
-        button = event["button"]
-        if button == 4:
-            self._switch_selection(-1)
-        if button in [1, 5]:
-            self._switch_selection(1)
-        if button == 2:
-            self._choose_what_to_display(force_refresh=True)
-        if button == 3:
-            self._apply()
-
     def xrandr(self):
         """
         This is the main py3status method, it will orchestrate what's being
@@ -508,6 +490,23 @@ class Py3status:
                 self._fallback_to_available_output()
 
         return response
+
+    def on_click(self, event):
+        """
+        Left click & scroll up/down: switch between modes
+        Right click: apply selected mode
+        Middle click: force refresh of available modes
+        """
+        self._no_force_on_change = True
+        button = event["button"]
+        if button == 4:
+            self._switch_selection(-1)
+        if button in [1, 5]:
+            self._switch_selection(1)
+        if button == 2:
+            self._choose_what_to_display(force_refresh=True)
+        if button == 3:
+            self._apply()
 
 
 if __name__ == "__main__":

--- a/py3status/modules/zypper_updates.py
+++ b/py3status/modules/zypper_updates.py
@@ -35,7 +35,6 @@ class Py3status:
     thresholds = [(0, "good"), (50, "degraded"), (100, "bad")]
 
     def post_config_hook(self):
-        self.thresholds_init = self.py3.get_color_names_list(self.format)
         self.reg_ex_pkg = re.compile(b"v\\s\\S+", re.M)
 
     def zypper_updates(self):
@@ -47,9 +46,7 @@ class Py3status:
             "update": len(self.reg_ex_pkg.findall(output)),
         }
 
-        for x in self.thresholds_init:
-            if x in zypper_data:
-                self.py3.threshold_get_color(zypper_data[x], x)
+        self.py3.threshold_update(zypper_data, self.format)
 
         return {
             "cached_until": self.py3.time_in(self.cache_timeout),

--- a/py3status/py3.py
+++ b/py3status/py3.py
@@ -109,6 +109,7 @@ class Py3:
         self._report_exception_cache = set()
         self._thresholds = None
         self._threshold_gradients = {}
+        self._threshold_update_names = {}
         self._uid = uuid4()
 
         if module:
@@ -1233,6 +1234,26 @@ class Py3:
         setattr(self._py3status_module, color_name, color)
 
         return color
+
+    def threshold_update(self, thresholds, format_string):
+        """
+        Convenience helper for static threshold updates.
+
+        This checks threshold names from the format string against
+        values in the thresholds dict and updates matching threshold colors.
+
+        :param thresholds: dict containing threshold values
+        :param format_string: format string to check for threshold names
+        """
+        try:
+            names = self._threshold_update_names[format_string]
+        except KeyError:
+            names = self.get_color_names_list(format_string)
+            self._threshold_update_names[format_string] = names
+
+        for name in names:
+            if name in thresholds:
+                self.threshold_get_color(thresholds[name], name)
 
     def replace(self, value, name=None):
         """

--- a/py3status/py3.py
+++ b/py3status/py3.py
@@ -103,6 +103,7 @@ class Py3:
         self._format_color_names = {}
         self._format_placeholders = {}
         self._format_placeholders_cache = {}
+        self._has_thresholds = None
         self._logger = None
         self._module = module
         self._replacements = None
@@ -172,7 +173,7 @@ class Py3:
 
     def _thresholds_init(self):
         """
-        Initiate and check any thresholds set
+        Initialize and check any thresholds set
         """
         thresholds = getattr(self._py3status_module, "thresholds", [])
         self._thresholds = {}
@@ -687,6 +688,12 @@ class Py3:
         self._format_placeholders_cache[format_string][key] = False
         return False
 
+    def _thresholds_available(self):
+        if self._has_thresholds is None:
+            module = getattr(self, "_py3status_module", None)
+            self._has_thresholds = bool(getattr(module, "thresholds", None))
+        return self._has_thresholds
+
     def get_color_names_list(self, format_string, matches=None):
         """
         Returns a list of color names in ``format_string``.
@@ -704,16 +711,14 @@ class Py3:
             [seq] 	matches any character in seq
             [!seq] 	matches any character not in seq
         """
-        if not getattr(self._py3status_module, "thresholds", None):
-            return []
-        elif not format_string:
+        if not self._thresholds_available():
             return []
 
-        if format_string not in self._format_color_names:
+        try:
+            names = self._format_color_names[format_string]
+        except KeyError:
             names = self._formatter.get_color_names(format_string)
             self._format_color_names[format_string] = names
-        else:
-            names = self._format_color_names[format_string]
 
         if not matches:
             return list(names)
@@ -1163,30 +1168,40 @@ class Py3:
         if self._thresholds is None:
             self._thresholds_init()
 
-        # allow name with different values
+        # allow one threshold name to use per-item threshold values
         if isinstance(name, tuple):
-            name_used = "{}/{}".format(name[0], name[1])
-            if name[2]:
-                self._thresholds[name_used] = [(x[0], self._get_color(x[1])) for x in name[2]]
-            name = name[0]
+            name, key, thresholds = name
+            name_used = f"{name}/{key}"
+            if thresholds:
+                self._thresholds[name_used] = [(x[0], self._get_color(x[1])) for x in thresholds]
+                self._threshold_gradients.pop(name_used, None)
         else:
             # if name not in thresholds info then use defaults
             name_used = name
-            if name_used not in self._thresholds:
+            thresholds = self._thresholds.get(name_used)
+            if thresholds is None:
                 name_used = None
+                thresholds = self._thresholds.get(name_used)
 
-        # convert value to int/float
-        thresholds = self._thresholds.get(name_used)
+        # save color so it can be accessed via safe_format()
+        if name:
+            color_name = f"color_threshold_{name}"
+        else:
+            color_name = "color_threshold"
+
+        # skip on empty thresholds/values
+        if not thresholds or value is None or value == "":
+            setattr(self._py3status_module, color_name, None)
+            return None
+
+        # conversion
         color = None
         try:
             value = float(value)
         except (TypeError, ValueError):
             pass
 
-        # skip on empty thresholds/values
-        if not thresholds or value in [None, ""]:
-            pass
-        elif isinstance(value, str):
+        if isinstance(value, str):
             # string
             for threshold in thresholds:
                 if value == threshold[0]:
@@ -1226,11 +1241,6 @@ class Py3:
             except TypeError:
                 color = None
 
-        # save color so it can be accessed via safe_format()
-        if name:
-            color_name = f"color_threshold_{name}"
-        else:
-            color_name = "color_threshold"
         setattr(self._py3status_module, color_name, color)
 
         return color
@@ -1245,6 +1255,9 @@ class Py3:
         :param thresholds: dict containing threshold values
         :param format_string: format string to check for threshold names
         """
+        if not self._thresholds_available() or not thresholds or "color=" not in format_string:
+            return
+
         try:
             names = self._threshold_update_names[format_string]
         except KeyError:

--- a/tests/test_consistency.py
+++ b/tests/test_consistency.py
@@ -1,24 +1,21 @@
+import ast
 from pathlib import Path
 
 MODULE_PATH = Path(__file__).resolve().parent.parent / "py3status" / "modules"
 
 
-def test_method_mismatch():
-    line = "def {}(self"
-    skip_files = ["__init__.py", "i3pystatus.py"]
-    errors = []
-
+def get_module_files(skip_files):
     for _file in sorted(MODULE_PATH.iterdir()):
         if _file.suffix == ".py" and _file.name not in skip_files:
-            with _file.open() as f:
-                if f"def {_file.stem}(self" not in f.read():
-                    errors.append((_file.stem, _file))
-    if errors:
-        line = "Method mismatched error(s) detected!\n\n"
-        for error in errors:
-            line += "Method `{}` is not in module `{}`\n".format(*error)
-        print(line[:-1])
-        assert False
+            yield _file
+
+
+def get_py3status_methods(_file):
+    tree = ast.parse(_file.read_text(), filename=str(_file))
+    for node in tree.body:
+        if isinstance(node, ast.ClassDef) and node.name == "Py3status":
+            return [item.name for item in node.body if isinstance(item, ast.FunctionDef)]
+    return []
 
 
 def test_authors():
@@ -26,11 +23,10 @@ def test_authors():
     skip_files = ["__init__.py"]
     errors = []
 
-    for _file in sorted(MODULE_PATH.iterdir()):
-        if _file.suffix == ".py" and _file.name not in skip_files:
-            with _file.open() as f:
-                if comment not in f.read():
-                    errors.append((comment, _file))
+    for _file in get_module_files(skip_files):
+        with _file.open() as f:
+            if comment not in f.read():
+                errors.append((comment, _file))
     if errors:
         line = "Missing @author error(s) detected!\n\n"
         for error in errors:
@@ -44,11 +40,10 @@ def test_sample_output():
     skip_files = ["__init__.py"]
     errors = []
 
-    for _file in sorted(MODULE_PATH.iterdir()):
-        if _file.suffix == ".py" and _file.name not in skip_files:
-            with _file.open() as f:
-                if comment not in f.read():
-                    errors.append((comment, _file))
+    for _file in get_module_files(skip_files):
+        with _file.open() as f:
+            if comment not in f.read():
+                errors.append((comment, _file))
     if errors:
         line = "Missing sample error(s) detected!\n\n"
         for error in errors:
@@ -80,11 +75,10 @@ def test_available_configuration_parameters():
     skip_files = ["__init__.py"]
     errors = []
 
-    for _file in sorted(MODULE_PATH.iterdir()):
-        if _file.suffix == ".py" and _file.name not in skip_files:
-            with _file.open() as f:
-                if comment not in f.read():
-                    errors.append((comment, _file))
+    for _file in get_module_files(skip_files):
+        with _file.open() as f:
+            if comment not in f.read():
+                errors.append((comment, _file))
     if errors:
         line = "Missing comment error(s) detected!\n\n"
         for error in errors:
@@ -99,15 +93,14 @@ def test_class_meta_before_parameters():
     errors = []
     skip_files = ["__init__.py"]
 
-    for _file in sorted(MODULE_PATH.iterdir()):
-        if _file.suffix == ".py" and _file.name not in skip_files:
-            with _file.open() as f:
-                for x in f.readlines():
-                    if line in x:
-                        errors.append((line, _file))
-                        break
-                    elif comment in x:
-                        break
+    for _file in get_module_files(skip_files):
+        with _file.open() as f:
+            for x in f.readlines():
+                if line in x:
+                    errors.append((line, _file))
+                    break
+                elif comment in x:
+                    break
     if errors:
         line = "Class Meta error(s) detected!\n\n"
         for error in errors:
@@ -122,18 +115,17 @@ def test_examples_before_requires():
     errors = []
     skip_files = ["__init__.py"]
 
-    for _file in sorted(MODULE_PATH.iterdir()):
-        if _file.suffix == ".py" and _file.name not in skip_files:
-            with _file.open() as f:
-                output = f.read()
-                if line not in output or comment not in output:
-                    continue
-                for x in output.splitlines():
-                    if x.startswith(line):
-                        errors.append((line, _file))
-                        break
-                    elif x.startswith(comment):
-                        break
+    for _file in get_module_files(skip_files):
+        with _file.open() as f:
+            output = f.read()
+            if line not in output or comment not in output:
+                continue
+            for x in output.splitlines():
+                if x.startswith(line):
+                    errors.append((line, _file))
+                    break
+                elif x.startswith(comment):
+                    break
     if errors:
         line = "Examples error(s) detected!\n\n"
         for error in errors:
@@ -148,18 +140,17 @@ def test_authors_before_examples():
     errors = []
     skip_files = ["__init__.py"]
 
-    for _file in sorted(MODULE_PATH.iterdir()):
-        if _file.suffix == ".py" and _file.name not in skip_files:
-            with _file.open() as f:
-                output = f.read()
-                if line not in output or comment not in output:
-                    continue
-                for x in output.splitlines():
-                    if x.startswith(line):
-                        errors.append((line, _file))
-                        break
-                    elif x.startswith(comment):
-                        break
+    for _file in get_module_files(skip_files):
+        with _file.open() as f:
+            output = f.read()
+            if line not in output or comment not in output:
+                continue
+            for x in output.splitlines():
+                if x.startswith(line):
+                    errors.append((line, _file))
+                    break
+                elif x.startswith(comment):
+                    break
     if errors:
         line = "Author error(s) detected!\n\n"
         for error in errors:
@@ -182,16 +173,57 @@ def test_format_placeholders():
     ]
     errors = []
 
-    for _file in sorted(MODULE_PATH.iterdir()):
-        if _file.suffix == ".py" and _file.name not in skip_files:
-            with _file.open() as f:
-                output = f.read()
-                if comment not in output:
-                    if comment2 not in output:
-                        errors.append((comment, _file))
+    for _file in get_module_files(skip_files):
+        with _file.open() as f:
+            output = f.read()
+            if comment not in output:
+                if comment2 not in output:
+                    errors.append((comment, _file))
     if errors:
         line = f"Missing `{comment}` error(s) detected!\n\n"
         for error in errors:
             line += "`{}` is not in module `{}`\n".format(*error)
         print(line[:-1])
+        assert False
+
+
+def test_module_method_order():
+    skip_files = ["__init__.py", "i3pystatus.py"]
+    errors = []
+
+    for _file in get_module_files(skip_files):
+        methods = get_py3status_methods(_file)
+        module_method = _file.stem
+        if module_method not in methods:
+            errors.append(f"Module `{_file}` should define `{module_method}()`")
+            continue
+
+        if "post_config_hook" in methods and methods[0] != "post_config_hook":
+            errors.append(
+                f"Module `{_file}` should define `post_config_hook()` first when present"
+            )
+
+        expected_tail = [module_method]
+        if "kill" in methods:
+            expected_tail.append("kill")
+        if "on_click" in methods:
+            expected_tail.append("on_click")
+
+        helper_methods = methods[1:] if methods[0] == "post_config_hook" else methods
+        helper_methods = helper_methods[: -len(expected_tail)]
+        for method in helper_methods:
+            if not method.startswith("_"):
+                errors.append(
+                    f"Module `{_file}` should define `{method}()` before "
+                    f"`{module_method}()` only if it is private"
+                )
+
+        if methods[-len(expected_tail) :] != expected_tail:
+            expected_methods = " then ".join(f"`{name}()`" for name in expected_tail)
+            errors.append(f"Module `{_file}` should end with {expected_methods}")
+
+    if errors:
+        line = "Module method ordering error(s) detected!\n\n"
+        line += "\n".join(errors)
+        print(line)
         assert False


### PR DESCRIPTION
Merge this last.
Merge `enforce method order` first https://github.com/ultrabug/py3status/pull/2345.

-----

This turns your typical threshold handling...
```python
# CURRENT THRESHOLD HANDLING

# [post_config_hook]
    color_names = self.py3.get_color_names_list(format_string)

# [module_method]
    for name in color_names:
        if name in dict:
           value = dict[name]
           self.py3.threshold_get_color(value, name)
```

... into a simplified/static one.
```python
# BASIC THRESHOLD HANDLING

# [module_method]  # NEW!
    py3.threshold_update(dict, format_string)
```
----
For more fine-grained threshold control (for example, `lm_sensors` and maybe `sysdata`), keep using...
```python
# EXPLICIT THRESHOLD HANDLING

# [post_config_hook]
    color_names = self.py3.get_color_names_list(format_string)  # Commonly used. 
    placeholders = self.py3.get_placeholders_list(format_string)  # Rarely used.

# [module_method]

  # [Insert Custom Threshold Handling Code Here]
    # [Insert Custom Threshold Handling Code Here]
      # [Insert Custom Threshold Handling Code Here]
        self.py3.threshold_get_color(value, name)  # Commonly used.
```