### PR TITLE
core: fix include_paths dedup silently overwriting the first match

### DIFF
--- a/py3status/core.py
+++ b/py3status/core.py
@@ -460,7 +460,7 @@ class Py3statusWrapper:
                 module_name = f_name.stem
                 # do not overwrite modules if already found
                 if module_name in path_included_modules:
-                    pass
+                    continue
                 path_included_modules[module_name] = (include_path, f_name)
         return dict(sorted(path_included_modules.items()))
 


### PR DESCRIPTION
Bugfix.

>_get_path_included_modules() was meant to let an earlier (higher-
priority) include_path win when the same module name exists in more
than one configured directory - the comment says so explicitly - but
the guard used "pass" instead of "continue", so it never actually
prevented anything: the very next line unconditionally overwrote the
entry regardless. A later, lower-priority path would silently win
instead.
>
>Dates back to the original include_paths dedup logic (ba704bd, 2016) -
a one-word authoring mistake, not a regression, dormant for ~9 years
since it only bites when the same module name genuinely exists in two
different include directories.