### PR TITLE
py3.safe_format: remove max_width parameter

### DIFF
--- a/docs/dev-guide/the-py3-helper.md
+++ b/docs/dev-guide/the-py3-helper.md
@@ -382,7 +382,7 @@ be added automatically following the convention:
 
 returns: HttpResponse
 
-### safe_format(format_string, param_dict=None, force_composite=False, attr_getter=None, max_width=None)
+### safe_format(format_string, param_dict=None, force_composite=False, attr_getter=None)
 
 Parser for advanced formatting.
 
@@ -434,9 +434,6 @@ returned.
 
 attr_getter is a function that will when called with an attribute name
 as a parameter will return a value.
-
-max_width lets you to control the total max width of 'full_text' the
-module is allowed to output on the bar.
 
 ### stop_sound()
 

--- a/py3status/modules/mpris.py
+++ b/py3status/modules/mpris.py
@@ -22,7 +22,6 @@ Configuration parameters:
     icon_play: specify icon for play button (default u'\u25b7')
     icon_previous: specify icon for previous button (default u'\u25c3')
     icon_stop: specify icon for stop button (default u'\u25a1')
-    max_width: maximum status length (default None)
     player_priority: priority of the players.
         Keep in mind that the state has a higher priority than
         player_priority. So when player_priority is "[mpd, bomi]" and mpd is
@@ -387,7 +386,6 @@ class Py3status:
     icon_play = "\u25b7"
     icon_previous = "\u25c3"
     icon_stop = "\u25a1"
-    max_width = None
     player_priority = []
     replacements = None
     state_pause = "\u25eb"
@@ -708,9 +706,7 @@ class Py3status:
                 placeholders = {"state": current_state_map["state_icon"]}
                 color = current_state_map["color"]
                 composite = self.py3.safe_format(
-                    self.format,
-                    dict(self._empty_response, **placeholders, **data),
-                    max_width=self.max_width,
+                    self.format, dict(self._empty_response, **placeholders, **data)
                 )
             else:
                 # The player changed during our processing

--- a/py3status/py3.py
+++ b/py3status/py3.py
@@ -809,7 +809,6 @@ class Py3:
         param_dict=None,
         force_composite=False,
         attr_getter=None,
-        max_width=None,
     ):
         r"""
         Parser for advanced formatting.
@@ -866,30 +865,15 @@ class Py3:
 
         attr_getter is a function that will when called with an attribute name
         as a parameter will return a value.
-
-        max_width lets you to control the total max width of 'full_text' the
-        module is allowed to output on the bar.
         """
         try:
-            result = self._formatter.format(
+            return self._formatter.format(
                 format_string,
                 self._py3status_module,
                 param_dict,
                 force_composite=force_composite,
                 attr_getter=attr_getter,
             )
-            if max_width is not None and max_width > 0:
-                if isinstance(result, str):
-                    result = result[:max_width]
-                elif isinstance(result, Composite):
-                    chars_left = max_width
-                    for composite in result:
-                        if "index" in composite:
-                            continue
-                        composite["full_text"] = composite["full_text"][:chars_left]
-                        chars_left -= len(composite["full_text"])
-                        chars_left = max(0, chars_left)
-            return result
         except Exception as err:
             self._report_exception(f"Invalid format `{format_string}` ({err})")
             return f"invalid format ({err})"


### PR DESCRIPTION
Not easy to say this. I respect you too. Hear this out.

 This reverts https://github.com/ultrabug/py3status/pull/2113 in favor of something that exists for long time.

I particularly don't remember my comments there. I found this odd when I was working on `threshold_update` and went looking at the history. I feel like this was a rushed PR. My original suggestion wasn't even attempted.

1)  `mpris`'s default format means the the buttons are the first one getting cut off but wait, okay, you skip ones with `index`, then that mean `max_width` can be inaccurate, or a little unclear, but okay, I understand this.

2) This was made specifically for `mpris` only and may have been made fast to address user's feature request with `mpris` outside of this space.

3) It is not easy to add this config in several modules, but it is much easier to safeformat modules and just having users inline `\?max_length=5`  in their formats (anywhere) if they want it.

4) Most likely, no other modules will use this implementation.

EDIT: I just want this to be looked at... again. Users should use (simplified) suggestion below instead.
```diff
diff --git a/py3status/modules/static_string.py b/py3status/modules/static_string.py
index 1c26059..db53fbe 100644
--- a/py3status/modules/static_string.py
+++ b/py3status/modules/static_string.py
@@ -15,7 +15,7 @@ class Py3status:
     """ """
 
     # available configuration parameters
-    format = "Hello, world!"
+    format = "\?max_length=5 Hello, world!"
 
     def static_string(self):
         return {
```
```shell
$ python static_string.py --term
Hello
Hello
^C⏎
```