### PR TITLE
formatter: allow compact soft spaces

### DIFF
--- a/py3status/formatter.py
+++ b/py3status/formatter.py
@@ -198,6 +198,9 @@ class Formatter:
                 # and return to parent block to continue
                 if not block.parent:
                     raise Exception("Too many `]`")
+                # treat empty soft block as a soft space block
+                if block.commands.soft and not block.content:
+                    block.add(Literal(" "))
                 block = block.parent
             elif token.group("switch"):
                 # a new option has been created

--- a/tests/test_formatter.py
+++ b/tests/test_formatter.py
@@ -1050,19 +1050,23 @@ def test_bad_composite_color():
 
 
 def test_soft_1():
-    run_formatter({"format": r"{name}[\?soft  ]{name}", "expected": "Björk Björk"})
+    for soft_space in (r"[\?soft ]", r"[\?soft  ]"):
+        run_formatter({"format": f"{{name}}{soft_space}{{name}}", "expected": "Björk Björk"})
 
 
 def test_soft_2():
-    run_formatter({"format": r"{name}[\?soft  ]{empty}", "expected": "Björk"})
+    for soft_space in (r"[\?soft ]", r"[\?soft  ]"):
+        run_formatter({"format": f"{{name}}{soft_space}{{empty}}", "expected": "Björk"})
 
 
 def test_soft_3():
-    run_formatter({"format": r"{empty}[\?soft  ]{empty}", "expected": ""})
+    for soft_space in (r"[\?soft ]", r"[\?soft  ]"):
+        run_formatter({"format": f"{{empty}}{soft_space}{{empty}}", "expected": ""})
 
 
 def test_soft_4():
-    run_formatter({"format": r"[\?soft  ]", "expected": ""})
+    for soft_space in (r"[\?soft ]", r"[\?soft  ]"):
+        run_formatter({"format": soft_space, "expected": ""})
 
 
 def test_soft_5():


### PR DESCRIPTION
We need to insert two spaces in `[\?soft  ]` to add a soft space.
- One to make a block
- One to insert a space.

This inserts a space for us on empty soft blocks so we don't have to add extra spaces in our format... Plus, empty soft blocks does nothing.

Before: 
```python
Explicit = "[\?soft  ]" -> " "
Inferred = "[\?soft ]" -> ""  # No space. :(
```

After:
```python
Explicit = "[\?soft  ]" -> " "
Inferred = "[\?soft ]" -> " "  # Yay, a soft space.
```