### PR TITLE
module: support i3bar min_width string values

### DIFF
--- a/docs/user-guide/configuration.md
+++ b/docs/user-guide/configuration.md
@@ -167,7 +167,8 @@ The following options will work on `i3`.
   is not reached. Either `left` (default), `center`, or `right`.
 - `background`: Specify a background color for py3status modules.
 - `markup`: Specify how modules should be parsed.
-- `min_width`: Specify a minimum width of pixels for modules.
+- `min_width`: Specify a minimum width in pixels, or use a string to
+  specify the minimum width using that text's rendered width.
 - `separator`: Specify a separator boolean for modules.
 - `separator_block_width`: Specify a separator block width for
   modules.

--- a/py3status/module.py
+++ b/py3status/module.py
@@ -331,8 +331,8 @@ class Module:
         # i3bar
         min_width = fn(self.module_full_name, "min_width")
         if not hasattr(min_width, "none_setting"):
-            if not isinstance(min_width, int):
-                err = "Invalid `min_width` attribute, should be an int. "
+            if not isinstance(min_width, (int, str)):
+                err = "Invalid `min_width` attribute, should be an int or string. "
                 err += f"Got `{min_width}`."
                 raise TypeError(err)
             self.i3bar_module_options["min_width"] = min_width


### PR DESCRIPTION
This fixes `min_width = "WWWWWWWW"`.

```python
order += "static_string wall"
order += "static_string width_pixels"
order += "static_string width_text"
order += "static_string wall"

static_string wall {
    format = "\|"
}

static_string width_pixels {
    format = "200"
    min_width = 200
    align = "center"
}

# fix this
static_string width_text {
    align = "center"
    format = "W"
    min_width = "WWWWWWWW"
}
```

---

From  https://i3wm.org/docs/i3bar-protocol.html
> **min_width**
>
> The minimum width (in pixels) of the block. If the content of the full_text key take less space than the specified min_width, the block will be padded to the left and/or the right side, according to the align key. This is useful when you want to prevent the whole status line to shift when value take more or less space between each iteration.
>
>The value can also be a string. In this case, the width of the text given by min_width determines the minimum width of the block. This is useful when you want to set a sensible minimum width regardless of which font you are using, and at what particular size.


