### PR TITLE
py3, modules: support native separators

### DIFF
--- a/docs/dev-guide/the-py3-helper.md
+++ b/docs/dev-guide/the-py3-helper.md
@@ -438,6 +438,15 @@ as a parameter will return a value.
 max_width lets you to control the total max width of 'full_text' the
 module is allowed to output on the bar.
 
+### safe_join(separator, items)
+
+Join items using a format string, Composite, or native separators.
+
+String separators are processed by the formatter. Boolean separators
+control whether native separators are used between visible items.
+
+A Composite object will be returned.
+
 ### stop_sound()
 
 Stops any currently playing sounds for this module.

--- a/py3status/composite.py
+++ b/py3status/composite.py
@@ -95,7 +95,21 @@ class Composite:
             diff = item.copy()
             del diff["full_text"]
 
-            if diff == diff_last or (item["full_text"].strip() == "" and item_last):
+            can_merge = (
+                # no native separator on the previous item
+                not (item_last is not None and isinstance(item_last.get("separator"), bool))
+                and (
+                    # merge identical attributes
+                    diff == diff_last
+                    or (
+                        # merge unseparated whitespace
+                        item_last is not None
+                        and "separator" not in item
+                        and not item["full_text"].strip()
+                    )
+                )
+            )
+            if can_merge:
                 item_last["full_text"] += item["full_text"]
             else:
                 diff_last = diff
