### PR TITLE
core, modules: fix str/Path mismatches left by the pathlib refactor

### DIFF
--- a/py3status/core.py
+++ b/py3status/core.py
@@ -183,7 +183,7 @@ class Common:
         NOTE: msg should not end in a '.' for consistency.
         """
         # Get list of paths that our stack trace should be found in.
-        py3_paths = [Path(__file__).resolve()] + self.config["include_paths"]
+        py3_paths = [Path(__file__).resolve().parent] + self.config["include_paths"]
         traceback = None
 
         try:
@@ -209,9 +209,9 @@ class Common:
                 for item in reversed(stack):
                     filename = item[0]
                     for path in py3_paths:
-                        if filename.startswith(path):
+                        if filename.startswith(str(path)):
                             # Found a good trace
-                            filename = item[0].name
+                            filename = Path(item[0]).name
                             line_no = item[1]
                             found = True
                             break

--- a/py3status/modules/backlight.py
+++ b/py3status/modules/backlight.py
@@ -148,7 +148,7 @@ class Py3status:
         if self._logind_proxy:
             brightness_max = int(Path(f"{self.device}/max_brightness").read_text())
             brightness = brightness_max * level / 100
-            self._logind_proxy.SetBrightness("backlight", self.device.name, brightness)
+            self._logind_proxy.SetBrightness("backlight", Path(self.device).name, brightness)
 
     def _get_backlight_level(self):
         if self.command_available:

--- a/py3status/modules/coin_balance.py
+++ b/py3status/modules/coin_balance.py
@@ -130,7 +130,7 @@ class Py3status:
 
     def _get_daemon_config_value(self, coin, key):
         try:
-            with (Path.home() / f".{coin}" / coin).open() as cfg:
+            with (Path.home() / f".{coin}" / f"{coin}.conf").open() as cfg:
                 for line in cfg.readlines():
                     line = line.strip()
                     if line.startswith("#"):

--- a/py3status/modules/file_status.py
+++ b/py3status/modules/file_status.py
@@ -52,6 +52,7 @@ missing
 {'color': '#FF0000', 'full_text': u'\u25a0'}
 """
 
+from glob import glob
 from pathlib import Path
 
 STRING_NO_PATHS = "missing paths"
@@ -115,7 +116,7 @@ class Py3status:
 
     def file_status(self):
         # init data
-        paths = sorted(files for path in self.paths for files in path.parent.glob(path.name))
+        paths = sorted(Path(files) for path in self.paths for files in glob(str(path)))
         count_path = len(paths)
         format_path = None
 

--- a/py3status/modules/screenshot.py
+++ b/py3status/modules/screenshot.py
@@ -81,7 +81,7 @@ class Py3status:
         pathname = self.save_path / basename
         self.shot_data["basename"] = basename
 
