### PR TITLE
py3: raise invalid format errors

### DIFF
--- a/py3status/py3.py
+++ b/py3status/py3.py
@@ -891,8 +891,9 @@ class Py3:
                         chars_left = max(0, chars_left)
             return result
         except Exception as err:
-            self._report_exception(f"Invalid format `{format_string}` ({err})")
-            return f"invalid format ({err})"
+            msg = f"Invalid format `{format_string}` ({err})"
+            self._report_exception(msg)
+            raise Exception(msg) from err
 
     def composite_update(self, item, update_dict, soft=False):
         """


### PR DESCRIPTION
This throws an exception. Better than seeing several `invalid format ({err})` from invalid `format_separator`.

```python
order += "sysdata cpu" 
sysdata cpu {
    format = "{format_cpu}"
    format_cpu_separator = "[]]"
}
```