@@ -112,15 +126,20 @@ class Composite:
         The output will be a Composite.
         """
         output = Composite()
-        first_item = True
+        previous_block = None
+        is_boolean_separator = isinstance(separator, bool)
         for item in items:
-            # skip empty items
             if not item:
                 continue
-            # skip separator on first item
-            if first_item:
-                first_item = False
-            else:
+            if is_boolean_separator:
+                item = Composite(item).copy()
+                for block in reversed(item):
+                    if block.get("full_text"):
+                        if previous_block is not None:
+                            previous_block.setdefault("separator", separator)
+                        previous_block = block
+                        break
+            elif output:
                 output.append(separator)
             output.append(item)
         return output

--- a/py3status/modules/bluetooth.py
+++ b/py3status/modules/bluetooth.py
@@ -168,9 +168,7 @@ class Py3status:
 
                 new_device.append(self.py3.safe_format(self.format_device, device))
 
-            format_device_separator = self.py3.safe_format(self.format_device_separator)
-            format_device = self.py3.composite_join(format_device_separator, new_device)
-
+            format_device = self.py3.safe_join(self.format_device_separator, new_device)
             adapter.update({"format_device": format_device, "device": len(devices)})
 
             for x in self.thresholds_init["format_adapter"]:
@@ -179,9 +177,7 @@ class Py3status:
 
             new_adapter.append(self.py3.safe_format(self.format_adapter, adapter))
 
-        format_adapter_separator = self.py3.safe_format(self.format_adapter_separator)
-        format_adapter = self.py3.composite_join(format_adapter_separator, new_adapter)
-
+        format_adapter = self.py3.safe_join(self.format_adapter_separator, new_adapter)
         bluetooth_data = {"format_adapter": format_adapter, "adapter": len(adapters)}
 
         for x in self.thresholds_init["format"]:

--- a/py3status/modules/coin_market.py
+++ b/py3status/modules/coin_market.py
@@ -180,8 +180,7 @@ class Py3status:
 
             new_coin.append(self.py3.safe_format(self.format_coin, market))
 
-        format_coin_separator = self.py3.safe_format(self.format_coin_separator)
-        format_coin = self.py3.composite_join(format_coin_separator, new_coin)
+        format_coin = self.py3.safe_join(self.format_coin_separator, new_coin)
 
         return {
             "cached_until": self.py3.time_in(self.cache_timeout),

--- a/py3status/modules/file_status.py
+++ b/py3status/modules/file_status.py
@@ -122,8 +122,6 @@ class Py3status:
         # format paths
         if self.init["format_path"]:
             new_data = []
-            format_path_separator = self.py3.safe_format(self.format_path_separator)
-
             for pathname in paths:
                 path = {}
                 for key in self.init["format_path"]:
@@ -136,7 +134,7 @@ class Py3status:
                     path[key] = self.py3.safe_format(value)
                 new_data.append(self.py3.safe_format(self.format_path, path))
 
-            format_path = self.py3.composite_join(format_path_separator, new_data)
+            format_path = self.py3.safe_join(self.format_path_separator, new_data)
 
         for x in self.thresholds_init:
             if x in ["path", "paths"]:

--- a/py3status/modules/frame.py
+++ b/py3status/modules/frame.py
@@ -14,8 +14,7 @@ Configuration parameters:
     format_button_closed: Format for the button when frame open (default '+')
     format_button_open: Format for the button when frame closed (default '-')
     format_separator: Specify separator between contents.
-        If this is None then the default i3bar separator will be used
-        (default None)
+        Booleans control native separators (default True)
     open: If button then the frame can be set to be open or close
         (default True)
 
@@ -95,13 +94,16 @@ class Py3status:
     format = "{output}"
     format_button_closed = "+"
     format_button_open = "-"
-    format_separator = None
+    format_separator = True
     open = True
 
     class Meta:
         container = True
 
     def post_config_hook(self):
+        # migrate separator config
+        if self.format_separator is None:
+            self.format_separator = True
         self.urgent = False
         if not self.py3.format_contains(self.format, "button"):
             self.open = True
@@ -116,27 +118,13 @@ class Py3status:
 
         # get the child modules output.
         composites = {}
-        output = []
-        if self.format_separator:
-            format_separator = self.py3.safe_format(self.format_separator)
+        outputs = []
         for item in self.items:
-            out = self.py3.get_output(item)[:]
-            for o in out:
-                composites["output_" + o["name"]] = o["full_text"]
-            if self.format_separator is None:
-                if out and "separator" not in out[-1]:
-                    # we copy the item as we do not want to change the
-                    # original.
-                    last_item = out[-1].copy()
-                    last_item["separator"] = True
-                    out[-1] = last_item
-            elif self.format_separator:
-                out += format_separator
-            output += out
-
-        # Remove last separator
-        if self.format_separator:
-            output = output[:-1]
+            output = self.py3.get_output(item)
+            for block in output:
+                composites["output_" + block["name"]] = block["full_text"]
+            outputs.append(output)
+        output = self.py3.safe_join(self.format_separator, outputs)
         if self.open:
             urgent = False
         else:

--- a/py3status/modules/google_calendar.py
+++ b/py3status/modules/google_calendar.py
@@ -211,7 +211,7 @@ class Py3status:
     warn_timeout = 300
 
     def post_config_hook(self):
-        self.button_states = [False] * self.num_events
+        self.button_states = {}
         self.events = None
         self.no_update = False
 
@@ -365,7 +365,7 @@ class Py3status:
             "total_minutes": total_minutes,
         }
 
-    def _format_timedelta(self, index, time_delta, event_active):
+    def _format_timedelta(self, time_delta, event_active):
         """
         Formats the dict time_to containing days/hours/minutes until an
         event starts into a composite according to time_to_formatted.