-        self.py3.command_run(" ".join(self.screenshot_command, pathname))
+        self.py3.command_run(" ".join([self.screenshot_command, str(pathname)]))
 
         if self.upload_server and self.upload_user and self.upload_path:
             self.py3.command_run(


### PR DESCRIPTION
## `report_exception` has been silently swallowing exception details since 2020

### Root cause

Commit 37603bf3d08d08ebf8fe38ef5d419e51f03821ec ("use pathlib everywhere to manipulate paths and files (#1978)", 2020-12-13) converted one variable in `Common.report_exception` (`py3status/core.py`) from a string to a `Path` object, but didn't update the code around it that still assumed the old string type. The original (broken) diff:

```diff
-        py3_paths = [os.path.dirname(__file__)] + self.config["include_paths"]
+        py3_paths = [Path(__file__).resolve()] + self.config["include_paths"]
         traceback = None

         try:
@@ -197,7 +197,7 @@ class Common:
                 # should be made to appear correct.  We caught the exception
                 # but make it look as though we did not.
                 traceback += format_stack(error_frame, 1) + format_tb(tb)
-                filename = os.path.basename(error_frame.f_code.co_filename)
+                filename = Path(error_frame.f_code.co_filename).name
                 line_no = error_frame.f_lineno
             else:
                 # This is a none module based error
@@ -210,7 +210,7 @@ class Common:
                     for path in py3_paths:
                         if filename.startswith(path):
                             # Found a good trace
-                            filename = os.path.basename(item[0])
+                            filename = item[0].name
                             line_no = item[1]
                             found = True
                             break
```

Two separate, real bugs came out of this:

**Bug 1 — type mismatch.** `filename` (from `traceback.extract_tb()`) is always a plain `str`. `path` (from the now-`Path`-typed `py3_paths`) is a `Path`. `str.startswith(Path)` raises `TypeError`.

**Bug 2 — wrong attribute access.** `item[0]` is also always a plain `str` (same `extract_tb()` source, untouched by this refactor). `str` has no `.name` attribute — `item[0].name` raises `AttributeError`. This only fires *after* Bug 1 is fixed and a match is found.

Both exceptions are swallowed by a bare `except: pass` two lines below, so none of this was ever visible — you just got the plain message with zero enrichment, forever.

**Bug 3 — found while verifying the fix.** Even `py3_paths`' own-package entry was wrong on its own terms: `Path(__file__).resolve()` is the path to `core.py` *itself* (e.g. `.../py3status/core.py`), not the `py3status/` directory. The original `os.path.dirname(__file__)` returned the directory, which is what's needed since it's used as a prefix match against *other* files. Without `.parent`, an exception raised from any py3status file other than `core.py` (`module.py`, `py3.py`, etc.) never matches — same silent-swallow effect, one level deeper.

### The fix

```diff
-                        if filename.startswith(path):
+                        if filename.startswith(str(path)):
                             # Found a good trace
-                            filename = item[0].name
+                            filename = Path(item[0]).name
                             line_no = item[1]
                             found = True
                             break
```

```diff
-        py3_paths = [Path(__file__).resolve()] + self.config["include_paths"]
+        py3_paths = [Path(__file__).resolve().parent] + self.config["include_paths"]
```

Both proven with tests that fail on the old code and pass on the new (`tests/test_core.py`):
- `test_report_exception_enriches_message_with_exception_details` — proves Bug 1 + Bug 2.
- `test_report_exception_matches_other_files_in_the_py3status_package` — proves Bug 3.

### This isn't on_click-specific — 14 call sites lose their error detail

`report_exception` is called from all over the codebase. Only calls that pass `error_frame` explicitly (2 call sites, both in `py3.py`, both feeding `Py3._report_exception`) take a different, unaffected code path. Every other call site below hits the buggy branch and has been losing its exception type/filename/line enrichment since Dec 2020:

| # | File:line | Message | What it covers |
|---|---|---|---|
| 1 | `module.py:98` | `"could not be loaded"` | module import/syntax errors |
| 2 | `module.py:161` | `"post_config_hook failed"` | a module's `post_config_hook()` raising |
| 3 | `module.py:172` | (raw `msg`) | `runtime_error()` in testing mode |
| 4 | `module.py:947` | `"on_click event failed"` | any module's `on_click()` raising (the one that started this) |
| 5 | `module.py:1078` | `"user method '{meth}' failed"` | **any regular module update method crashing — the most common case** |
| 6 | `events.py:272` | `"event failed"` | event-processing task failures |
| 7 | `events.py:275` | (raw exception object) | click-dispatch task failures |
| 8 | `command.py:281` | `"command failed"` | py3-cmd command execution failures |
| 9 | `i3status.py:423` | `""` (literally empty) | i3status thread failures |
| 10 | `core.py:62` | `"Runner"` | background runner thread failures |
| 11 | `core.py:554` | (raw `msg`, level=warning) | internal `notify_user` failures |
| 12 | `parse_config.py:390` | `"shell: called with command \`{param}\`"` | config-time shell command failures |
| 13 | `__init__.py:35` | `"Setup error ({err})"` | py3status startup failures |
| 14 | `__init__.py:46` | `"Runtime error ({err})"` | py3status main loop failures |

Row 5 is the one that matters most in practice — it's the generic path every module's regular render method goes through when it raises. This bug has been silently degrading error visibility for *any* module crash, not just on_click, for ~5 years.

### Other bugs from the same commit, still broken today

| File | Bug | Trigger |
|---|---|---|
| `modules/backlight.py:151` | `self.device.name` called on a plain `str` | `backlight { device = "intel_backlight" }` without `brightnessctl`/`light` installed → `AttributeError` |
| `modules/coin_balance.py:133` | `os.path` → `Path` translation dropped the `.conf` suffix | Bitcoin/Litecoin/Dogecoin modules with no `username`/`password` set silently never find their config file |
| `modules/screenshot.py:84` | `" ".join(self.screenshot_command, pathname)` — wrong call shape (`str.join` takes one iterable, not two args) | Click the screenshot module → `TypeError` every time, no screenshot ever taken |
| `modules/file_status.py:118` | `path.parent.glob(path.name)` only expands a wildcard in the *last* path component | Unconfirmed impact — a middle-of-path wildcard would now silently match nothing |

### Other bugs from the same commit, already fixed over time (confirms this was a systemic pattern, not a one-off)

| File | Bug | Fixed by | Time to fix |
|---|---|---|---|
| `argparsers.py` | bare `str` mixed into a list of `Path`s; `.resolve()` on argparse strings | `9e4d7a3`/`741a32b`, `f98c8e3` | same day → ~1mo |
| `command.py` | absolute glob pattern on a relative `Path`; `Popen`/socket calls given `Path` not str | `4e938d5`, `73cdace` (#2003) | same day → ~2mo |
| `screenshots.py` (core) | `mkdir(parents=True, exists_ok=True)` — typo'd kwarg | `2b224a2` | same day |
| `modules/google_calendar.py` | identical `exists_ok=True` typo, 2 call sites | `2b224a2` | same day |
| `storage.py` | `.expanduser()`/`/` operator on values still stored as strings | `102ad92` (#2004) | ~2 months |
| `setup.py` | `sys.path.remove(Path)` after inserting `str(Path)` | `fe3af84` (#1983) | 3 days |
| `modules/mail.py` | `os.path.expandvars()` returns str, then `.exists()` called on it | `8e155ea` (#2125) | ~18 months |
| `modules/conky.py` | `Path(self.tmpfile)` on a file object, not `.name` | `8e97cae` (#2238) | ~3.2 years |
| `modules/xsel.py` | `Path(self.log_file)` called unconditionally, crashes on the `None` default | `d78a60d` (#2279) | ~4.1 years |
| `autodoc.py` | `Path` passed where docutils wanted a str | moot — dead code removed (`c2389aa`, 2023-06-18) | ~2.5 years |
| `modules/thunderbird_todos.py` | `Path` used in old-style `.format()` (benign in practice) | moot — module removed (`804ac9a`, 2026-07-28) | ~5.6 years |