### PR TITLE
module: document i3bar and non-i3bar separators

### DIFF
--- a/py3status/core.py
+++ b/py3status/core.py
@@ -137,11 +137,11 @@ class Common:
         self.none_setting = NoneSetting()
         self.config = py3_wrapper.config
 
-    def get_config_attribute(self, name, attribute):
+    def get_config_attribute(self, name, attribute, general=True):
         """
         Look for the attribute in the config.  Start with the named module and
-        then walk up through any containing group and then try the general
-        section of the config.
+        then walk up through any containing group and the py3status section.
+        Finally, try the general section unless `general` is false.
         """
 
         # A user can set a param to None in the config to prevent a param
@@ -158,7 +158,7 @@ class Common:
         if hasattr(param, "none_setting"):
             # check py3status config section
             param = config["py3status"].get(attribute, self.none_setting)
-        if hasattr(param, "none_setting"):
+        if hasattr(param, "none_setting") and general:
             # check py3status general section
             param = config["general"].get(attribute, self.none_setting)
         if param and (attribute == "color" or attribute.startswith("color_")):
@@ -776,7 +776,7 @@ class Py3statusWrapper:
             self.config["py3_config"]["general"]["output_format"]
         )
 
-        # determine the output separator, if needed
+        # configure the separator for non-i3bar output formats
         color_separator = None
         if self.config["py3_config"]["general"]["colors"]:
             color_separator = self.config["py3_config"]["general"]["color_separator"]

--- a/py3status/module.py
+++ b/py3status/module.py
@@ -346,17 +346,18 @@ class Module:
                     raise ValueError(err)
                 self.i3bar_module_options["align"] = align
 
-        separator = fn(self.module_full_name, "separator")
+        separator = fn(self.module_full_name, "separator", True)
         if not hasattr(separator, "none_setting"):
-            # HACK: separator is a valid setting in the general section
-            # of the configuration. but it's a string, not a boolean.
-            # revisit how i3status and py3status differ in this regard.
+            # separator is a valid setting in the general section
+            # (a string for non-i3bar output formats); we usually
+            # want boolean from module or py3status section.
+            # ----
             # if not isinstance(separator, bool):
-
             #     err = "Invalid `separator` attribute, should be a boolean. "
             #     err += f"Got `{separator}`."
             #     raise TypeError(err)
             # self.i3bar_module_options["separator"] = separator
+            # ----
             if isinstance(separator, bool):
                 self.i3bar_module_options["separator"] = separator
 


### PR DESCRIPTION
~~This addresses `HACK: separator` issue I ran into... when I added  universal/i3bar_gaps module options years ago.~~

* Applied the fix at first, but ultimately, we need to keep the code unchanged.
* Keep `general` on `True` for `separator` config and just document.