@@ -396,18 +396,19 @@ class Py3status:
         Returns: A composite containing the individual response for each event.
         """
         responses = []
-        self.event_urls = []
+        self.event_urls = {}
 
-        for index, event in enumerate(self.events):
-            self.py3.threshold_get_color(index + 1, "event")
-            self.py3.threshold_get_color(index + 1, "time")
+        for index, event in enumerate(self.events, start=1):
+            event_id = f"id/{event['id']}"
+            self.py3.threshold_get_color(index, "event")
+            self.py3.threshold_get_color(index, "time")
 
             event_dict = {}
 
             event_dict["summary"] = event.get("summary")
             event_dict["location"] = event.get("location")
             event_dict["description"] = event.get("description")
-            self.event_urls.append(event.get(self.preferred_event_link, event.get("htmlLink")))
+            self.event_urls[event_id] = event.get(self.preferred_event_link, event.get("htmlLink"))
 
             if event["start"].get("date") is not None:
                 start_dt = self._gstr_to_date(event["start"].get("date"))
@@ -432,7 +433,7 @@ class Py3status:
             else:
                 event_active = False
 
-            event_dict["format_timer"] = self._format_timedelta(index, time_delta, event_active)
+            event_dict["format_timer"] = self._format_timedelta(time_delta, event_active)
 
             if self.warn_threshold > 0:
                 self._check_warn_threshold(time_delta, event_dict)
@@ -440,7 +441,7 @@ class Py3status:
             event_formatted = self.py3.safe_format(
                 self.format_event,
                 {
-                    "is_toggled": self.button_states[index],
+                    "is_toggled": self.button_states.get(event_id, False),
                     "summary": event_dict["summary"],
                     "location": event_dict["location"],
                     "description": event_dict["description"],
@@ -453,16 +454,14 @@ class Py3status:
                 },
             )
 
-            self.py3.composite_update(event_formatted, {"index": index})
+            self.py3.composite_update(event_formatted, {"index": event_id})
             responses.append(event_formatted)
 
             self.no_update = False
 
-        format_separator = self.py3.safe_format(self.format_separator)
-        self.py3.composite_update(format_separator, {"index": "sep"})
-        responses = self.py3.composite_join(format_separator, responses)
+        self.button_states = {k: v for k, v in self.button_states.items() if k in self.event_urls}
 
-        return {"events": responses}
+        return {"events": self.py3.safe_join(self.format_separator, responses)}
 
     def google_calendar(self):
         """
