### PR TITLE
py3: add get_config helper

### DIFF
--- a/py3status/module_test.py
+++ b/py3status/module_test.py
@@ -54,6 +54,7 @@ class MockPy3statusWrapper:
             "testing": True,
             "log_file": True,
             "wm": {"msg": "i3-msg", "nag": "i3-nagbar"},
+            "wm_name": "i3",
         }
         self.events_thread = self.EventThread()
         self.udev_monitor = self.UdevMonitor()

--- a/py3status/py3.py
+++ b/py3status/py3.py
@@ -476,6 +476,16 @@ class Py3:
             if module_info:
                 module_info["module"].force_update()
 
+    def get_config(self, name):
+        """
+        Return a supported py3status configuration value.
+        Supported configs: `testing`, `wm_name`
+        """
+        runtime_settings = ["testing", "wm_name"]
+        if name in runtime_settings:
+            return self._py3_wrapper.config.get(name)
+        raise ValueError(f"Unsupported config `{name}`")
+
     def get_wm_msg(self):
         """
         Return the control program of the current window manager.


### PR DESCRIPTION
This adds a public config helper for the following configs: `markup`, `testing`, and `wm_name`.

1) Module `i3status` needs `markup` config
    - Currently doesn't have anything.
    - _Return `'pango'` or `None`_ (default).
    - User-inputted _`'none'`_ can be be passed along.

2) Module `sysinfo` uses `testing` config to (debug) print placeholders in terminal.
    - Currently uses a private/internal config.
    - _Return `True` or  `None`_
    - We may like to use `testing` more in `post_config_hook` instead of test_module's config for some modules.

3) Module `sysinfo` can use `wm_name` config as one of the placeholders.
    - Currently uses `self.py3.get_wm_msg().removesuffix("msg").removesuffix("-")`.
    - _Returns `'i3'` or `'sway'`_
----

Is there a better solution for configs like this?

Modules can getattr colors just fine. i3status needs some stability in its life, pls.

----

I need this, or something equivalent, to optionally and properly get the markup value for i3status module -- and nothing else.