@@ -504,21 +503,22 @@ class Py3status:
             """
             self.no_update = True
             button = event["button"]
-            button_index = event["index"]
+            index = event["index"]
 
-            if button_index == "sep":
+            # real events are tagged "id/<event id>" (a string); an int
+            # here is the separator's own positional fallback, never real
+            if isinstance(index, int):
                 self.py3.prevent_refresh()
             elif button == self.button_refresh:
                 # wait before the next refresh
                 if time.monotonic() - self.last_update > 1:
                     self.no_update = False
             elif button == self.button_toggle:
-                self.button_states[button_index] = not self.button_states[button_index]
+                self.button_states[index] = not self.button_states.get(index, False)
             elif button == self.button_open:
-                if self.event_urls:
-                    self.py3.command_run(
-                        self.browser_invocation.format(self.event_urls[button_index])
-                    )
+                url = self.event_urls.get(index)
+                if url:
+                    self.py3.command_run(self.browser_invocation.format(url))
                 self.py3.prevent_refresh()
             else:
                 self.py3.prevent_refresh()

--- a/py3status/modules/hddtemp.py
+++ b/py3status/modules/hddtemp.py
@@ -163,8 +163,7 @@ class Py3status:
 
             new_data.append(self.py3.safe_format(self.format_hdd, hdd))
 
-        format_separator = self.py3.safe_format(self.format_separator)
-        format_hdd = self.py3.composite_join(format_separator, new_data)
+        format_hdd = self.py3.safe_join(self.format_separator, new_data)
 
         return {
             "cached_until": self.py3.time_in(self.cache_timeout),

--- a/py3status/modules/librelinkup.py
+++ b/py3status/modules/librelinkup.py
@@ -187,8 +187,7 @@ class Py3status:
 
             new_patient.append(self.py3.safe_format(self.format_patient, patient_data))
 
-        format_patient_separator = self.py3.safe_format(self.format_patient_separator)
-        format_patient = self.py3.composite_join(format_patient_separator, new_patient)
+        format_patient = self.py3.safe_join(self.format_patient_separator, new_patient)
 
         return {
             "cached_until": self.py3.time_in(self.cache_timeout),

--- a/py3status/modules/lm_sensors.py
+++ b/py3status/modules/lm_sensors.py
@@ -313,16 +313,14 @@ class Py3status:
 
                 new_sensor.append(self.py3.safe_format(self.format_sensor, sensor))
 
-            format_sensor_separator = self.py3.safe_format(self.format_sensor_separator)
-            format_sensor = self.py3.composite_join(format_sensor_separator, new_sensor)
+            format_sensor = self.py3.safe_join(self.format_sensor_separator, new_sensor)
 
             chip["format_sensor"] = format_sensor
             del chip["sensors"]
 
             new_chip.append(self.py3.safe_format(self.format_chip, chip))
 
-        format_chip_separator = self.py3.safe_format(self.format_chip_separator)
-        format_chip = self.py3.composite_join(format_chip_separator, new_chip)
+        format_chip = self.py3.safe_join(self.format_chip_separator, new_chip)
         self.first_run = False
 
         return {

--- a/py3status/modules/mega_sync.py
+++ b/py3status/modules/mega_sync.py
@@ -51,8 +51,7 @@ class Py3status:
                 cells = dict(zip(columns, line.split()))
                 megasync_data.append(self.py3.safe_format(self.format_sync, cells))
 
-            format_sync_separator = self.py3.safe_format(self.format_sync_separator)
-            format_sync = self.py3.composite_join(format_sync_separator, megasync_data)
+            format_sync = self.py3.safe_join(self.format_sync_separator, megasync_data)
 
         return {
             "cached_until": self.py3.time_in(self.cache_timeout),

--- a/py3status/modules/networkmanager.py
+++ b/py3status/modules/networkmanager.py
@@ -167,8 +167,7 @@ class Py3status:
 
             new_device.append(self.py3.safe_format(self.format_device, device))
 
-        format_device_separator = self.py3.safe_format(self.format_device_separator)
-        format_device = self.py3.composite_join(format_device_separator, new_device)
+        format_device = self.py3.safe_join(self.format_device_separator, new_device)
 
         self.first_run = False
 

--- a/py3status/modules/nvidia_smi.py
+++ b/py3status/modules/nvidia_smi.py
@@ -142,8 +142,7 @@ class Py3status:
 
             new_gpu.append(self.py3.safe_format(self.format_gpu, gpu))
 
-        format_gpu_separator = self.py3.safe_format(self.format_gpu_separator)
-        format_gpu = self.py3.composite_join(format_gpu_separator, new_gpu)
+        format_gpu = self.py3.safe_join(self.format_gpu_separator, new_gpu)
 
         return {
             "cached_until": self.py3.time_in(self.cache_timeout),

--- a/py3status/modules/playerctl.py
+++ b/py3status/modules/playerctl.py
@@ -349,8 +349,7 @@ class Py3status:
 
             players.append(format_player)
 
-        format_player_separator = self.py3.safe_format(self.format_player_separator)
-        format_players = self.py3.composite_join(format_player_separator, players)
+        format_players = self.py3.safe_join(self.format_player_separator, players)
 
         return {
             "cached_until": self.py3.time_in(cached_until),

--- a/py3status/modules/sql.py
+++ b/py3status/modules/sql.py
@@ -159,8 +159,7 @@ class Py3status:
 
                 new_data.append(self.py3.safe_format(self.format_row, row))
 
-            format_separator = self.py3.safe_format(self.format_separator)
-            format_row = self.py3.composite_join(format_separator, new_data)
+            format_row = self.py3.safe_join(self.format_separator, new_data)
             sql_data.update({"row": count_row, "format_row": format_row})
 
             for x in self.thresholds_init["format"]:

--- a/py3status/modules/sysdata.py
+++ b/py3status/modules/sysdata.py
@@ -501,8 +501,7 @@ class Py3status:
                         self.py3.threshold_get_color(cpu[x], x)
                 new_cpu.append(self.py3.safe_format(self.format_cpu, cpu))
 
-            format_cpu_separator = self.py3.safe_format(self.format_cpu_separator)
-            sys["format_cpu"] = self.py3.composite_join(format_cpu_separator, new_cpu)
+            sys["format_cpu"] = self.py3.safe_join(self.format_cpu_separator, new_cpu)
 
     def _update_cpu_temp(self, sys):
         sys["cpu_temp"], sys["cpu_temp_unit"] = self._get_cputemp(self.cpu_temp_unit)

--- a/py3status/modules/timewarrior.py
+++ b/py3status/modules/timewarrior.py
@@ -227,8 +227,7 @@ class Py3status:
                         self.py3.threshold_get_color(tag_data[x], x)
                 new_tag.append(self.py3.safe_format(self.format_tag, tag_data))
 
-            format_tag_separator = self.py3.safe_format(self.format_tag_separator)
-            format_tag = self.py3.composite_join(format_tag_separator, new_tag)
+            format_tag = self.py3.safe_join(self.format_tag_separator, new_tag)
 
             time["format_tag"] = format_tag
             del time["tags"]
@@ -270,8 +269,7 @@ class Py3status:
 
             new_time.append(self.py3.safe_format(self.format_time, time))
 
-        format_time_separator = self.py3.safe_format(self.format_time_separator)
-        format_time = self.py3.composite_join(format_time_separator, new_time)
+        format_time = self.py3.safe_join(self.format_time_separator, new_time)
         return format_time
 
     def timewarrior(self):

--- a/py3status/modules/usbguard.py
+++ b/py3status/modules/usbguard.py
@@ -139,8 +139,7 @@ class Py3status:
 
             device_info.append(self.py3.safe_format(self.format_device, device))
 
-        format_device_separator = self.py3.safe_format(self.format_device_separator)
-        format_device = self.py3.composite_join(format_device_separator, device_info)
+        format_device = self.py3.safe_join(self.format_device_separator, device_info)
 
         return format_device
 

--- a/py3status/modules/vpn_status.py
+++ b/py3status/modules/vpn_status.py
@@ -200,11 +200,10 @@ class Py3status:
         color = self.py3.COLOR_GOOD if vpns else self.py3.COLOR_BAD
 
         # Format and create the response dict
-        format_vpn_separator = self.py3.safe_format(self.format_vpn_separator)
-        format_vpns = self.py3.composite_join(format_vpn_separator, vpns)
-        full_text = self.py3.safe_format(self.format, {"format_vpn": format_vpns})
+        format_vpn = self.py3.safe_join(self.format_vpn_separator, vpns)
+
         response = {
-            "full_text": full_text,
+            "full_text": self.py3.safe_format(self.format, {"format_vpn": format_vpn}),
             "color": color,
             "cached_until": self.py3.CACHE_FOREVER,
         }

--- a/py3status/modules/weather_owm.py
+++ b/py3status/modules/weather_owm.py
@@ -826,8 +826,7 @@ class Py3status:
             forecasts.append(self.py3.safe_format(self.format_forecast, future))
 
         # Give the final format
-        format_forecast_separator = self.py3.safe_format(self.format_forecast_separator)
-        today["forecast"] = self.py3.composite_join(format_forecast_separator, forecasts)
+        today["forecast"] = self.py3.safe_join(self.format_forecast_separator, forecasts)
 
         return self.py3.safe_format(self.format, today)
 

--- a/py3status/modules/wwan.py
+++ b/py3status/modules/wwan.py
@@ -448,8 +448,7 @@ class Py3status:
             except:  # noqa e722
                 break
 
-        format_message_separator = self.py3.safe_format(self.format_message_separator)
-        format_message = self.py3.composite_join(format_message_separator, new_message)
+        format_message = self.py3.safe_join(self.format_message_separator, new_message)
 
         return format_message
 

--- a/py3status/modules/xkb_input.py
+++ b/py3status/modules/xkb_input.py
@@ -447,8 +447,7 @@ class Py3status:
                     self.py3.threshold_get_color(_input[x], x)
             new_input.append(self.py3.safe_format(self.format_input, _input))
 
-        format_input_separator = self.py3.safe_format(self.format_input_separator)
-        format_input = self.py3.composite_join(format_input_separator, new_input)
+        format_input = self.py3.safe_join(self.format_input_separator, new_input)
 
         input_data = {
             "format_input": format_input,

--- a/py3status/py3.py
+++ b/py3status/py3.py
@@ -910,6 +910,23 @@ class Py3:
         """
         return Composite.composite_join(separator, items)
 
+    def safe_join(self, separator, items):
+        """
+        Join items using a format string, Composite, or native separators.
+
+        String separators are processed by the formatter. Boolean separators
+        control whether native separators are used between visible items.
+
+        A Composite object will be returned.
+        """
+        if isinstance(separator, str):
+            try:
+                separator = self._formatter.format(separator, self._py3status_module)
+            except Exception as err:
+                self._report_exception(f"Invalid format `{separator}` ({err})")
+                return f"invalid format ({err})"
+        return Composite.composite_join(separator, items)
+
     def composite_create(self, item):
         """
         Create and return a Composite.

--- a/tests/test_composite.py
+++ b/tests/test_composite.py
@@ -84,3 +84,84 @@ def test_Composite_iadd_4():
     c += Composite("moo")
     result = c.get_content()
     assert result == [{"full_text": "moo"}, {"full_text": "moo"}]
+
+
+# Composite simplify
+
+
+def test_Composite_simplify_separator():
+    composite = Composite(
+        [
+            {"full_text": "one", "separator": True},
+            {"full_text": "two", "separator": True},
+        ]
+    )
+    assert composite.simplify().get_content() == [
+        {"full_text": "one", "separator": True},
+        {"full_text": "two", "separator": True},
+    ]
+
+
+def test_Composite_simplify_disabled_separator():
+    composite = Composite(
+        [
+            {"full_text": "one", "separator": False},
+            {"full_text": "two", "separator": False},
+        ]
+    )
+    assert composite.simplify().get_content() == [
+        {"full_text": "one", "separator": False},
+        {"full_text": "two", "separator": False},
+    ]
+
+
+# Composite join
+
+
+def test_Composite_simplify_whitespace_separator():
+    composite = Composite(
+        [
+            {"full_text": "one"},
+            {"full_text": " ", "separator": False, "separator_block_width": 0},
+        ]
+    )
+
+    assert composite.simplify().get_content() == [
+        {"full_text": "one"},
+        {"full_text": " ", "separator": False, "separator_block_width": 0},
+    ]
+
+
+def test_Composite_join_native_separator():
+    items = [
+        Composite({"full_text": "one"}),
+        Composite({"full_text": "two", "separator": False, "separator_block_width": 0}),
+        Composite({"full_text": "three", "separator_block_width": 9}),
+    ]
+    result = Composite.composite_join(True, items)
+
+    assert result.simplify().get_content() == [
+        {"full_text": "one", "separator": True},
+        {"full_text": "two", "separator": False, "separator_block_width": 0},
+        {"full_text": "three", "separator_block_width": 9},
+    ]
+    assert items[0].get_content() == [{"full_text": "one"}]
+
+
+def test_Composite_join_native_separator_trailing_empty_block():
+    items = [
+        Composite([{"full_text": "one"}, {"full_text": ""}]),
+        Composite([{"full_text": "two"}, {"full_text": ""}]),
+    ]
+
+    assert Composite.composite_join(True, items).simplify().get_content() == [
+        {"full_text": "one", "separator": True},
+        {"full_text": "two"},
+    ]
+
+
+def test_Composite_join_disabled_native_separator():
+    assert Composite.composite_join(False, ["one", "two"]).simplify().get_content() == [
+        {"full_text": "one", "separator": False},
+        {"full_text": "two"},
+    ]

--- a/tests/test_py3.py
+++ b/tests/test_py3.py
@@ -1,5 +1,7 @@
 from pprint import pformat
 
+from py3status.composite import Composite
+from py3status.formatter import Formatter
 from py3status.py3 import Py3
 
 
@@ -19,6 +21,9 @@ class MockWrapper:
 
     def get_config_attribute(self, module_name, name):
         return self.settings.get(name, MissingSetting())
+
+    def report_exception(self, *args, **kwargs):
+        pass
 
 
 class MockModule:
@@ -40,6 +45,63 @@ def test_config_color_resolution(monkeypatch):
     assert not py3.is_color(disabled_color)
     assert Py3(MockModule({})).COLOR_HIDDEN == "hidden"
     assert Py3(MockModule({})).COLOR_NOTACOLOR is None
+
+def test_safe_join():
+    safe_py3 = Py3()
+    safe_py3._formatter = Formatter()
+    safe_py3._py3status_module = object()
+    items = ["one", "two"]
+
+    assert list(safe_py3.safe_join(r"\?color=#FF0000&show  \| ", items)) == [
+        {"full_text": "one"},
+        {"full_text": " | ", "color": "#FF0000"},
+        {"full_text": "two"},
+    ]
+
+    separator = Composite({"full_text": " / ", "color": "#00FF00"})
+    assert list(safe_py3.safe_join(separator, items)) == [
+        {"full_text": "one"},
+        {"full_text": " / ", "color": "#00FF00"},
+        {"full_text": "two"},
+    ]
+
+    assert list(safe_py3.safe_join(True, items)) == [
+        {"full_text": "one", "separator": True},
+        {"full_text": "two"},
+    ]
+    assert list(safe_py3.safe_join(False, items)) == [
+        {"full_text": "one", "separator": False},
+        {"full_text": "two"},
+    ]
+
+
+def test_safe_join_stops_with_error_like_safe_format(monkeypatch):
+    monkeypatch.setattr(Py3, "_formatter", None)
+    scoped_py3 = Py3(MockModule({}))
+
+    # a broken separator must not become literal, repeated error text
+    # between every item; safe_join should stop and return the error, the
+    # same way safe_format does, rather than repeating it as content
+    assert (
+        scoped_py3.safe_join("[unclosed", ["one", "two", "three"])
+        == "invalid format (Block not closed)"
+    )
+
+
+def test_safe_join_native_separator_nested():
+    safe_py3 = Py3()
+    safe_py3._formatter = Formatter()
+    safe_py3._py3status_module = object()
+    items = safe_py3.safe_join(True, ["one", "two"])
+
+    output = safe_py3.safe_format("X {items} Y", {"items": items}, force_composite=True)
+
+    assert list(output) == [
+        {"full_text": "X "},
+        {"full_text": "one", "separator": True},
+        {"full_text": "two"},
+        {"full_text": " Y"},
+    ]
 
 
 def test_format_units():


### PR DESCRIPTION
~~(Hack)~~ Every once in a while, I wonder why we can't have nice things... like real separators.

We safeformat our separators everywhere so technically `safeformat` is for strings, not `None`, but if we do this way, we can return `None` back straight to `composite_join()` next where it will add real separators there.

I do it this way just because if we don't, we will need to do something like this for all modules w/ separators.
```python
separator = self.format_separator
if separator is not None:
    separator = self.py3.safe_format(separator)

output = self.py3.composite_join(separator, items)    
```
or one liner
```python
output = self.py3.composite_join(None if format_separator is None else self.py3.safe_format(format_separator), items)
```
---- 

`lm_sensors` : Add this for chips for for sensors to see diff.
```diff
diff --git a/py3status/modules/lm_sensors.py b/py3status/modules/lm_sensors.py
index d48e355..8dccb1e 100644
--- a/py3status/modules/lm_sensors.py
+++ b/py3status/modules/lm_sensors.py
@@ -176,9 +176,10 @@ class Py3status:
     chips = []
     format = "{format_chip}"
     format_chip = "{name} {format_sensor}"
-    format_chip_separator = " "
+    format_chip_separator = None
     format_sensor = r"[\?color=darkgray {name}] [\?color=auto.input&show {input}]"
-    format_sensor_separator = " "
+    format_sensor_separator = None
     sensors = []
     thresholds = {"auto.input": True}
 
```
Idk if we need this. Idk if we should merge this. Cool feature tho.
Changes `safe_format`'s `format_string` too. Hack.

---

Pls you no merge. Need 2 think more.